### PR TITLE
Fix docs typo

### DIFF
--- a/docs/docs/plugins/list.mdx
+++ b/docs/docs/plugins/list.mdx
@@ -61,5 +61,5 @@ npm install @udecode/plate-list-ui
 ### Source Code
 
 - [Variables](https://github.com/udecode/plate/blob/main/docs/src/live/live.tsx)
-- [packages/elements/link](https://github.com/udecode/plate/tree/main/packages/elements/link/src)
-- [packages/elements/link-ui](https://github.com/udecode/plate/tree/main/packages/elements/link-ui/src)
+- [packages/elements/list](https://github.com/udecode/plate/tree/main/packages/elements/list/src)
+- [packages/elements/list-ui](https://github.com/udecode/plate/tree/main/packages/elements/list-ui/src)


### PR DESCRIPTION
**Description**

Fix wrong url from link to list.

Fix url in this page.
https://plate.udecode.io/docs/plugins/list#source-code

**Issue**

Fixes: none. document only.

**Example**

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)
