### PR TITLE
Csv detect take2

### DIFF
--- a/.changeset/large-phones-pretend.md
+++ b/.changeset/large-phones-pretend.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-csv-serializer': patch
+---
+
+add optional errorTolerance for csv deserializer detection

--- a/packages/serializers/csv-serializer/src/deserializer/createDeserializeCSVPlugin.ts
+++ b/packages/serializers/csv-serializer/src/deserializer/createDeserializeCSVPlugin.ts
@@ -12,6 +12,10 @@ export interface WithDeserializeCSVOptions<
   T extends SPEditor = SPEditor & ReactEditor
 > {
   plugins?: PlatePlugin<T>[];
+  // Percentage in decimal form, from 0 to a very large number, 0 for no errors allowed,
+  // Default is 0.25
+  // Percentage based on number of errors compared to number of rows
+  errorTolerance?: number;
 }
 
 /**
@@ -20,16 +24,17 @@ export interface WithDeserializeCSVOptions<
  */
 export const withDeserializeCSV = <
   T extends ReactEditor & SPEditor = ReactEditor & SPEditor
->({ plugins = [] }: WithDeserializeCSVOptions<T> = {}): WithOverride<T> => (
-  editor
-) => {
+>({
+  plugins = [],
+  errorTolerance = 0.25,
+}: WithDeserializeCSVOptions<T> = {}): WithOverride<T> => (editor) => {
   const { insertData } = editor;
 
   editor.insertData = (data) => {
     const content = data.getData('text/plain');
 
     if (content) {
-      const fragment = deserializeCSV(editor, content, true);
+      const fragment = deserializeCSV(editor, content, true, errorTolerance);
 
       if (fragment?.length) {
         return insertDeserializedFragment(editor, { fragment, plugins });


### PR DESCRIPTION
**Description**

Extends #900 with a look at the number of errors in csv parsing to determine if something is csv or not.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

**Issue**

Fixes: Multi-line paragraphs were still getting handled as csv in many scenarios.

**Example**



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
