### PR TITLE
Safari regex

### DIFF
--- a/.changeset/chilled-ties-knock.md
+++ b/.changeset/chilled-ties-knock.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-media-embed-ui": patch
+---
+
+Safari does not support regex look behind

--- a/packages/elements/media-embed-ui/src/MediaEmbedElement/MediaEmbedUrlInput.tsx
+++ b/packages/elements/media-embed-ui/src/MediaEmbedElement/MediaEmbedUrlInput.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { IS_SAFARI } from 'slate-react/dist/utils/environment';
 import { CSSProp } from 'styled-components';
 
 export const MediaEmbedUrlInput = ({
@@ -15,7 +16,8 @@ export const MediaEmbedUrlInput = ({
 
   const validateUrl = (newUrl: string) => {
     // if not starting with http, assume pasting of full iframe embed code
-    if (newUrl.substring(0, 4) !== 'http') {
+    // Restrict Safari due to lack of regex look behind https://github.com/udecode/plate/issues/880
+    if (newUrl.substring(0, 4) !== 'http' && !IS_SAFARI) {
       const regex = /(?<=src=").*?(?=[*"])/g;
       const src = newUrl.match(regex)?.[0];
       if (src) {

--- a/packages/elements/media-embed-ui/src/MediaEmbedElement/MediaEmbedUrlInput.tsx
+++ b/packages/elements/media-embed-ui/src/MediaEmbedElement/MediaEmbedUrlInput.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { IS_SAFARI } from 'slate-react/dist/utils/environment';
 import { CSSProp } from 'styled-components';
 
 export const MediaEmbedUrlInput = ({
@@ -17,7 +16,11 @@ export const MediaEmbedUrlInput = ({
   const validateUrl = (newUrl: string) => {
     // if not starting with http, assume pasting of full iframe embed code
     // Restrict Safari due to lack of regex look behind https://github.com/udecode/plate/issues/880
-    if (newUrl.substring(0, 4) !== 'http' && !IS_SAFARI) {
+    if (
+      newUrl.substring(0, 4) !== 'http' &&
+      typeof navigator !== 'undefined' &&
+      /Version\/[\d.]+.*Safari/.test(navigator.userAgent)
+    ) {
       const regex = /(?<=src=").*?(?=[*"])/g;
       const src = newUrl.match(regex)?.[0];
       if (src) {


### PR DESCRIPTION
**Description**

Media embed regex breaks Safari due to it not yet supporting regex look behind.

My solution is somewhat of a cop out (I don't know a good way to feature detect Safari's lack of regex look behind, and other attempts I made at an older style regex syntax fail for at least one of my embed examples). I'm happy to replace this with a better regex, but I want to unbreak the release for Safari users as a higher priorty.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

**Issue**

Fixes: #880

**Example**



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
