### PR TITLE
Allow users to disable an editor

### DIFF
--- a/packages/core/src/hooks/usePlate/usePlateEffects.ts
+++ b/packages/core/src/hooks/usePlate/usePlateEffects.ts
@@ -49,12 +49,12 @@ export const usePlateEffects = <T extends SPEditor = SPEditor>({
 
   useEffect(() => {
     setInitialState({
-      enabled: true,
+      enabled,
       plugins: [],
       pluginKeys: [],
       value: [],
     });
-  }, [id, setInitialState]);
+  }, [enabled, id, setInitialState]);
 
   // Slate.value
   useEffect(() => {


### PR DESCRIPTION
Currently, Plate takes an enabled prop, but ends up ignoring it and using a true value. I have changed it to use the value given by the user instead.