### PR TITLE
Allow PortalBody to be mounted on a custom container

### DIFF
--- a/.changeset/shy-bugs-shave-2.md
+++ b/.changeset/shy-bugs-shave-2.md
@@ -1,0 +1,6 @@
+---
+"@udecode/plate-toolbar": minor
+---
+
+`BalloonToolbar` – New prop: `portalElement` used to customize the `Portal` container
+

--- a/.changeset/shy-bugs-shave-3.md
+++ b/.changeset/shy-bugs-shave-3.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-styled-components": minor
+---
+
+`PortalBody` – New prop `element`: Allow to be mounted on a custom container. Using `document.body` can conflict with other portals with the same container.

--- a/.changeset/shy-bugs-shave.md
+++ b/.changeset/shy-bugs-shave.md
@@ -2,4 +2,4 @@
 "@udecode/plate-mention-ui": minor
 ---
 
-`MentionSelect` – New prop: `portalElement` used to customize the `Portal` container
+`MentionSelect` – New prop: `portalElement` used to customize the `PortalBody` container

--- a/.changeset/shy-bugs-shave.md
+++ b/.changeset/shy-bugs-shave.md
@@ -2,4 +2,4 @@
 "@udecode/plate-mention-ui": minor
 ---
 
-`MentionSelect` – New prop: `portalElement` used to customize the `PortalBody` container
+`MentionSelect` – New prop: `portalElement` used to customize the `Portal` container

--- a/.changeset/shy-bugs-shave.md
+++ b/.changeset/shy-bugs-shave.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-mention-ui": minor
+---
+
+`MentionSelect` – New prop: `portalElement` used to customize the `Portal` container

--- a/packages/elements/mention-ui/src/MentionSelect/MentionSelect.tsx
+++ b/packages/elements/mention-ui/src/MentionSelect/MentionSelect.tsx
@@ -14,6 +14,7 @@ export const MentionSelect = (props: MentionSelectProps) => {
     options,
     valueIndex,
     onClickMention,
+    portalElement,
     renderLabel = (mentionable: MentionNodeData) => mentionable.value,
   } = props;
 
@@ -39,7 +40,7 @@ export const MentionSelect = (props: MentionSelectProps) => {
   const styles = getMentionSelectStyles(props);
 
   return (
-    <PortalBody>
+    <PortalBody element={portalElement}>
       <div
         ref={ref}
         css={styles.root.css}

--- a/packages/elements/mention-ui/src/MentionSelect/MentionSelect.types.ts
+++ b/packages/elements/mention-ui/src/MentionSelect/MentionSelect.types.ts
@@ -11,4 +11,5 @@ export interface MentionSelectProps
   extends GetMentionSelectProps,
     StyledProps<MentionSelectStyles> {
   renderLabel?: (mentionable: MentionNodeData) => string;
+  portalElement?: Element;
 }

--- a/packages/ui/styled-components/src/PortalBody/PortalBody.tsx
+++ b/packages/ui/styled-components/src/PortalBody/PortalBody.tsx
@@ -1,6 +1,9 @@
 import { ReactPortal } from 'react';
 import * as ReactDOM from 'react-dom';
+import { PortalBodyProps } from './PortalBody.types';
 
-export const PortalBody: ({ children }: any) => ReactPortal = ({
+export const PortalBody: ({
   children,
-}: any) => ReactDOM.createPortal(children, document.body);
+  element,
+}: PortalBodyProps) => ReactPortal = ({ children, element }: PortalBodyProps) =>
+  ReactDOM.createPortal(children, element || document.body);

--- a/packages/ui/styled-components/src/PortalBody/PortalBody.types.ts
+++ b/packages/ui/styled-components/src/PortalBody/PortalBody.types.ts
@@ -1,0 +1,3 @@
+import { ReactNode } from 'react';
+
+export type PortalBodyProps = { children: ReactNode; element?: Element };

--- a/packages/ui/toolbar/src/BalloonToolbar/BalloonToolbar.tsx
+++ b/packages/ui/toolbar/src/BalloonToolbar/BalloonToolbar.tsx
@@ -14,6 +14,7 @@ export const BalloonToolbar = (props: BalloonToolbarProps) => {
     direction = 'top',
     theme = 'dark',
     arrow = false,
+    portalElement,
   } = props;
 
   const ref = React.useRef<HTMLDivElement>(null);
@@ -32,7 +33,7 @@ export const BalloonToolbar = (props: BalloonToolbarProps) => {
   });
 
   return (
-    <PortalBody>
+    <PortalBody element={portalElement}>
       <ToolbarBase
         ref={ref}
         css={styles.root.css}

--- a/packages/ui/toolbar/src/BalloonToolbar/BalloonToolbar.types.ts
+++ b/packages/ui/toolbar/src/BalloonToolbar/BalloonToolbar.types.ts
@@ -29,4 +29,6 @@ export interface BalloonToolbarProps extends StyledProps<ToolbarProps> {
    * Show an arrow pointing to up or down depending on the direction.
    */
   arrow?: boolean;
+
+  portalElement?: Element;
 }


### PR DESCRIPTION
**Description**

Allow PortalBody to be mounted on a custom container. Using `document.body` can conflict with other portals with the same container

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
