### PR TITLE
fix(serializers): updated stripClassNames.preserveClassNames

### DIFF
--- a/.changeset/forty-owls-check.md
+++ b/.changeset/forty-owls-check.md
@@ -1,0 +1,5 @@
+---
+"@udecode/slate-plugins-html-serializer": minor
+---
+
+updated stripClassNames.preserveClassNames

--- a/packages/serializers/html-serializer/src/serializer/__tests__/classNames.spec.ts
+++ b/packages/serializers/html-serializer/src/serializer/__tests__/classNames.spec.ts
@@ -126,6 +126,50 @@ it('serialize with slate classNames: multiple tags', () => {
   );
 });
 
+it('serialize with preserveClassNames empty', () => {
+  const editor = createEditorPlugins({
+    options: {
+      align_center: {
+        getNodeProps: () => ({
+          className: 'a slate-align_center',
+        }),
+      },
+    },
+  });
+
+  expect(
+    serializeHTMLFromNodes(editor, {
+      plugins: [createAlignPlugin()],
+      nodes: [
+        { type: 'align_center', children: [{ text: 'I am centered text!' }] },
+      ],
+      preserveClassNames: [],
+    })
+  ).toBe('<div>I am centered text!</div>');
+});
+
+it('serialize with custom unmatched preserved classname: a+custom', () => {
+  const editor = createEditorPlugins({
+    options: {
+      align_center: {
+        getNodeProps: () => ({
+          className: 'a slate-align_center',
+        }),
+      },
+    },
+  });
+
+  expect(
+    serializeHTMLFromNodes(editor, {
+      plugins: [createAlignPlugin()],
+      nodes: [
+        { type: 'align_center', children: [{ text: 'I am centered text!' }] },
+      ],
+      preserveClassNames: ['custom-'],
+    })
+  ).toBe('<div>I am centered text!</div>');
+});
+
 it('serialize with custom preserved classname: a+custom', () => {
   const editor = createEditorPlugins({
     options: {


### PR DESCRIPTION
**stripClassNames behaves erratically depending on what is passed into preserveClassNames**

Passing in an empty [] into `serializeHTMLFromNodes.preserveClassNames` causes it to render a set of empty spaces.

In addition, if you were to pass in an arbitrary string to `serializeHTMLFromNodes.preserveClassNames` (ie. `preserveClassNames = ['foo']`), the class names are all removed, but the remaining html element is left with a space in its string.

**Issue**

Fixes: #808 

**Example**

```
const HTML = serializeHTMLFromNodes(editor, {
    preserveClassNames: []
})
```

```
const HTML = serializeHTMLFromNodes(editor, {
    preserveClassNames: ['foo']
})
```

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
