### PR TITLE
Fix multiple instances of styled-components

### DIFF
--- a/.changeset/honest-dolphins-study.md
+++ b/.changeset/honest-dolphins-study.md
@@ -1,0 +1,23 @@
+---
+'@udecode/plate-dnd': major
+'@udecode/plate-alignment-ui': major
+'@udecode/plate-block-quote-ui': major
+'@udecode/plate-code-block-ui': major
+'@udecode/plate-excalidraw': major
+'@udecode/plate-image-ui': major
+'@udecode/plate-link-ui': major
+'@udecode/plate-list-ui': major
+'@udecode/plate-media-embed-ui': major
+'@udecode/plate-mention-ui': major
+'@udecode/plate-table-ui': major
+'@udecode/plate-find-replace-ui': major
+'@udecode/plate-font-ui': major
+'@udecode/plate-placeholder': major
+'@udecode/plate': major
+'@udecode/plate-styled-components': major
+'@udecode/plate-toolbar': major
+---
+
+WHAT: moved styled-components from dependencies to peer dependencies.  
+WHY: there was multiple instances of styled-components across all the packages.  
+HOW: make sure to have `styled-components` in your dependencies.

--- a/.changeset/honest-dolphins-study.md
+++ b/.changeset/honest-dolphins-study.md
@@ -18,6 +18,6 @@
 '@udecode/plate-toolbar': major
 ---
 
-WHAT: moved styled-components from dependencies to peer dependencies.  
-WHY: there was multiple instances of styled-components across all the packages.  
+WHAT: moved `styled-components` from dependencies to peer dependencies.  
+WHY: there was multiple instances of `styled-components` across all the packages.  
 HOW: make sure to have `styled-components` in your dependencies.

