### PR TITLE
fix: mention & placeholder

### DIFF
--- a/.changeset/nice-ties-hope.md
+++ b/.changeset/nice-ties-hope.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-placeholder": patch
+---
+
+fix: the placeholder should not be present when the block has only void elements 

--- a/packages/elements/mention/src/transforms/insertMention.ts
+++ b/packages/elements/mention/src/transforms/insertMention.ts
@@ -21,7 +21,7 @@ export const insertMention = (
 ) => {
   const mentionNode: MentionNode = {
     type: getPlatePluginType(editor, pluginKey),
-    children: [{ text: '' }],
+    children: [{ text: ' ' }],
     ...data,
   };
 

--- a/packages/elements/mention/src/transforms/insertMention.ts
+++ b/packages/elements/mention/src/transforms/insertMention.ts
@@ -21,7 +21,7 @@ export const insertMention = (
 ) => {
   const mentionNode: MentionNode = {
     type: getPlatePluginType(editor, pluginKey),
-    children: [{ text: ' ' }],
+    children: [{ text: '' }],
     ...data,
   };
 

--- a/packages/placeholder/src/components/Placeholder.tsx
+++ b/packages/placeholder/src/components/Placeholder.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { createNodeHOC, createNodesHOC } from '@udecode/plate-common';
-import { Node } from 'slate';
+import { useEditorRef } from '@udecode/plate-core';
+import { Editor } from 'slate';
 import { useFocused, useSelected } from 'slate-react';
 import { getPlaceholderStyles } from './Placeholder.styles';
 import { PlaceholderProps } from './Placeholder.types';
@@ -16,14 +17,15 @@ export const Placeholder = (props: PlaceholderProps) => {
 
   const focused = useFocused();
   const selected = useSelected();
+  const editor = useEditorRef();
 
   const enabled = useMemo(() => {
-    const string = Node.string(element);
-
+    const isEmptyBlock = Editor.isEmpty(editor, element);
     return (
-      (!hideOnBlur && !string) || (hideOnBlur && focused && selected && !string)
+      (!hideOnBlur && isEmptyBlock) ||
+      (hideOnBlur && focused && selected && isEmptyBlock)
     );
-  }, [element, hideOnBlur, focused, selected]);
+  }, [editor, element, hideOnBlur, focused, selected]);
 
   return React.Children.map(children, (child) => {
     return React.cloneElement(child, {


### PR DESCRIPTION
**Description**

Before 

https://user-images.githubusercontent.com/24937683/132167778-710d301c-0203-4bfc-9f4b-b10c2209150b.mov

After 

https://user-images.githubusercontent.com/24937683/132167817-798e9c0e-2bf3-4a94-80e8-40c954a5b410.mov

The placeholder overlaps with the mention element if the node is empty. So added empty space to the mention node when creating it. Please let me know if you have any better fix than this.


<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

**Issue**

Fixes: 

**Example**



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
