### PR TITLE
CSV detection was getting triggered for plain text paste

### DIFF
--- a/.changeset/wise-ads-tan.md
+++ b/.changeset/wise-ads-tan.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-csv-serializer': patch
+---
+
+Make sure there's at least a 2x2 table before treating text as csv

--- a/packages/serializers/csv-serializer/src/deserializer/utils/deserializeCSV.ts
+++ b/packages/serializers/csv-serializer/src/deserializer/utils/deserializeCSV.ts
@@ -14,6 +14,15 @@ import {
 } from '@udecode/plate-table';
 import { parse } from 'papaparse';
 
+const isValidCsv = (data: Record<string, string>[][]) => {
+  return !(
+    !data ||
+    data.length < 2 ||
+    data[0].length < 2 ||
+    data[1].length < 2
+  );
+};
+
 export const deserializeCSV = <T extends SPEditor = SPEditor>(
   editor: T,
   content: string,
@@ -24,6 +33,8 @@ export const deserializeCSV = <T extends SPEditor = SPEditor>(
 
   if (testCsv.errors.length === 0) {
     const csv = parse(content, { header });
+
+    if (!isValidCsv(csv.data as Record<string, string>[][])) return;
 
     const paragraph = getPlatePluginType(editor, ELEMENT_DEFAULT);
     const table = getPlatePluginType(editor, ELEMENT_TABLE);


### PR DESCRIPTION
**Description**

CSV check was not sufficient as it would create tables from single blocks of text.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

**Issue**

Fixes: Check to make sure it's at least a 2x2 table before handling as csv.

**Example**



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
