### PR TITLE
fix prettier quote config and trailingComma to match eslint settings

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}


### PR DESCRIPTION
This has no impact on the code, but it will enable contributors to use prettier and it will no longer conflict with eslint when it comes to quotes or trailing comma.