### PR TITLE
wrap more list transforms inside withoutNormalizing calls

### DIFF
--- a/packages/elements/list/src/transforms/insertListItem.ts
+++ b/packages/elements/list/src/transforms/insertListItem.ts
@@ -46,14 +46,16 @@ export const insertListItem = (editor: SPEditor) => {
      * If start, insert a list item before
      */
     if (isStart) {
-      insertNodes<TElement>(
-        editor,
-        {
-          type: liType,
-          children: [{ type: licType, children: [{ text: '' }] }],
-        },
-        { at: listItemPath }
-      );
+      Editor.withoutNormalizing(editor, () => {
+        insertNodes<TElement>(
+          editor,
+          {
+            type: liType,
+            children: [{ type: licType, children: [{ text: '' }] }],
+          },
+          { at: listItemPath }
+        );
+      });
       return true;
     }
 

--- a/packages/elements/list/src/transforms/moveListItemDown.ts
+++ b/packages/elements/list/src/transforms/moveListItemDown.ts
@@ -22,36 +22,37 @@ export const moveListItemDown = (
   } catch (e) {
     return;
   }
+  Editor.withoutNormalizing(editor, () => {
+    // Previous sibling is the new parent
+    const previousSiblingItem = Editor.node(
+      editor,
+      previousListItemPath
+    ) as NodeEntry<Ancestor>;
 
-  // Previous sibling is the new parent
-  const previousSiblingItem = Editor.node(
-    editor,
-    previousListItemPath
-  ) as NodeEntry<Ancestor>;
+    if (previousSiblingItem) {
+      const [previousNode, previousPath] = previousSiblingItem;
 
-  if (previousSiblingItem) {
-    const [previousNode, previousPath] = previousSiblingItem;
-
-    const sublist = previousNode.children.find((n) =>
-      match(n, { type: getListTypes(editor) })
-    ) as Element | undefined;
-    const newPath = previousPath.concat(
-      sublist ? [1, sublist.children.length] : [1]
-    );
-
-    if (!sublist) {
-      // Create new sublist
-      wrapNodes(
-        editor,
-        { type: listNode.type, children: [] },
-        { at: listItemPath }
+      const sublist = previousNode.children.find((n) =>
+        match(n, { type: getListTypes(editor) })
+      ) as Element | undefined;
+      const newPath = previousPath.concat(
+        sublist ? [1, sublist.children.length] : [1]
       );
-    }
 
-    // Move the current item to the sublist
-    Transforms.moveNodes(editor, {
-      at: listItemPath,
-      to: newPath,
-    });
-  }
+      if (!sublist) {
+        // Create new sublist
+        wrapNodes(
+          editor,
+          { type: listNode.type, children: [] },
+          { at: listItemPath }
+        );
+      }
+
+      // Move the current item to the sublist
+      Transforms.moveNodes(editor, {
+        at: listItemPath,
+        to: newPath,
+      });
+    }
+  });
 };

--- a/packages/elements/list/src/transforms/moveListItems.ts
+++ b/packages/elements/list/src/transforms/moveListItems.ts
@@ -7,57 +7,59 @@ import { moveListItemDown } from './moveListItemDown';
 import { moveListItemUp } from './moveListItemUp';
 
 export const moveListItems = (editor: SPEditor, increase = true) => {
-  // Get the selected lic
-  const [...lics] = getNodes(editor, {
-    at: editor.selection!,
-    match: {
-      type: getPlatePluginType(editor, ELEMENT_LIC),
-    },
-  });
-
-  if (!lics.length) return;
-
-  const highestLicPaths: Path[] = [];
-  const highestLicPathRefs: PathRef[] = [];
-
-  // Filter out the nested lic, we just need to move the highest ones
-  lics.forEach((lic) => {
-    const licPath = lic[1];
-    const liPath = Path.parent(licPath);
-
-    const isAncestor = highestLicPaths.some((path) => {
-      const highestLiPath = Path.parent(path);
-
-      return Path.isAncestor(highestLiPath, liPath);
+  Editor.withoutNormalizing(editor, () => {
+    // Get the selected lic
+    const [...lics] = getNodes(editor, {
+      at: editor.selection!,
+      match: {
+        type: getPlatePluginType(editor, ELEMENT_LIC),
+      },
     });
-    if (!isAncestor) {
-      highestLicPaths.push(licPath);
-      highestLicPathRefs.push(Editor.pathRef(editor, licPath));
-    }
-  });
 
-  const licPathRefsToMove = increase
-    ? highestLicPathRefs
-    : highestLicPathRefs.reverse();
+    if (!lics.length) return;
 
-  licPathRefsToMove.forEach((licPathRef) => {
-    const licPath = licPathRef.unref();
-    if (!licPath) return;
+    const highestLicPaths: Path[] = [];
+    const highestLicPathRefs: PathRef[] = [];
 
-    const listItem = getParent(editor, licPath);
-    if (!listItem) return;
-    const listEntry = getParent(editor, listItem[1]);
+    // Filter out the nested lic, we just need to move the highest ones
+    lics.forEach((lic) => {
+      const licPath = lic[1];
+      const liPath = Path.parent(licPath);
 
-    if (increase) {
-      moveListItemDown(editor, {
-        list: listEntry as any,
-        listItem: listItem as any,
+      const isAncestor = highestLicPaths.some((path) => {
+        const highestLiPath = Path.parent(path);
+
+        return Path.isAncestor(highestLiPath, liPath);
       });
-    } else if (listEntry && isListNested(editor, listEntry[1])) {
-      moveListItemUp(editor, {
-        list: listEntry as any,
-        listItem: listItem as any,
-      });
-    }
+      if (!isAncestor) {
+        highestLicPaths.push(licPath);
+        highestLicPathRefs.push(Editor.pathRef(editor, licPath));
+      }
+    });
+
+    const licPathRefsToMove = increase
+      ? highestLicPathRefs
+      : highestLicPathRefs.reverse();
+
+    licPathRefsToMove.forEach((licPathRef) => {
+      const licPath = licPathRef.unref();
+      if (!licPath) return;
+
+      const listItem = getParent(editor, licPath);
+      if (!listItem) return;
+      const listEntry = getParent(editor, listItem[1]);
+
+      if (increase) {
+        moveListItemDown(editor, {
+          list: listEntry as any,
+          listItem: listItem as any,
+        });
+      } else if (listEntry && isListNested(editor, listEntry[1])) {
+        moveListItemUp(editor, {
+          list: listEntry as any,
+          listItem: listItem as any,
+        });
+      }
+    });
   });
 };

--- a/packages/elements/list/src/transforms/removeFirstListItem.ts
+++ b/packages/elements/list/src/transforms/removeFirstListItem.ts
@@ -1,6 +1,6 @@
 import { isFirstChild } from '@udecode/plate-common';
 import { SPEditor, TElement } from '@udecode/plate-core';
-import { NodeEntry } from 'slate';
+import { Editor, NodeEntry } from 'slate';
 import { isListNested } from '../queries/isListNested';
 import { moveListItemUp } from './moveListItemUp';
 
@@ -19,12 +19,12 @@ export const removeFirstListItem = (
 ) => {
   const [, listPath] = list;
   const [, listItemPath] = listItem;
+  Editor.withoutNormalizing(editor, () => {
+    if (!isListNested(editor, listPath) && !isFirstChild(listItemPath)) {
+      moveListItemUp(editor, { list, listItem });
 
-  if (!isListNested(editor, listPath) && !isFirstChild(listItemPath)) {
-    moveListItemUp(editor, { list, listItem });
-
-    return true;
-  }
-
+      return true;
+    }
+  });
   return false;
 };

--- a/packages/elements/list/src/transforms/removeListItem.ts
+++ b/packages/elements/list/src/transforms/removeListItem.ts
@@ -29,72 +29,73 @@ export const removeListItem = (
   if (isExpanded(editor.selection) || !hasListChild(editor, liNode)) {
     return false;
   }
+  Editor.withoutNormalizing(editor, () => {
+    const previousLiPath = getPreviousPath(liPath);
 
-  const previousLiPath = getPreviousPath(liPath);
+    /**
+     * If there is a previous li, we need to move sub-lis to the previous li.
+     * As we need to delete first, we will:
+     * 1. insert a temporary li: tempLi
+     * 2. move sub-lis to tempLi
+     * 3. delete
+     * 4. move sub-lis from tempLi to the previous li.
+     * 5. remove tempLi
+     */
+    if (previousLiPath) {
+      const previousLi = Editor.node(
+        editor,
+        previousLiPath
+      ) as NodeEntry<TElement>;
 
-  /**
-   * If there is a previous li, we need to move sub-lis to the previous li.
-   * As we need to delete first, we will:
-   * 1. insert a temporary li: tempLi
-   * 2. move sub-lis to tempLi
-   * 3. delete
-   * 4. move sub-lis from tempLi to the previous li.
-   * 5. remove tempLi
-   */
-  if (previousLiPath) {
-    const previousLi = Editor.node(
-      editor,
-      previousLiPath
-    ) as NodeEntry<TElement>;
+      // 1
+      let tempLiPath = Path.next(liPath);
+      insertNodes<TElement>(
+        editor,
+        {
+          type: getPlatePluginType(editor, ELEMENT_LI),
+          children: [
+            {
+              type: getPlatePluginType(editor, ELEMENT_LIC),
+              children: [{ text: '' }],
+            },
+          ],
+        },
+        { at: tempLiPath }
+      );
 
-    // 1
-    let tempLiPath = Path.next(liPath);
-    insertNodes<TElement>(
-      editor,
-      {
-        type: getPlatePluginType(editor, ELEMENT_LI),
-        children: [
-          {
-            type: getPlatePluginType(editor, ELEMENT_LIC),
-            children: [{ text: '' }],
-          },
-        ],
-      },
-      { at: tempLiPath }
-    );
+      const tempLi = Editor.node(editor, tempLiPath) as NodeEntry<TElement>;
+      const tempLiPathRef = Editor.pathRef(editor, tempLi[1]);
 
-    const tempLi = Editor.node(editor, tempLiPath) as NodeEntry<TElement>;
-    const tempLiPathRef = Editor.pathRef(editor, tempLi[1]);
+      // 2
+      moveListItemSublistItemsToListItemSublist(editor, {
+        fromListItem: listItem,
+        toListItem: tempLi,
+      });
 
-    // 2
-    moveListItemSublistItemsToListItemSublist(editor, {
+      // 3
+      deleteFragment(editor, {
+        reverse: true,
+      });
+
+      tempLiPath = tempLiPathRef.unref()!;
+
+      // 4
+      moveListItemSublistItemsToListItemSublist(editor, {
+        fromListItem: [tempLi[0], tempLiPath],
+        toListItem: previousLi,
+      });
+
+      // 5
+      Transforms.removeNodes(editor, { at: tempLiPath });
+
+      return true;
+    }
+
+    // If it's the first li, move the sublist to the parent list
+    moveListItemsToList(editor, {
       fromListItem: listItem,
-      toListItem: tempLi,
+      toList: list,
+      toListIndex: 1,
     });
-
-    // 3
-    deleteFragment(editor, {
-      reverse: true,
-    });
-
-    tempLiPath = tempLiPathRef.unref()!;
-
-    // 4
-    moveListItemSublistItemsToListItemSublist(editor, {
-      fromListItem: [tempLi[0], tempLiPath],
-      toListItem: previousLi,
-    });
-
-    // 5
-    Transforms.removeNodes(editor, { at: tempLiPath });
-
-    return true;
-  }
-
-  // If it's the first li, move the sublist to the parent list
-  moveListItemsToList(editor, {
-    fromListItem: listItem,
-    toList: list,
-    toListIndex: 1,
   });
 };

--- a/packages/elements/list/src/transforms/unindentListItems.ts
+++ b/packages/elements/list/src/transforms/unindentListItems.ts
@@ -1,6 +1,9 @@
 import { SPEditor } from '@udecode/plate-core';
+import { Editor } from 'slate';
 import { moveListItems } from './moveListItems';
 
 export const unindentListItems = (editor: SPEditor) => {
-  moveListItems(editor, false);
+  Editor.withoutNormalizing(editor, () => {
+    moveListItems(editor, false);
+  });
 };

--- a/packages/elements/list/src/transforms/unwrapList.ts
+++ b/packages/elements/list/src/transforms/unwrapList.ts
@@ -1,30 +1,32 @@
 import { ELEMENT_DEFAULT, setNodes, unwrapNodes } from '@udecode/plate-common';
 import { getPlatePluginType, SPEditor } from '@udecode/plate-core';
-import { Path } from 'slate';
+import { Editor, Path } from 'slate';
 import { ELEMENT_LI, ELEMENT_OL, ELEMENT_UL } from '../defaults';
 
 export const unwrapList = (editor: SPEditor, { at }: { at?: Path } = {}) => {
-  setNodes(
-    editor,
-    {
-      type: getPlatePluginType(editor, ELEMENT_DEFAULT),
-    },
-    { at }
-  );
+  Editor.withoutNormalizing(editor, () => {
+    setNodes(
+      editor,
+      {
+        type: getPlatePluginType(editor, ELEMENT_DEFAULT),
+      },
+      { at }
+    );
 
-  unwrapNodes(editor, {
-    at,
-    match: { type: getPlatePluginType(editor, ELEMENT_LI) },
-  });
+    unwrapNodes(editor, {
+      at,
+      match: { type: getPlatePluginType(editor, ELEMENT_LI) },
+    });
 
-  unwrapNodes(editor, {
-    at,
-    match: {
-      type: [
-        getPlatePluginType(editor, ELEMENT_UL),
-        getPlatePluginType(editor, ELEMENT_OL),
-      ],
-    },
-    split: true,
+    unwrapNodes(editor, {
+      at,
+      match: {
+        type: [
+          getPlatePluginType(editor, ELEMENT_UL),
+          getPlatePluginType(editor, ELEMENT_OL),
+        ],
+      },
+      split: true,
+    });
   });
 };


### PR DESCRIPTION
**Description**

It's easy to cause Slate to crash when applying sequential transforms. This approach wraps more transform logic inside withoutNormalizing calls to allow a group of transforms to get applied together before Slate normalization gets applied. 

The current PR does not touch a few of the transforms where the structure and return of booleans makes the pattern a bit different.

If there's a better pattern we should follow let me know!

**Issue**

Fixes: Nothing specific, other than we're trying to make transformation and normalization more reliable.


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
