### PR TITLE
Allow to set level to 0

### DIFF
--- a/packages/slate-plugins/src/dnd/__tests__/selectable.spec.tsx
+++ b/packages/slate-plugins/src/dnd/__tests__/selectable.spec.tsx
@@ -33,10 +33,10 @@ it('should render draggable component', () => {
 it('should filter based on level', () => {
   const editor = jest.fn();
   jest.spyOn(SlateReact, 'useEditor').mockReturnValue(editor as any);
-  jest.spyOn(ReactEditor, 'findPath').mockReturnValue([0, 0, 0]);
+  jest.spyOn(ReactEditor, 'findPath').mockReturnValue([0, 0]);
   const DraggableElement = getSelectableElement({
     component: DEFAULTS_PARAGRAPH.p.component,
-    level: 1,
+    level: 0,
   });
   const { container } = render(
     <DndProvider backend={TestBackend}>

--- a/packages/slate-plugins/src/dnd/components/getSelectableElement.tsx
+++ b/packages/slate-plugins/src/dnd/components/getSelectableElement.tsx
@@ -31,7 +31,7 @@ export const getSelectableElement = ({
       ]);
       const filteredOut = useMemo(
         () =>
-          (level && level !== path.length - 1) ||
+          (Number.isInteger(level) && level !== path.length - 1) ||
           (filter && filter(editor, path)),
         [path, editor]
       );


### PR DESCRIPTION
## Issue
- Setting `level: 0` was causing `getSelectableElement` to ignore the filters

## What I did
- Check falsy values via `Number.isInteger`.



## Checklist
- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->