### PR TITLE
Fix link in contributing.md

### DIFF
--- a/docs/docs/plate/contributing.md
+++ b/docs/docs/plate/contributing.md
@@ -16,5 +16,5 @@ Plate is a modular, multi-package, monorepo project. It consists of a
 core package that creates the plugin system, based on which the plugin
 packages are implemented.
 
-See the [contributing guide](https://github.com/udecode/plate/CONTRIBUTING.md) to learn how to contribute
+See the [contributing guide](https://github.com/udecode/plate/blob/main/CONTRIBUTING.md) to learn how to contribute
 your code to the project.

--- a/docs/docs/plate/contributing.md
+++ b/docs/docs/plate/contributing.md
@@ -16,5 +16,5 @@ Plate is a modular, multi-package, monorepo project. It consists of a
 core package that creates the plugin system, based on which the plugin
 packages are implemented.
 
-See the [contributing guide](.https://github.com/udecode/plate/CONTRIBUTING.md) to learn how to contribute
+See the [contributing guide](https://github.com/udecode/plate/CONTRIBUTING.md) to learn how to contribute
 your code to the project.


### PR DESCRIPTION
**Description**
There was an extra (dot) in the markdown link, and the link itself 404’d. This PR removes the dot and provides a working link