--- a/docs/docs/components/balloon-toolbar.mdx
+++ b/docs/docs/components/balloon-toolbar.mdx
@@ -3,6 +3,14 @@ slug: /components/balloon-toolbar
 title: Balloon Toolbar
 ---
 
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-toolbar
+```
+
+### Usage
+
 ```ts live
 () => {
   const BallonToolbarMarks = () => {
@@ -64,3 +72,8 @@ title: Balloon Toolbar
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/ui/toolbar](https://github.com/udecode/plate/tree/main/packages/ui/toolbar/src)

--- a/docs/docs/components/dnd.mdx
+++ b/docs/docs/components/dnd.mdx
@@ -3,6 +3,14 @@ slug: /components/dnd
 title: Drag & Drop
 ---
 
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-dnd
+```
+
+### Usage
+
 <iframe
   src="https://codesandbox.io/embed/plate-playground-v1-2mh1c?autoresize=1&fontsize=16&theme=dark"
   style={{

--- a/docs/docs/components/placeholder.mdx
+++ b/docs/docs/components/placeholder.mdx
@@ -3,6 +3,14 @@ slug: /components/placeholder
 title: Placeholder
 ---
 
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-placeholder
+```
+
+### Usage
+
 ```ts live
 () => {
   const componentsPlaceholder = withStyledPlaceHolders(components);
@@ -24,3 +32,8 @@ title: Placeholder
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/placeholder](https://github.com/udecode/plate/tree/main/packages/placeholder/src)

--- a/docs/docs/components/plate.mdx
+++ b/docs/docs/components/plate.mdx
@@ -3,6 +3,14 @@ slug: /components/plate
 title: Plate
 ---
 
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-core
+```
+
+### Usage
+
 ```ts live
 () => {
   const id = 'plate';
@@ -39,3 +47,8 @@ title: Plate
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/core](https://github.com/udecode/plate/tree/main/packages/core/src)

--- a/docs/docs/examples/editable-voids.mdx
+++ b/docs/docs/examples/editable-voids.mdx
@@ -27,3 +27,7 @@ title: Editable Voids
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)

--- a/docs/docs/examples/huge-document.mdx
+++ b/docs/docs/examples/huge-document.mdx
@@ -56,3 +56,7 @@ title: Huge Document
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)

--- a/docs/docs/examples/iframe.mdx
+++ b/docs/docs/examples/iframe.mdx
@@ -26,3 +26,7 @@ title: IFrame
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -12,10 +12,10 @@ You can install all the packages bundled together:
 npm install @udecode/plate
 ```
 
-You will also need these peer dependencies (slate >= 0.60):
+You will also need these peer dependencies:
 
 ```bash npm2yarn
-npm install slate slate-react slate-history slate-hyperscript react react-dom
+npm install slate slate-react slate-history slate-hyperscript react react-dom styled-components
 ```
 
 Alternatively you can install only the packages you need:

--- a/docs/docs/playground.mdx
+++ b/docs/docs/playground.mdx
@@ -3,14 +3,13 @@ slug: /playground
 title: Playground
 ---
 
-:::note
-
-Most of the following variables are exported from the library or defined in the corresponding example.
-For quick lookup, jump to the [source code](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx).
-
-:::
-
 The following playground uses most of the provided plugins.
+
+### Installation
+
+See [Installation](/docs/installation)
+
+### Usage
 
 ```ts live
 () => {
@@ -127,3 +126,8 @@ The following playground uses most of the provided plugins.
   return <Editor />;
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages](https://github.com/udecode/plate/tree/main/packages)

--- a/docs/docs/plugins/alignment.mdx
+++ b/docs/docs/plugins/alignment.mdx
@@ -5,13 +5,22 @@ title: Alignment
 
 ### `createAlignPlugin`
 
-An align element aligns its children:
+Align element which aligns its children:
 - default `type` are:
   - `'align_left'`
   - `'align_center'`
   - `'align_right'`
   - `'align_justify'`
 - wrap node strategy
+
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-alignment
+npm install @udecode/plate-alignment-ui
+```
+
+### Usage
 
 ```ts live
 () => {
@@ -59,3 +68,9 @@ An align element aligns its children:
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/elements/alignment](https://github.com/udecode/plate/tree/main/packages/elements/alignment/src)
+- [packages/elements/alignment-ui](https://github.com/udecode/plate/tree/main/packages/elements/alignment-ui/src)

--- a/docs/docs/plugins/autoformat.mdx
+++ b/docs/docs/plugins/autoformat.mdx
@@ -106,8 +106,9 @@ This package provides the following rules:
 
 ### Source code
 
-[packages/autoformat](https://github.com/udecode/plate/tree/main/packages/autoformat/src)
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/autoformat](https://github.com/udecode/plate/tree/main/packages/autoformat/src)
 
 ### API
 
-[AutoformatRule](https://plate-api.udecode.io/interfaces/autoformatrule.html)
+- [AutoformatRule](https://plate-api.udecode.io/interfaces/autoformatrule.html)

--- a/docs/docs/plugins/basic-elements.mdx
+++ b/docs/docs/plugins/basic-elements.mdx
@@ -11,6 +11,14 @@ Returns a list of the following plugins:
 - `createHeadingPlugin()` for the `h1`, `h2`,... elements
 - `createParagraphPlugin()` for the `p` element
 
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-basic-elements
+```
+
+### Usage
+
 ```ts live
 () => {
   const ToolbarButtonsBasicElements = () => {
@@ -79,3 +87,8 @@ Returns a list of the following plugins:
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/elements/basic-elements](https://github.com/udecode/plate/tree/main/packages/elements/basic-elements/src)

--- a/docs/docs/plugins/basic-marks.mdx
+++ b/docs/docs/plugins/basic-marks.mdx
@@ -14,6 +14,14 @@ Returns a list of the following plugins:
 - `createSuperscriptPlugin()` for the `superscript` mark
 - `createCodePlugin()` for the `code` mark
 
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-basic-marks
+```
+
+### Usage
+
 ```ts live
 () => {
   const ToolbarButtonsBasicMarks = () => {
@@ -78,3 +86,8 @@ Returns a list of the following plugins:
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/marks/basic-marks](https://github.com/udecode/plate/tree/main/packages/marks/basic-marks/src)

--- a/docs/docs/plugins/excalidraw.mdx
+++ b/docs/docs/plugins/excalidraw.mdx
@@ -3,7 +3,13 @@ slug: /plugins/excalidraw
 title: Excalidraw
 ---
 
-### `createExcalidrawPlugin`
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-excalidraw
+```
+
+### Usage
 
 ```ts live
 () => {
@@ -30,3 +36,8 @@ title: Excalidraw
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/elements/excalidraw](https://github.com/udecode/plate/tree/main/packages/elements/excalidraw/src)

--- a/docs/docs/plugins/exit-break.mdx
+++ b/docs/docs/plugins/exit-break.mdx
@@ -3,9 +3,17 @@ slug: /plugins/exit-break
 title: Exit Break
 ---
 
+### `createExitBreakPlugin`
+
 Allows you to create hotkeys which exit the current block.
 
-### `createExitBreakPlugin`
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-break
+```
+
+### Usage
 
 ```ts live
 () => {
@@ -51,3 +59,8 @@ Allows you to create hotkeys which exit the current block.
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/break](https://github.com/udecode/plate/tree/main/packages/break/src)

--- a/docs/docs/plugins/find-replace.mdx
+++ b/docs/docs/plugins/find-replace.mdx
@@ -7,7 +7,14 @@ title: Find & Replace
 "Replace" feature is not yet supported
 :::
 
-### `useFindReplacePlugin`
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-find-replace
+npm install @udecode/plate-find-replace-ui
+```
+
+### Usage
 
 ```ts live
 () => {
@@ -36,3 +43,9 @@ title: Find & Replace
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/find-replace](https://github.com/udecode/plate/tree/main/packages/find-replace/src)
+- [packages/find-replace-ui](https://github.com/udecode/plate/tree/main/packages/find-replace-ui/src)

--- a/docs/docs/plugins/font.mdx
+++ b/docs/docs/plugins/font.mdx
@@ -5,6 +5,15 @@ title: Font color
 
 Use the toolbar dropdowns in the demo below to control font color and font background color.
 
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-font
+npm install @udecode/plate-font-ui
+```
+
+### Usage
+
 ```ts live
 () => {
   let styledComponents = createPlateComponents({
@@ -58,3 +67,9 @@ Use the toolbar dropdowns in the demo below to control font color and font backg
   return <Editor />;
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/marks/font](https://github.com/udecode/plate/tree/main/packages/marks/font/src)
+- [packages/marks/font-ui](https://github.com/udecode/plate/tree/main/packages/marks/font-ui/src)

--- a/docs/docs/plugins/forced-layout.mdx
+++ b/docs/docs/plugins/forced-layout.mdx
@@ -8,6 +8,15 @@ Allows you to enforce document structure. For example, you can require that the 
 - `createNormalizeTypesPlugin`
 - `createTrailingBlockPlugin`
 
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-normalizers
+npm install @udecode/plate-trailing-block
+```
+
+### Usage
+
 ```ts live
 () => {
   const plugins = [
@@ -30,3 +39,9 @@ Allows you to enforce document structure. For example, you can require that the 
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/normalizers](https://github.com/udecode/plate/tree/main/packages/normalizers/src)
+- [packages/trailing-block](https://github.com/udecode/plate/tree/main/packages/trailing-block/src)

--- a/docs/docs/plugins/highlight.mdx
+++ b/docs/docs/plugins/highlight.mdx
@@ -3,7 +3,13 @@ slug: /plugins/highlight
 title: Highlight
 ---
 
-### `createHighlightPlugin`
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-highlight
+```
+
+### Usage
 
 ```ts live
 () => {
@@ -40,3 +46,8 @@ title: Highlight
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/marks/highlight](https://github.com/udecode/plate/tree/main/packages/marks/highlight/src)

--- a/docs/docs/plugins/image.mdx
+++ b/docs/docs/plugins/image.mdx
@@ -3,7 +3,14 @@ slug: /plugins/image
 title: Image
 ---
 
-### `createImagePlugin`
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-image
+npm install @udecode/plate-image-ui
+```
+
+### Usage
 
 ```ts live
 () => {
@@ -30,3 +37,9 @@ title: Image
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/elements/image](https://github.com/udecode/plate/tree/main/packages/elements/image/src)
+- [packages/elements/image-ui](https://github.com/udecode/plate/tree/main/packages/elements/image-ui/src)

--- a/docs/docs/plugins/kbd.mdx
+++ b/docs/docs/plugins/kbd.mdx
@@ -3,7 +3,13 @@ slug: /plugins/kbd
 title: Keyboard Input
 ---
 
-### `createKbdPlugin`
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-kbd
+```
+
+### Usage
 
 ```ts live
 () => {
@@ -40,3 +46,8 @@ title: Keyboard Input
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/marks/kbd](https://github.com/udecode/plate/tree/main/packages/marks/kbd/src)

--- a/docs/docs/plugins/link.mdx
+++ b/docs/docs/plugins/link.mdx
@@ -9,6 +9,15 @@ A link is an inline element:
 - default `type` is `'a'`
 - `url` is the url of the link.
 
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-link
+npm install @udecode/plate-link-ui
+```
+
+### Usage
+
 ```ts live
 () => {
   const plugins = [
@@ -33,3 +42,9 @@ A link is an inline element:
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/elements/link](https://github.com/udecode/plate/tree/main/packages/elements/link/src)
+- [packages/elements/link-ui](https://github.com/udecode/plate/tree/main/packages/elements/link-ui/src)

--- a/docs/docs/plugins/list.mdx
+++ b/docs/docs/plugins/list.mdx
@@ -3,7 +3,14 @@ slug: /plugins/list
 title: List
 ---
 
-### `createListPlugin`
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-list
+npm install @udecode/plate-list-ui
+```
+
+### Usage
 
 ```ts live
 () => {
@@ -50,3 +57,9 @@ title: List
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/elements/link](https://github.com/udecode/plate/tree/main/packages/elements/link/src)
+- [packages/elements/link-ui](https://github.com/udecode/plate/tree/main/packages/elements/link-ui/src)

--- a/docs/docs/plugins/media-embed.mdx
+++ b/docs/docs/plugins/media-embed.mdx
@@ -3,7 +3,14 @@ slug: /plugins/media-embed
 title: Media Embed
 ---
 
-### `createMediaEmbedPlugin`
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-media-embed
+npm install @udecode/plate-media-embed-ui
+```
+
+### Usage
 
 ```ts live
 () => {
@@ -25,3 +32,9 @@ title: Media Embed
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/elements/media-embed](https://github.com/udecode/plate/tree/main/packages/elements/media-embed/src)
+- [packages/elements/media-embed-ui](https://github.com/udecode/plate/tree/main/packages/elements/media-embed-ui/src)

--- a/docs/docs/plugins/mention.mdx
+++ b/docs/docs/plugins/mention.mdx
@@ -3,7 +3,14 @@ slug: /plugins/mention
 title: Mention
 ---
 
-### `useMentionPlugin`
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-mention
+npm install @udecode/plate-mention-ui
+```
+
+### Usage
 
 ```ts live
 () => {
@@ -64,3 +71,9 @@ title: Mention
   return <Editor />
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/elements/mention](https://github.com/udecode/plate/tree/main/packages/elements/mention/src)
+- [packages/elements/mention-ui](https://github.com/udecode/plate/tree/main/packages/elements/mention-ui/src)

--- a/docs/docs/plugins/reset-node.mdx
+++ b/docs/docs/plugins/reset-node.mdx
@@ -9,6 +9,14 @@ Allows you to reset the block type based on certain rules.
 
 In the following example, you can press `Enter` in an empty block quote or `Backspace` at the start of a block so it resets to a paragraph.
 
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-reset-node
+```
+
+### Usage
+
 ```ts live
 () => {
   const resetBlockTypesCommonRule = {
@@ -53,3 +61,8 @@ In the following example, you can press `Enter` in an empty block quote or `Back
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/reset-node](https://github.com/udecode/plate/tree/main/packages/reset-node/src)

--- a/docs/docs/plugins/serializing-ast.mdx
+++ b/docs/docs/plugins/serializing-ast.mdx
@@ -3,7 +3,13 @@ slug: /serializing-ast
 title: AST
 ---
 
-## Deserializer
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-ast-serializer
+```
+
+### Usage
 
 ```ts live
 () => {
@@ -41,3 +47,8 @@ title: AST
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/serializers/ast-serializer](https://github.com/udecode/plate/tree/main/packages/serializers/ast-serializer/src)

--- a/docs/docs/plugins/serializing-csv.mdx
+++ b/docs/docs/plugins/serializing-csv.mdx
@@ -3,7 +3,13 @@ slug: /serializing-csv
 title: CSV
 ---
 
-## Deserializer
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-csv-serializer
+```
+
+### Usage
 
 ```ts live
 () => {
@@ -41,3 +47,8 @@ title: CSV
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/serializers/csv-serializer](https://github.com/udecode/plate/tree/main/packages/serializers/csv-serializer/src)

--- a/docs/docs/plugins/serializing-html.mdx
+++ b/docs/docs/plugins/serializing-html.mdx
@@ -3,7 +3,15 @@ slug: /serializing-html
 title: HTML
 ---
 
-## Serializer
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-html-serializer
+```
+
+### Usage
+
+#### Serializer
 
 Use `serializeHTMLFromNodes`:
 
@@ -26,7 +34,7 @@ Use `serializeHTMLFromNodes`:
 }
 ```
 
-## Deserializer
+#### Deserializer
 
 ```ts live
 () => {
@@ -64,3 +72,8 @@ Use `serializeHTMLFromNodes`:
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/serializers/html-serializer](https://github.com/udecode/plate/tree/main/packages/serializers/html-serializer/src)

--- a/docs/docs/plugins/serializing-md.mdx
+++ b/docs/docs/plugins/serializing-md.mdx
@@ -3,11 +3,19 @@ slug: /serializing-md
 title: Markdown
 ---
 
-## Serializer
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-md-serializer
+```
+
+### Usage
+
+#### Serializer
 
 Use [remark-slate](https://github.com/hanford/remark-slate).
 
-## Deserializer
+#### Deserializer
 
 ```ts live
 () => {
@@ -32,3 +40,8 @@ Use [remark-slate](https://github.com/hanford/remark-slate).
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/serializers/md-serializer](https://github.com/udecode/plate/tree/main/packages/serializers/md-serializer/src)

--- a/docs/docs/plugins/soft-break.mdx
+++ b/docs/docs/plugins/soft-break.mdx
@@ -7,6 +7,14 @@ title: Soft Break
 
 Allows you to create hotkeys which insert a line break, without exiting the current block.
 
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-break
+```
+
+### Usage
+
 ```ts live
 () => {
   const optionsSoftBreakPlugin = {
@@ -43,3 +51,8 @@ Allows you to create hotkeys which insert a line break, without exiting the curr
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/break](https://github.com/udecode/plate/tree/main/packages/break/src)

--- a/docs/docs/plugins/table.mdx
+++ b/docs/docs/plugins/table.mdx
@@ -3,6 +3,15 @@ slug: /plugins/table
 title: Table
 ---
 
+### Installation
+
+```bash npm2yarn
+npm install @udecode/plate-table
+npm install @udecode/plate-table-ui
+```
+
+### Usage
+
 ```ts live
 () => {
   const ToolbarButtonsTable = () => (
@@ -40,3 +49,9 @@ title: Table
   );
 }
 ```
+
+### Source Code
+
+- [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
+- [packages/elements/table](https://github.com/udecode/plate/tree/main/packages/elements/table/src)
+- [packages/elements/table-ui](https://github.com/udecode/plate/tree/main/packages/elements/table-ui/src)

--- a/docs/package.json
+++ b/docs/package.json
@@ -96,6 +96,7 @@
     "react-dnd-html5-backend": "^14.0.0",
     "react-icons": "^4.2.0",
     "sass": "^1.32.12",
+    "styled-components": "5.1.1",
     "tailwindcss": "^2.1.4",
     "zustand": "^3.4.2"
   },

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2005,385 +2005,413 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.5.tgz#fdd299f23205c3455af88ce618dd65c14cb73e22"
   integrity sha512-wnra4Vw9dopnuybR6HBywJ/URYpYrKLoepBTEtgfJup8Ahoi2zJECPP2cwiXp7btTvOT2CULv87aQRA4eZSP6g==
 
-"@udecode/plate-alignment-ui@1.1.7":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-alignment-ui@link:../packages/elements/alignment-ui":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-alignment@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-alignment@link:../packages/elements/alignment":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-ast-serializer@1.1.8":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-ast-serializer@link:../packages/serializers/ast-serializer":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-autoformat@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-autoformat@link:../packages/autoformat":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-basic-elements@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-basic-elements@link:../packages/elements/basic-elements":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-basic-marks@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-basic-marks@link:../packages/marks/basic-marks":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-block-quote-ui@1.1.7":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-block-quote-ui@link:../packages/elements/block-quote-ui":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-block-quote@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-block-quote@link:../packages/elements/block-quote":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-break@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-break@link:../packages/break":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-code-block-ui@1.1.7":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-code-block-ui@link:../packages/elements/code-block-ui":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-code-block@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-code-block@link:../packages/elements/code-block":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-common@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-common@link:../packages/common":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-core@1.0.0":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-core@link:../packages/core":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-csv-serializer@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-csv-serializer@link:../packages/serializers/csv-serializer":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-dnd@1.1.7":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-dnd@link:../packages/dnd":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-excalidraw@link:../packages/elements/excalidraw":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-find-replace-ui@1.1.7":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-find-replace-ui@link:../packages/find-replace-ui":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-find-replace@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-find-replace@link:../packages/find-replace":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-font-ui@1.1.7":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-font-ui@link:../packages/marks/font-ui":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-font@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-font@link:../packages/marks/font":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-heading@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-heading@link:../packages/elements/heading":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-highlight@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-highlight@link:../packages/marks/highlight":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-html-serializer@1.1.7":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-html-serializer@link:../packages/serializers/html-serializer":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-image-ui@1.1.7":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-image-ui@link:../packages/elements/image-ui":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-image@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-image@link:../packages/elements/image":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-kbd@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-kbd@link:../packages/marks/kbd":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-link-ui@1.1.7":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-link-ui@link:../packages/elements/link-ui":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-link@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-link@link:../packages/elements/link":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-list-ui@1.1.8":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-list-ui@link:../packages/elements/list-ui":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-list@1.1.8":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-list@link:../packages/elements/list":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-md-serializer@1.1.8":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-md-serializer@link:../packages/serializers/md-serializer":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-media-embed-ui@1.1.7":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-media-embed-ui@link:../packages/elements/media-embed-ui":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-media-embed@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-media-embed@link:../packages/elements/media-embed":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-mention-ui@1.1.7":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-mention-ui@link:../packages/elements/mention-ui":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-mention@1.1.7":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-mention@link:../packages/elements/mention":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-node-id@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-node-id@link:../packages/node-id":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-normalizers@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-normalizers@link:../packages/normalizers":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-paragraph@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-paragraph@link:../packages/elements/paragraph":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-placeholder@1.1.7":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-placeholder@link:../packages/placeholder":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-reset-node@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-reset-node@link:../packages/reset-node":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-select@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-select@link:../packages/select":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-serializer@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-serializer@link:../packages/serializers/serializer":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-styled-components@1.1.7":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-styled-components@link:../packages/ui/styled-components":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-table-ui@1.1.7":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-table-ui@link:../packages/elements/table-ui":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-table@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-table@link:../packages/elements/table":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-test-utils@link:../packages/test-utils":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-toolbar@1.1.7":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-toolbar@link:../packages/ui/toolbar":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-trailing-block@1.1.6":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate-trailing-block@link:../packages/trailing-block":
-  version "0.0.0"
-  uid ""
-
-"@udecode/plate@link:../packages/plate":
-  version "0.0.0"
-  uid ""
+"@udecode/plate-alignment-ui@2.0.0", "@udecode/plate-alignment-ui@file:../packages/elements/alignment-ui":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-alignment" "2.0.0"
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-styled-components" "2.0.0"
+    "@udecode/plate-toolbar" "2.0.0"
+
+"@udecode/plate-alignment@2.0.0", "@udecode/plate-alignment@file:../packages/elements/alignment":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-ast-serializer@2.0.0", "@udecode/plate-ast-serializer@file:../packages/serializers/ast-serializer":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-block-quote" "2.0.0"
+    "@udecode/plate-code-block" "2.0.0"
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-heading" "2.0.0"
+    "@udecode/plate-link" "2.0.0"
+    "@udecode/plate-list" "2.0.0"
+    "@udecode/plate-paragraph" "2.0.0"
+    "@udecode/plate-serializer" "2.0.0"
+    remark-parse "^9.0.0"
+    remark-slate "^1.4.0"
+    unified "^9.2.0"
+
+"@udecode/plate-autoformat@2.0.0", "@udecode/plate-autoformat@file:../packages/autoformat":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-basic-elements@2.0.0", "@udecode/plate-basic-elements@file:../packages/elements/basic-elements":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-block-quote" "2.0.0"
+    "@udecode/plate-code-block" "2.0.0"
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-heading" "2.0.0"
+    "@udecode/plate-paragraph" "2.0.0"
+
+"@udecode/plate-basic-marks@2.0.0", "@udecode/plate-basic-marks@file:../packages/marks/basic-marks":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-block-quote-ui@2.0.0", "@udecode/plate-block-quote-ui@file:../packages/elements/block-quote-ui":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-block-quote" "2.0.0"
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-styled-components" "2.0.0"
+
+"@udecode/plate-block-quote@2.0.0", "@udecode/plate-block-quote@file:../packages/elements/block-quote":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-break@2.0.0", "@udecode/plate-break@file:../packages/break":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-code-block-ui@2.0.0", "@udecode/plate-code-block-ui@file:../packages/elements/code-block-ui":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-code-block" "2.0.0"
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-styled-components" "2.0.0"
+    "@udecode/plate-toolbar" "2.0.0"
+
+"@udecode/plate-code-block@2.0.0", "@udecode/plate-code-block@file:../packages/elements/code-block":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    prismjs "^1.23.0"
+
+"@udecode/plate-common@2.0.0", "@udecode/plate-common@file:../packages/common":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-core" "1.0.0"
+    is-hotkey "^0.1.6"
+
+"@udecode/plate-core@1.0.0", "@udecode/plate-core@file:../packages/core":
+  version "1.0.0"
+  dependencies:
+    lodash "^4.17.21"
+    zustand "^3.4.2"
+
+"@udecode/plate-csv-serializer@2.0.1", "@udecode/plate-csv-serializer@file:../packages/serializers/csv-serializer":
+  version "2.0.1"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-serializer" "2.0.0"
+    "@udecode/plate-table" "2.0.1"
+    papaparse "^5.3.1"
+
+"@udecode/plate-dnd@2.0.0", "@udecode/plate-dnd@file:../packages/dnd":
+  version "2.0.0"
+  dependencies:
+    "@react-hook/merged-ref" "^1.3.0"
+    "@tippyjs/react" "^4.2.0"
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-styled-components" "2.0.0"
+    react-dnd "^14.0.2"
+    react-dnd-html5-backend "^14.0.0"
+
+"@udecode/plate-excalidraw@file:../packages/elements/excalidraw":
+  version "2.0.0"
+  dependencies:
+    "@excalidraw/excalidraw-next" "0.8.0-69b6fbb"
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-styled-components" "2.0.0"
+
+"@udecode/plate-find-replace-ui@2.0.0", "@udecode/plate-find-replace-ui@file:../packages/find-replace-ui":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-find-replace" "2.0.0"
+    "@udecode/plate-styled-components" "2.0.0"
+    "@udecode/plate-toolbar" "2.0.0"
+
+"@udecode/plate-find-replace@2.0.0", "@udecode/plate-find-replace@file:../packages/find-replace":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-font-ui@2.0.0", "@udecode/plate-font-ui@file:../packages/marks/font-ui":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-font" "2.0.0"
+    "@udecode/plate-styled-components" "2.0.0"
+    "@udecode/plate-toolbar" "2.0.0"
+
+"@udecode/plate-font@2.0.0", "@udecode/plate-font@file:../packages/marks/font":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-heading@2.0.0", "@udecode/plate-heading@file:../packages/elements/heading":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-highlight@2.0.0", "@udecode/plate-highlight@file:../packages/marks/highlight":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-html-serializer@2.0.0", "@udecode/plate-html-serializer@file:../packages/serializers/html-serializer":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-serializer" "2.0.0"
+
+"@udecode/plate-image-ui@2.0.0", "@udecode/plate-image-ui@file:../packages/elements/image-ui":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-image" "2.0.0"
+    "@udecode/plate-styled-components" "2.0.0"
+    "@udecode/plate-toolbar" "2.0.0"
+
+"@udecode/plate-image@2.0.0", "@udecode/plate-image@file:../packages/elements/image":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-kbd@2.0.0", "@udecode/plate-kbd@file:../packages/marks/kbd":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-link-ui@2.0.0", "@udecode/plate-link-ui@file:../packages/elements/link-ui":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-link" "2.0.0"
+    "@udecode/plate-styled-components" "2.0.0"
+    "@udecode/plate-toolbar" "2.0.0"
+
+"@udecode/plate-link@2.0.0", "@udecode/plate-link@file:../packages/elements/link":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-normalizers" "2.0.0"
+
+"@udecode/plate-list-ui@2.0.0", "@udecode/plate-list-ui@file:../packages/elements/list-ui":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-list" "2.0.0"
+    "@udecode/plate-styled-components" "2.0.0"
+    "@udecode/plate-toolbar" "2.0.0"
+
+"@udecode/plate-list@2.0.0", "@udecode/plate-list@file:../packages/elements/list":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-reset-node" "2.0.0"
+
+"@udecode/plate-md-serializer@2.0.0", "@udecode/plate-md-serializer@file:../packages/serializers/md-serializer":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-block-quote" "2.0.0"
+    "@udecode/plate-code-block" "2.0.0"
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-heading" "2.0.0"
+    "@udecode/plate-link" "2.0.0"
+    "@udecode/plate-list" "2.0.0"
+    "@udecode/plate-paragraph" "2.0.0"
+    "@udecode/plate-serializer" "2.0.0"
+    remark-parse "^9.0.0"
+    remark-slate "^1.4.0"
+    unified "^9.2.0"
+
+"@udecode/plate-media-embed-ui@2.0.0", "@udecode/plate-media-embed-ui@file:../packages/elements/media-embed-ui":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-media-embed" "2.0.0"
+    "@udecode/plate-styled-components" "2.0.0"
+
+"@udecode/plate-media-embed@2.0.0", "@udecode/plate-media-embed@file:../packages/elements/media-embed":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-mention-ui@2.0.0", "@udecode/plate-mention-ui@file:../packages/elements/mention-ui":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-mention" "2.0.0"
+    "@udecode/plate-styled-components" "2.0.0"
+
+"@udecode/plate-mention@2.0.0", "@udecode/plate-mention@file:../packages/elements/mention":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-node-id@2.0.0", "@udecode/plate-node-id@file:../packages/node-id":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-normalizers@2.0.0", "@udecode/plate-normalizers@file:../packages/normalizers":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-paragraph@2.0.0", "@udecode/plate-paragraph@file:../packages/elements/paragraph":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-placeholder@2.0.0", "@udecode/plate-placeholder@file:../packages/placeholder":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-styled-components" "2.0.0"
+
+"@udecode/plate-reset-node@2.0.0", "@udecode/plate-reset-node@file:../packages/reset-node":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-select@2.0.0", "@udecode/plate-select@file:../packages/select":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-serializer@2.0.0", "@udecode/plate-serializer@file:../packages/serializers/serializer":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-styled-components@2.0.0", "@udecode/plate-styled-components@file:../packages/ui/styled-components":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    clsx "^1.1.1"
+
+"@udecode/plate-table-ui@2.0.1", "@udecode/plate-table-ui@file:../packages/elements/table-ui":
+  version "2.0.1"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-styled-components" "2.0.0"
+    "@udecode/plate-table" "2.0.1"
+    "@udecode/plate-toolbar" "2.0.0"
+
+"@udecode/plate-table@2.0.1", "@udecode/plate-table@file:../packages/elements/table":
+  version "2.0.1"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate-test-utils@file:../packages/test-utils":
+  version "1.0.0"
+
+"@udecode/plate-toolbar@2.0.0", "@udecode/plate-toolbar@file:../packages/ui/toolbar":
+  version "2.0.0"
+  dependencies:
+    "@tippyjs/react" "^4.2.0"
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-styled-components" "2.0.0"
+    react-use "^17.1.1"
+
+"@udecode/plate-trailing-block@2.0.0", "@udecode/plate-trailing-block@file:../packages/trailing-block":
+  version "2.0.0"
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
+"@udecode/plate@file:../packages/plate":
+  version "2.0.1"
+  dependencies:
+    "@udecode/plate-alignment" "2.0.0"
+    "@udecode/plate-alignment-ui" "2.0.0"
+    "@udecode/plate-ast-serializer" "2.0.0"
+    "@udecode/plate-autoformat" "2.0.0"
+    "@udecode/plate-basic-elements" "2.0.0"
+    "@udecode/plate-basic-marks" "2.0.0"
+    "@udecode/plate-block-quote" "2.0.0"
+    "@udecode/plate-block-quote-ui" "2.0.0"
+    "@udecode/plate-break" "2.0.0"
+    "@udecode/plate-code-block" "2.0.0"
+    "@udecode/plate-code-block-ui" "2.0.0"
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+    "@udecode/plate-csv-serializer" "2.0.1"
+    "@udecode/plate-dnd" "2.0.0"
+    "@udecode/plate-find-replace" "2.0.0"
+    "@udecode/plate-find-replace-ui" "2.0.0"
+    "@udecode/plate-font" "2.0.0"
+    "@udecode/plate-font-ui" "2.0.0"
+    "@udecode/plate-heading" "2.0.0"
+    "@udecode/plate-highlight" "2.0.0"
+    "@udecode/plate-html-serializer" "2.0.0"
+    "@udecode/plate-image" "2.0.0"
+    "@udecode/plate-image-ui" "2.0.0"
+    "@udecode/plate-kbd" "2.0.0"
+    "@udecode/plate-link" "2.0.0"
+    "@udecode/plate-link-ui" "2.0.0"
+    "@udecode/plate-list" "2.0.0"
+    "@udecode/plate-list-ui" "2.0.0"
+    "@udecode/plate-md-serializer" "2.0.0"
+    "@udecode/plate-media-embed" "2.0.0"
+    "@udecode/plate-media-embed-ui" "2.0.0"
+    "@udecode/plate-mention" "2.0.0"
+    "@udecode/plate-mention-ui" "2.0.0"
+    "@udecode/plate-node-id" "2.0.0"
+    "@udecode/plate-normalizers" "2.0.0"
+    "@udecode/plate-paragraph" "2.0.0"
+    "@udecode/plate-placeholder" "2.0.0"
+    "@udecode/plate-reset-node" "2.0.0"
+    "@udecode/plate-select" "2.0.0"
+    "@udecode/plate-serializer" "2.0.0"
+    "@udecode/plate-styled-components" "2.0.0"
+    "@udecode/plate-table" "2.0.1"
+    "@udecode/plate-table-ui" "2.0.1"
+    "@udecode/plate-toolbar" "2.0.0"
+    "@udecode/plate-trailing-block" "2.0.0"
 
 "@webassemblyjs/ast@1.11.0":
   version "1.11.0"

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "slate-history": "0.62.0",
     "slate-hyperscript": "0.62.0",
     "slate-react": "0.65.2",
+    "styled-components": "5.1.1",
     "tailwindcss": "^2.1.2",
     "ts-jest": "^26.5.2",
     "twin.macro": "^2.4.2",

--- a/packages/dnd/package.json
+++ b/packages/dnd/package.json
@@ -47,7 +47,8 @@
     "react-dom": ">=16.8.0",
     "slate": ">=0.63.0",
     "slate-history": ">=0.60.0",
-    "slate-react": ">=0.63.0"
+    "slate-react": ">=0.63.0",
+    "styled-components": ">=5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/elements/alignment-ui/package.json
+++ b/packages/elements/alignment-ui/package.json
@@ -43,7 +43,8 @@
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
     "slate-history": ">=0.60.0",
-    "slate-react": ">=0.60.0"
+    "slate-react": ">=0.60.0",
+    "styled-components": ">=5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/elements/block-quote-ui/package.json
+++ b/packages/elements/block-quote-ui/package.json
@@ -42,7 +42,8 @@
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
     "slate-history": ">=0.60.0",
-    "slate-react": ">=0.60.0"
+    "slate-react": ">=0.60.0",
+    "styled-components": ">=5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/elements/code-block-ui/package.json
+++ b/packages/elements/code-block-ui/package.json
@@ -43,7 +43,8 @@
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
     "slate-history": ">=0.60.0",
-    "slate-react": ">=0.60.0"
+    "slate-react": ">=0.60.0",
+    "styled-components": ">=5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/elements/excalidraw/package.json
+++ b/packages/elements/excalidraw/package.json
@@ -42,7 +42,8 @@
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
     "slate-history": ">=0.60.0",
-    "slate-react": ">=0.60.0"
+    "slate-react": ">=0.60.0",
+    "styled-components": ">=5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/elements/image-ui/package.json
+++ b/packages/elements/image-ui/package.json
@@ -43,7 +43,8 @@
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
     "slate-history": ">=0.60.0",
-    "slate-react": ">=0.60.0"
+    "slate-react": ">=0.60.0",
+    "styled-components": ">=5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/elements/link-ui/package.json
+++ b/packages/elements/link-ui/package.json
@@ -43,7 +43,8 @@
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
     "slate-history": ">=0.60.0",
-    "slate-react": ">=0.60.0"
+    "slate-react": ">=0.60.0",
+    "styled-components": ">=5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/elements/list-ui/package.json
+++ b/packages/elements/list-ui/package.json
@@ -43,7 +43,8 @@
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
     "slate-history": ">=0.60.0",
-    "slate-react": ">=0.60.0"
+    "slate-react": ">=0.60.0",
+    "styled-components": ">=5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/elements/media-embed-ui/package.json
+++ b/packages/elements/media-embed-ui/package.json
@@ -42,7 +42,8 @@
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
     "slate-history": ">=0.60.0",
-    "slate-react": ">=0.60.0"
+    "slate-react": ">=0.60.0",
+    "styled-components": ">=5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/elements/mention-ui/package.json
+++ b/packages/elements/mention-ui/package.json
@@ -42,7 +42,8 @@
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
     "slate-history": ">=0.60.0",
-    "slate-react": ">=0.60.0"
+    "slate-react": ">=0.60.0",
+    "styled-components": ">=5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/elements/table-ui/package.json
+++ b/packages/elements/table-ui/package.json
@@ -43,7 +43,8 @@
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
     "slate-history": ">=0.60.0",
-    "slate-react": ">=0.60.0"
+    "slate-react": ">=0.60.0",
+    "styled-components": ">=5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/find-replace-ui/package.json
+++ b/packages/find-replace-ui/package.json
@@ -43,7 +43,8 @@
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
     "slate-history": ">=0.60.0",
-    "slate-react": ">=0.60.0"
+    "slate-react": ">=0.60.0",
+    "styled-components": ">=5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/marks/font-ui/package.json
+++ b/packages/marks/font-ui/package.json
@@ -43,7 +43,8 @@
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
     "slate-history": ">=0.60.0",
-    "slate-react": ">=0.60.0"
+    "slate-react": ">=0.60.0",
+    "styled-components": ">=5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/placeholder/package.json
+++ b/packages/placeholder/package.json
@@ -41,7 +41,8 @@
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
     "slate-history": ">=0.60.0",
-    "slate-react": ">=0.60.0"
+    "slate-react": ">=0.60.0",
+    "styled-components": ">=5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plate/package.json
+++ b/packages/plate/package.json
@@ -90,7 +90,8 @@
     "slate": ">=0.63.0",
     "slate-history": ">=0.60.0",
     "slate-hyperscript": ">=0.60.0",
-    "slate-react": ">=0.63.0"
+    "slate-react": ">=0.63.0",
+    "styled-components": ">=5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui/styled-components/package.json
+++ b/packages/ui/styled-components/package.json
@@ -34,8 +34,7 @@
   "dependencies": {
     "@udecode/plate-common": "2.0.0",
     "@udecode/plate-core": "1.0.0",
-    "clsx": "^1.1.1",
-    "styled-components": "5.1.1"
+    "clsx": "^1.1.1"
   },
   "devDependencies": {
     "twin.macro": "^2.6.1"
@@ -46,7 +45,8 @@
     "react-is": ">=16.8.0",
     "slate": ">=0.60.0",
     "slate-history": ">=0.60.0",
-    "slate-react": ">=0.60.0"
+    "slate-react": ">=0.60.0",
+    "styled-components": ">=5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui/toolbar/package.json
+++ b/packages/ui/toolbar/package.json
@@ -43,7 +43,8 @@
     "react-dom": ">=16.8.0",
     "slate": ">=0.60.0",
     "slate-history": ">=0.60.0",
-    "slate-react": ">=0.60.0"
+    "slate-react": ">=0.60.0",
+    "styled-components": ">=5.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
**Description**

WHAT: moved styled-components from dependencies to peer dependencies.  
WHY: there was multiple instances of styled-components across all the packages.  
HOW: make sure to have `styled-components` in your dependencies.

**Issue**

Fixes: #913



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
