### PR TITLE
Parse Media-Embed paste for src value

### DIFF
--- a/.changeset/hip-dodos-explain.md
+++ b/.changeset/hip-dodos-explain.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-media-embed-ui": minor
+---
+
+parse embed code when not matching url for media-embed

--- a/packages/elements/media-embed-ui/src/MediaEmbedElement/MediaEmbedUrlInput.tsx
+++ b/packages/elements/media-embed-ui/src/MediaEmbedElement/MediaEmbedUrlInput.tsx
@@ -13,12 +13,25 @@ export const MediaEmbedUrlInput = ({
 }) => {
   const [value, setValue] = React.useState(url);
 
+  const validateUrl = (newUrl: string) => {
+    // if not starting with http, assume pasting of full iframe embed code
+    if (newUrl.substring(0, 4) !== 'http') {
+      const regex = /(?<=src=").*?(?=[*"])/g;
+      const src = newUrl.match(regex)?.[0];
+      if (src) {
+        newUrl = src;
+      }
+    }
+    return newUrl;
+  };
+
   return (
     <input
       value={value}
       onClick={(e) => e.stopPropagation()}
       onChange={(e) => {
         const newUrl = e.target.value;
+        validateUrl(newUrl);
         setValue(newUrl);
         onChange(newUrl);
       }}


### PR DESCRIPTION
**Description**

When adding something via an iframe embed, many services automatically place the full embed code into the copy buffer, whereas our plugin only wants the src/url. This update inspects the value and if it's obviously not a URL, it attempts to extract the value of the src attribute to save users time and reduce the opportunity for errors.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

**Issue**

Nothing was broken so much as this saves users a step or two.

**Example**



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
