### PR TITLE
bug: some table cell calls were missing th

### DIFF
--- a/.changeset/dirty-elephants-yawn.md
+++ b/.changeset/dirty-elephants-yawn.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-table': patch
+---
+
+some table cell calls were missing th check

--- a/packages/elements/table/src/queries/getTableCellEntry.ts
+++ b/packages/elements/table/src/queries/getTableCellEntry.ts
@@ -1,11 +1,11 @@
 import { getAbove, getParent, someNode } from '@udecode/plate-common';
 import { getPlatePluginType, SPEditor } from '@udecode/plate-core';
 import { Location } from 'slate';
-import { ELEMENT_TD, ELEMENT_TR } from '../defaults';
+import { ELEMENT_TD, ELEMENT_TH, ELEMENT_TR } from '../defaults';
 
 /**
- * If at (default = selection) is in table>tr>td, return table, tr, and td
- * node entries.
+ * If at (default = selection) is in table>tr>td or table>tr>th,
+ * return table, tr, and td or th node entries.
  */
 export const getTableCellEntry = (
   editor: SPEditor,
@@ -15,7 +15,12 @@ export const getTableCellEntry = (
     at &&
     someNode(editor, {
       at,
-      match: { type: getPlatePluginType(editor, ELEMENT_TD) },
+      match: {
+        type: [
+          getPlatePluginType(editor, ELEMENT_TD),
+          getPlatePluginType(editor, ELEMENT_TH),
+        ],
+      },
     })
   ) {
     const selectionParent = getParent(editor, at);
@@ -25,13 +30,23 @@ export const getTableCellEntry = (
     const tableCell =
       getAbove(editor, {
         at,
-        match: { type: getPlatePluginType(editor, ELEMENT_TD) },
+        match: {
+          type: [
+            getPlatePluginType(editor, ELEMENT_TD),
+            getPlatePluginType(editor, ELEMENT_TH),
+          ],
+        },
       }) || getParent(editor, paragraphPath);
 
     if (!tableCell) return;
     const [tableCellNode, tableCellPath] = tableCell;
 
-    if (tableCellNode.type !== getPlatePluginType(editor, ELEMENT_TD)) return;
+    if (
+      tableCellNode.type !==
+      (getPlatePluginType(editor, ELEMENT_TD) ||
+        getPlatePluginType(editor, ELEMENT_TH))
+    )
+      return;
 
     const tableRow = getParent(editor, tableCellPath);
     if (!tableRow) return;

--- a/packages/elements/table/src/transforms/addColumn.ts
+++ b/packages/elements/table/src/transforms/addColumn.ts
@@ -1,7 +1,7 @@
 import { getAbove, insertNodes, someNode } from '@udecode/plate-common';
 import { getPlatePluginType, SPEditor, TElement } from '@udecode/plate-core';
 import { Path } from 'slate';
-import { ELEMENT_TABLE, ELEMENT_TD } from '../defaults';
+import { ELEMENT_TABLE, ELEMENT_TD, ELEMENT_TH } from '../defaults';
 import { TablePluginOptions } from '../types';
 import { getEmptyCellNode } from '../utils/getEmptyCellNode';
 
@@ -15,7 +15,7 @@ export const addColumn = (editor: SPEditor, { header }: TablePluginOptions) => {
       match: {
         type: [
           getPlatePluginType(editor, ELEMENT_TD),
-          getPlatePluginType(editor, ELEMENT_TD),
+          getPlatePluginType(editor, ELEMENT_TH),
         ],
       },
     });

--- a/packages/elements/table/src/utils/getEmptyCellNode.ts
+++ b/packages/elements/table/src/utils/getEmptyCellNode.ts
@@ -1,6 +1,6 @@
 import { ELEMENT_DEFAULT } from '@udecode/plate-common';
 import { getPlatePluginType, SPEditor } from '@udecode/plate-core';
-import { ELEMENT_TD } from '../defaults';
+import { ELEMENT_TD, ELEMENT_TH } from '../defaults';
 import { TablePluginOptions } from '../types';
 
 export const getEmptyCellNode = (
@@ -10,7 +10,7 @@ export const getEmptyCellNode = (
   return {
     type: header
       ? getPlatePluginType(editor, ELEMENT_TD)
-      : getPlatePluginType(editor, ELEMENT_TD),
+      : getPlatePluginType(editor, ELEMENT_TH),
     children: [
       {
         type: getPlatePluginType(editor, ELEMENT_DEFAULT),

--- a/packages/elements/table/src/withTable.ts
+++ b/packages/elements/table/src/withTable.ts
@@ -7,14 +7,14 @@ import {
   WithOverride,
 } from '@udecode/plate-core';
 import { Editor, Node, Point, Transforms } from 'slate';
-import { ELEMENT_TD } from './defaults';
+import { ELEMENT_TD, ELEMENT_TH } from './defaults';
 
 export const withTable = (): WithOverride<SPEditor> => (editor) => {
   const matchCells = (node: Node) => {
     return (
       isElement(node) &&
       (node.type === getPlatePluginType(editor, ELEMENT_TD) ||
-        node.type === getPlatePluginType(editor, ELEMENT_TD))
+        node.type === getPlatePluginType(editor, ELEMENT_TH))
     );
   };
 


### PR DESCRIPTION
**Description**

Some of our logic for working with table cells was referencing TD twice instead of TD and TH.

**Issue**

Fixes: #947

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)