### PR TITLE
fix(table): create ELEMENT_TD when header is disabled

### DIFF
--- a/packages/elements/table/src/utils/getEmptyCellNode.ts
+++ b/packages/elements/table/src/utils/getEmptyCellNode.ts
@@ -9,8 +9,8 @@ export const getEmptyCellNode = (
 ) => {
   return {
     type: header
-      ? getPlatePluginType(editor, ELEMENT_TD)
-      : getPlatePluginType(editor, ELEMENT_TH),
+      ? getPlatePluginType(editor, ELEMENT_TH)
+      : getPlatePluginType(editor, ELEMENT_TD),
     children: [
       {
         type: getPlatePluginType(editor, ELEMENT_DEFAULT),


### PR DESCRIPTION
**Description**

I believe the logic in `getEmptyCellNode` returns `ELEMENT_TH` when it should really return `ELEMENT_TD`. The if statement logic should basically be the other way around :) 

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
