### PR TITLE
vendor-peerDeps

### DIFF
--- a/.changeset/unlucky-socks-wait.md
+++ b/.changeset/unlucky-socks-wait.md
@@ -1,0 +1,35 @@
+---
+"@udecode/plate-autoformat": patch
+"@udecode/plate-break": patch
+"@udecode/plate-common": patch
+"@udecode/plate-alignment-ui": patch
+"@udecode/plate-alignment": patch
+"@udecode/plate-basic-elements": patch
+"@udecode/plate-block-quote-ui": patch
+"@udecode/plate-block-quote": patch
+"@udecode/plate-code-block-ui": patch
+"@udecode/plate-code-block": patch
+"@udecode/plate-excalidraw": patch
+"@udecode/plate-heading": patch
+"@udecode/plate-image-ui": patch
+"@udecode/plate-image": patch
+"@udecode/plate-link-ui": patch
+"@udecode/plate-link": patch
+"@udecode/plate-list-ui": patch
+"@udecode/plate-list": patch
+"@udecode/plate-media-embed-ui": patch
+"@udecode/plate-media-embed": patch
+"@udecode/plate-mention-ui": patch
+"@udecode/plate-mention": patch
+"@udecode/plate-paragraph": patch
+"@udecode/plate-table-ui": patch
+"@udecode/plate-table": patch
+"@udecode/plate-find-replace-ui": patch
+"@udecode/plate-find-replace": patch
+"@udecode/plate-basic-marks": patch
+"@udecode/plate-font-ui": patch
+"@udecode/plate-font": patch
+"@udecode/plate-highlight": patch
+---
+
+add `slate-history` as a peerDep

--- a/packages/autoformat/package.json
+++ b/packages/autoformat/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/break/package.json
+++ b/packages/break/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/alignment-ui/package.json
+++ b/packages/elements/alignment-ui/package.json
@@ -42,6 +42,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/alignment/package.json
+++ b/packages/elements/alignment/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/basic-elements/package.json
+++ b/packages/elements/basic-elements/package.json
@@ -43,6 +43,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/block-quote-ui/package.json
+++ b/packages/elements/block-quote-ui/package.json
@@ -41,6 +41,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/block-quote/package.json
+++ b/packages/elements/block-quote/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/code-block-ui/package.json
+++ b/packages/elements/code-block-ui/package.json
@@ -42,6 +42,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/code-block/package.json
+++ b/packages/elements/code-block/package.json
@@ -40,6 +40,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/excalidraw/package.json
+++ b/packages/elements/excalidraw/package.json
@@ -41,6 +41,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/heading/package.json
+++ b/packages/elements/heading/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/image-ui/package.json
+++ b/packages/elements/image-ui/package.json
@@ -42,6 +42,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/image/package.json
+++ b/packages/elements/image/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/link-ui/package.json
+++ b/packages/elements/link-ui/package.json
@@ -42,6 +42,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/link/package.json
+++ b/packages/elements/link/package.json
@@ -40,6 +40,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/list-ui/package.json
+++ b/packages/elements/list-ui/package.json
@@ -42,6 +42,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/list/package.json
+++ b/packages/elements/list/package.json
@@ -40,6 +40,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/media-embed-ui/package.json
+++ b/packages/elements/media-embed-ui/package.json
@@ -41,6 +41,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/media-embed/package.json
+++ b/packages/elements/media-embed/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/mention-ui/package.json
+++ b/packages/elements/mention-ui/package.json
@@ -41,6 +41,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/paragraph/package.json
+++ b/packages/elements/paragraph/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/table-ui/package.json
+++ b/packages/elements/table-ui/package.json
@@ -42,6 +42,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/elements/table/package.json
+++ b/packages/elements/table/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/find-replace-ui/package.json
+++ b/packages/find-replace-ui/package.json
@@ -42,6 +42,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/find-replace/package.json
+++ b/packages/find-replace/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/marks/basic-marks/package.json
+++ b/packages/marks/basic-marks/package.json
@@ -38,6 +38,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/marks/font-ui/package.json
+++ b/packages/marks/font-ui/package.json
@@ -42,6 +42,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/marks/font/package.json
+++ b/packages/marks/font/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/marks/highlight/package.json
+++ b/packages/marks/highlight/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/marks/kbd/package.json
+++ b/packages/marks/kbd/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/normalizers/package.json
+++ b/packages/normalizers/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/placeholder/package.json
+++ b/packages/placeholder/package.json
@@ -40,6 +40,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/reset-node/package.json
+++ b/packages/reset-node/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/serializers/ast-serializer/package.json
+++ b/packages/serializers/ast-serializer/package.json
@@ -50,6 +50,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/serializers/md-serializer/package.json
+++ b/packages/serializers/md-serializer/package.json
@@ -52,6 +52,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/serializers/serializer/package.json
+++ b/packages/serializers/serializer/package.json
@@ -40,6 +40,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/trailing-block/package.json
+++ b/packages/trailing-block/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/ui/styled-components/package.json
+++ b/packages/ui/styled-components/package.json
@@ -44,6 +44,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/packages/ui/toolbar/package.json
+++ b/packages/ui/toolbar/package.json
@@ -42,6 +42,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/templates/nested/package/package.json
+++ b/templates/nested/package/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {

--- a/templates/package/package.json
+++ b/templates/package/package.json
@@ -39,6 +39,7 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
+    "slate-history": ">=0.60.0",
     "slate-react": ">=0.60.0"
   },
   "publishConfig": {


### PR DESCRIPTION
**Description**

The core package has slate-history as a peerDep, so all the packages installing it should have this peerDep

Fixes these yarn 2 errors:

![CleanShot 2021-08-07 at 14 35 37](https://user-images.githubusercontent.com/19695832/128600490-8105598a-dda2-43ed-9cda-2835b42e7196.png)

