### PR TITLE
Prevent markdown deserializer from working on attachments

### DIFF
--- a/.changeset/great-years-lick.md
+++ b/.changeset/great-years-lick.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-md-serializer': patch
+---
+
+markdown deserializer was favoring URL over files when pasting content

--- a/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
+++ b/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
@@ -29,10 +29,9 @@ export const withDeserializeMD = <
   editor.insertData = (data) => {
     const content = data.getData('text/plain');
     const { files } = data;
-    if (content) {
-      // if content is simply a URL and does not contain a file,
-      // pass through to not break LinkPlugin
-      if (isUrl(content) && !files?.length) {
+    if (content && !files?.length) {
+      // if content is simply a URL pass through to not break LinkPlugin
+      if (isUrl(content)) {
         return insertData(data);
       }
 

--- a/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
+++ b/packages/serializers/md-serializer/src/deserializer/createDeserializeMDPlugin.ts
@@ -28,10 +28,11 @@ export const withDeserializeMD = <
 
   editor.insertData = (data) => {
     const content = data.getData('text/plain');
-
+    const { files } = data;
     if (content) {
-      // if content is simply a URL, pass through to not break LinkPlugin
-      if (isUrl(content)) {
+      // if content is simply a URL and does not contain a file,
+      // pass through to not break LinkPlugin
+      if (isUrl(content) && !files?.length) {
         return insertData(data);
       }
 


### PR DESCRIPTION
**Description**

When pasting a file, on Firefox content was showing the URL triggering markdown parsing. Instead if there's a file in the paste buffer, markdown parsing should not get triggered.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

**Issue**

Markdown parser was winning over image or file attachment when processing pasted content.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
