### PR TITLE
fix(table) typo in deleteColumn, fixes #899

### DIFF
--- a/.changeset/curvy-crews-scream.md
+++ b/.changeset/curvy-crews-scream.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-table': patch
+---
+
+add changeset

--- a/packages/elements/table/src/transforms/deleteColumn.ts
+++ b/packages/elements/table/src/transforms/deleteColumn.ts
@@ -1,7 +1,7 @@
 import { getAbove, someNode } from '@udecode/plate-common';
 import { getPlatePluginType, SPEditor } from '@udecode/plate-core';
 import { Transforms } from 'slate';
-import { ELEMENT_TABLE, ELEMENT_TD, ELEMENT_TR } from '../defaults';
+import { ELEMENT_TABLE, ELEMENT_TD, ELEMENT_TH, ELEMENT_TR } from '../defaults';
 
 export const deleteColumn = (editor: SPEditor) => {
   if (
@@ -13,7 +13,7 @@ export const deleteColumn = (editor: SPEditor) => {
       match: {
         type: [
           getPlatePluginType(editor, ELEMENT_TD),
-          getPlatePluginType(editor, ELEMENT_TD),
+          getPlatePluginType(editor, ELEMENT_TH),
         ],
       },
     });


### PR DESCRIPTION
**Description**

Typo in deleteColumn code was not referring to TH and TD, but TD twice

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

**Issue**

Fixes: #899

**Example**



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
