### PR TITLE
fix generic for WithOverride

### DIFF
--- a/packages/core/src/types/SlatePlugin/WithOverride.ts
+++ b/packages/core/src/types/SlatePlugin/WithOverride.ts
@@ -7,4 +7,4 @@ import { TEditor } from '../TEditor';
 export type WithOverride<
   TEditorInput extends TEditor = TEditor,
   TEditorOutputExtension = {}
-> = <T extends TEditorInput>(editor: T) => T & TEditorOutputExtension;
+> = (editor: TEditorInput) => TEditorInput & TEditorOutputExtension;


### PR DESCRIPTION
**Description**

The generic definition for WithOverride does not provide accurate type safety. This is somewhat evident as this fix breaks 8 existing tests that should probably fail in their current form.

**Issue**

Improve type safety of WithOverride

**Example**

The failing tests provide some good examples:

```
Summary of all failing tests
 FAIL  packages/elements/image-ui/src/ToolbarImage/ToolbarImage.spec.tsx
  ● Test suite failed to run

    packages/core/src/plugins/createHistoryPlugin.ts:27:9 - error TS2322: Type '(editor: T) => T & HistoryEditor' is not assignable to type 'WithOverride<SPEditor, {}>'.
      Types of parameters 'editor' and 'editor' are incompatible.
        Type 'SPEditor' is not assignable to type 'T'.
          'SPEditor' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'BaseEditor'.

    27   () => withHistory
               ~~~~~~~~~~~

      packages/core/src/utils/getSlatePluginWithOverrides.ts:10:13
        10   V extends (...args: any) => WithOverride<T> = (
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        The expected type comes from the return type of this signature.

 FAIL  packages/serializers/html-serializer/src/deserializer/__tests__/deserializeHTMLElement/not-element.spec.tsx
  ● Test suite failed to run

    packages/serializers/html-serializer/src/deserializer/__tests__/deserializeHTMLElement/not-element.spec.tsx:21:7 - error TS2322: Type 'import("/Users/default/livingspec/slate-plugins/packages/core/src/types/SlatePlugin/SlatePlugin").SlatePlugin<import("/Users/default/livingspec/slate-plugins/packages/core/src/types/SPEditor").SPEditor>[]' is not assignable to type 'import("/Users/default/livingspec/slate-plugins/packages/core/dist/types/SlatePlugin/SlatePlugin").SlatePlugin<import("/Users/default/livingspec/slate-plugins/packages/core/src/types/SPEditor").SPEditor>[]'.
      Type 'import("/Users/default/livingspec/slate-plugins/packages/core/src/types/SlatePlugin/SlatePlugin").SlatePlugin<import("/Users/default/livingspec/slate-plugins/packages/core/src/types/SPEditor").SPEditor>' is not assignable to type 'import("/Users/default/livingspec/slate-plugins/packages/core/dist/types/SlatePlugin/SlatePlugin").SlatePlugin<import("/Users/default/livingspec/slate-plugins/packages/core/src/types/SPEditor").SPEditor>'.
        Types of property 'withOverrides' are incompatible.
          Type 'WithOverride<TEditor<AnyObject>, {}> | WithOverride<TEditor<AnyObject>, {}>[] | undefined' is not assignable to type 'WithOverride<TEditor<{}>, {}> | WithOverride<TEditor<{}>, {}>[] | undefined'.
            Type 'WithOverride<TEditor<AnyObject>, {}>' is not assignable to type 'WithOverride<TEditor<{}>, {}> | WithOverride<TEditor<{}>, {}>[] | undefined'.
              Type 'WithOverride<TEditor<AnyObject>, {}>' is not assignable to type 'WithOverride<TEditor<{}>, {}>'.
                Type 'BaseEditor & AnyObject & { children: any[]; }' is not assignable to type 'T & {}'.
                  Type 'BaseEditor & AnyObject & { children: any[]; }' is not assignable to type 'T'.
                    'BaseEditor & AnyObject & { children: any[]; }' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'TEditor<{}>'.

    21       plugins: input1,
             ~~~~~~~

      packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLElement.ts:14:5
        14     plugins: SlatePlugin<T>[];
               ~~~~~~~
        The expected type comes from property 'plugins' which is declared here on type '{ plugins: SlatePlugin<SPEditor>[]; element: HTMLElement; }'

 FAIL  packages/serializers/html-serializer/src/deserializer/__tests__/deserializeHTMLElement/without-plugins.spec.tsx
  ● Test suite failed to run

    packages/serializers/html-serializer/src/deserializer/__tests__/deserializeHTMLElement/without-plugins.spec.tsx:21:7 - error TS2322: Type 'import("/Users/default/livingspec/slate-plugins/packages/core/src/types/SlatePlugin/SlatePlugin").SlatePlugin<import("/Users/default/livingspec/slate-plugins/packages/core/src/types/SPEditor").SPEditor>[]' is not assignable to type 'import("/Users/default/livingspec/slate-plugins/packages/core/dist/types/SlatePlugin/SlatePlugin").SlatePlugin<import("/Users/default/livingspec/slate-plugins/packages/core/src/types/SPEditor").SPEditor>[]'.
      Type 'import("/Users/default/livingspec/slate-plugins/packages/core/src/types/SlatePlugin/SlatePlugin").SlatePlugin<import("/Users/default/livingspec/slate-plugins/packages/core/src/types/SPEditor").SPEditor>' is not assignable to type 'import("/Users/default/livingspec/slate-plugins/packages/core/dist/types/SlatePlugin/SlatePlugin").SlatePlugin<import("/Users/default/livingspec/slate-plugins/packages/core/src/types/SPEditor").SPEditor>'.
        Types of property 'withOverrides' are incompatible.
          Type 'WithOverride<TEditor<AnyObject>, {}> | WithOverride<TEditor<AnyObject>, {}>[] | undefined' is not assignable to type 'WithOverride<TEditor<{}>, {}> | WithOverride<TEditor<{}>, {}>[] | undefined'.
            Type 'WithOverride<TEditor<AnyObject>, {}>' is not assignable to type 'WithOverride<TEditor<{}>, {}> | WithOverride<TEditor<{}>, {}>[] | undefined'.
              Type 'WithOverride<TEditor<AnyObject>, {}>' is not assignable to type 'WithOverride<TEditor<{}>, {}>'.
                Type 'BaseEditor & AnyObject & { children: any[]; }' is not assignable to type 'T & {}'.
                  Type 'BaseEditor & AnyObject & { children: any[]; }' is not assignable to type 'T'.
                    'BaseEditor & AnyObject & { children: any[]; }' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'TEditor<{}>'.

    21       plugins: input1,
             ~~~~~~~

      packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLElement.ts:14:5
        14     plugins: SlatePlugin<T>[];
               ~~~~~~~
        The expected type comes from property 'plugins' which is declared here on type '{ plugins: SlatePlugin<SPEditor>[]; element: HTMLElement; }'

 FAIL  packages/serializers/html-serializer/src/deserializer/__tests__/deserializeHTMLElement/pre-without-child.spec.tsx
  ● Test suite failed to run

    packages/serializers/html-serializer/src/deserializer/__tests__/deserializeHTMLElement/pre-without-child.spec.tsx:21:7 - error TS2322: Type 'import("/Users/default/livingspec/slate-plugins/packages/core/src/types/SlatePlugin/SlatePlugin").SlatePlugin<import("/Users/default/livingspec/slate-plugins/packages/core/src/types/SPEditor").SPEditor>[]' is not assignable to type 'import("/Users/default/livingspec/slate-plugins/packages/core/dist/types/SlatePlugin/SlatePlugin").SlatePlugin<import("/Users/default/livingspec/slate-plugins/packages/core/src/types/SPEditor").SPEditor>[]'.
      Type 'import("/Users/default/livingspec/slate-plugins/packages/core/src/types/SlatePlugin/SlatePlugin").SlatePlugin<import("/Users/default/livingspec/slate-plugins/packages/core/src/types/SPEditor").SPEditor>' is not assignable to type 'import("/Users/default/livingspec/slate-plugins/packages/core/dist/types/SlatePlugin/SlatePlugin").SlatePlugin<import("/Users/default/livingspec/slate-plugins/packages/core/src/types/SPEditor").SPEditor>'.
        Types of property 'withOverrides' are incompatible.
          Type 'WithOverride<TEditor<AnyObject>, {}> | WithOverride<TEditor<AnyObject>, {}>[] | undefined' is not assignable to type 'WithOverride<TEditor<{}>, {}> | WithOverride<TEditor<{}>, {}>[] | undefined'.
            Type 'WithOverride<TEditor<AnyObject>, {}>' is not assignable to type 'WithOverride<TEditor<{}>, {}> | WithOverride<TEditor<{}>, {}>[] | undefined'.
              Type 'WithOverride<TEditor<AnyObject>, {}>' is not assignable to type 'WithOverride<TEditor<{}>, {}>'.
                Type 'BaseEditor & AnyObject & { children: any[]; }' is not assignable to type 'T & {}'.
                  Type 'BaseEditor & AnyObject & { children: any[]; }' is not assignable to type 'T'.
                    'BaseEditor & AnyObject & { children: any[]; }' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'TEditor<{}>'.

    21       plugins: input1,
             ~~~~~~~

      packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLElement.ts:14:5
        14     plugins: SlatePlugin<T>[];
               ~~~~~~~
        The expected type comes from property 'plugins' which is declared here on type '{ plugins: SlatePlugin<SPEditor>[]; element: HTMLElement; }'

 FAIL  packages/core/src/hooks/useSlatePlugins/useSlatePlugins.spec.ts
  ● Test suite failed to run

    packages/core/src/plugins/createHistoryPlugin.ts:27:9 - error TS2322: Type '(editor: T) => T & HistoryEditor' is not assignable to type 'WithOverride<SPEditor, {}>'.
      Types of parameters 'editor' and 'editor' are incompatible.
        Type 'SPEditor' is not assignable to type 'T'.
          'SPEditor' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'BaseEditor'.

    27   () => withHistory
               ~~~~~~~~~~~

      packages/core/src/utils/getSlatePluginWithOverrides.ts:10:13
        10   V extends (...args: any) => WithOverride<T> = (
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        The expected type comes from the return type of this signature.

 FAIL  packages/ui/toolbar/src/__tests__/Toolbar/BalloonToolbar/with-selection.spec.tsx
  ● Test suite failed to run

    packages/core/src/plugins/createHistoryPlugin.ts:27:9 - error TS2322: Type '(editor: T) => T & HistoryEditor' is not assignable to type 'WithOverride<SPEditor, {}>'.
      Types of parameters 'editor' and 'editor' are incompatible.
        Type 'SPEditor' is not assignable to type 'T'.
          'SPEditor' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'BaseEditor'.

    27   () => withHistory
               ~~~~~~~~~~~

      packages/core/src/utils/getSlatePluginWithOverrides.ts:10:13
        10   V extends (...args: any) => WithOverride<T> = (
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        The expected type comes from the return type of this signature.

 FAIL  packages/elements/mention/src/__tests__/useMention/default.spec.tsx
  ● Test suite failed to run

    packages/elements/mention/src/__tests__/useMention/default.spec.tsx:8:31 - error TS2322: Type '{ value: string; id: number; house: string[]; }' is not assignable to type 'MentionNodeData'.
      Object literal may only specify known properties, and 'id' does not exist in type 'MentionNodeData'.

    8         { value: 'John Snow', id: 5, house: ['Targaryen', 'Stark'] },
                                    ~~~~~

 FAIL  packages/core/src/components/SlatePlugins.spec.tsx
  ● Test suite failed to run

    packages/core/src/plugins/createHistoryPlugin.ts:27:9 - error TS2322: Type '(editor: T) => T & HistoryEditor' is not assignable to type 'WithOverride<SPEditor, {}>'.
      Types of parameters 'editor' and 'editor' are incompatible.
        Type 'SPEditor' is not assignable to type 'T'.
          'SPEditor' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'BaseEditor'.

    27   () => withHistory
               ~~~~~~~~~~~

      packages/core/src/utils/getSlatePluginWithOverrides.ts:10:13
        10   V extends (...args: any) => WithOverride<T> = (
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        The expected type comes from the return type of this signature.


Test Suites: 8 failed, 229 passed, 237 total
Tests:       344 passed, 344 total
Snapshots:   0 total
Time:        79.3 s
Ran all test suites.
error Command failed with exit code 1.
```

**Context**

It's trivial if it works. Currently failing tests.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
