### PR TITLE
Fix nested list paste

### DIFF
--- a/.changeset/breezy-rats-end.md
+++ b/.changeset/breezy-rats-end.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-list': patch
+---
+
+Fix nested list paste

--- a/packages/common/src/queries/findNode.ts
+++ b/packages/common/src/queries/findNode.ts
@@ -1,13 +1,9 @@
 import { TEditor, TNode } from '@udecode/plate-core';
-import { Editor, Location, Node, NodeEntry, Path, Range, Span } from 'slate';
-import { MatchOptions } from '../types/Editor.types';
+import { Editor, Node, NodeEntry } from 'slate';
+import { EditorNodesOptions } from '../types';
 import { match } from './match';
 
-export type FindNodeOptions<T extends TNode = TNode> = {
-  at?: Location | Span;
-  reverse?: boolean;
-  voids?: boolean;
-} & MatchOptions<T>;
+export type FindNodeOptions<T extends TNode = TNode> = EditorNodesOptions<T>;
 
 /**
  * Find node matching the condition.
@@ -18,40 +14,14 @@ export const findNode = <T extends TNode = TNode>(
 ): NodeEntry<T> | undefined => {
   // Slate throws when things aren't found so we wrap in a try catch and return undefined on throw.
   try {
-    const {
-      match: _match = () => true,
-      at = editor.selection || [],
-      reverse = false,
-      voids = false,
-    } = options;
-
-    let from;
-    let to;
-    if (Span.isSpan(at)) {
-      [from, to] = at;
-    } else if (Range.isRange(at)) {
-      const first = Editor.path(editor, at, { edge: 'start' });
-      const last = Editor.path(editor, at, { edge: 'end' });
-      from = reverse ? last : first;
-      to = reverse ? first : last;
-    }
-
-    let root: NodeEntry = [editor, []];
-    if (Path.isPath(at)) {
-      root = Editor.node(editor, at);
-    }
-
-    const nodeEntries = Node.nodes(root[0], {
-      reverse,
-      from,
-      to,
-      pass: ([n]) => (voids ? false : Editor.isVoid(editor, n)),
+    const nodeEntries = Editor.nodes<T>(editor, {
+      ...options,
+      at: editor.selection || [],
+      match: (node) => match<Node>(node, options.match),
     });
 
     for (const [node, path] of nodeEntries) {
-      if (match<Node>(node, _match)) {
-        return [node as any, path];
-      }
+      return [node, path];
     }
   } catch (error) {
     return undefined;

--- a/packages/elements/list/src/getListInsertFragment.spec.tsx
+++ b/packages/elements/list/src/getListInsertFragment.spec.tsx
@@ -20,18 +20,20 @@ const editorTest = (input: any, fragment: any, expected: any) => {
 
 describe('when pasting ul > 2 li fragment', () => {
   describe('when selection in li', () => {
-    it('should filter out ul', () => {
+    it('should insert lis next to the lowest li', () => {
       const input = ((
         <editor>
           <hul>
             <hli>
               <hlic>one</hlic>
-            </hli>
-            <hli>
-              <hlic>
-                two
-                <cursor />
-              </hlic>
+              <hul>
+                <hli>
+                  <hlic>
+                    two
+                    <cursor />
+                  </hlic>
+                </hli>
+              </hul>
             </hli>
             <hli>
               <hlic>four</hlic>
@@ -55,12 +57,80 @@ describe('when pasting ul > 2 li fragment', () => {
           <hul>
             <hli>
               <hlic>one</hlic>
+              <hul>
+                <hli>
+                  <hlic>two</hlic>
+                </hli>
+                <hli>
+                  <hlic>three</hlic>
+                </hli>
+              </hul>
             </hli>
             <hli>
-              <hlic>two</hlic>
+              <hlic>four</hlic>
             </hli>
+          </hul>
+        </editor>
+      ) as any) as SPEditor;
+
+      editorTest(input, fragment, expected);
+    });
+
+    it('should insert nested lis next to the lowest li, without the leading empty lis', () => {
+      const input = ((
+        <editor>
+          <hul>
+            <hli>
+              <hlic>one</hlic>
+              <hul>
+                <hli>
+                  <hlic>
+                    two
+                    <cursor />
+                  </hlic>
+                </hli>
+              </hul>
+            </hli>
+            <hli>
+              <hlic>four</hlic>
+            </hli>
+          </hul>
+        </editor>
+      ) as any) as SPEditor;
+
+      const fragment = ((
+        <fragment>
+          <hul>
             <hli>
               <hlic>three</hlic>
+              <hul>
+                <hli>
+                  <hlic>five</hlic>
+                </hli>
+              </hul>
+            </hli>
+          </hul>
+        </fragment>
+      ) as any) as TDescendant[];
+
+      const expected = ((
+        <editor>
+          <hul>
+            <hli>
+              <hlic>one</hlic>
+              <hul>
+                <hli>
+                  <hlic>two</hlic>
+                </hli>
+                <hli>
+                  <hlic>three</hlic>
+                  <hul>
+                    <hli>
+                      <hlic>five</hlic>
+                    </hli>
+                  </hul>
+                </hli>
+              </hul>
             </hli>
             <hli>
               <hlic>four</hlic>

--- a/packages/elements/list/src/getListInsertFragment.ts
+++ b/packages/elements/list/src/getListInsertFragment.ts
@@ -1,50 +1,82 @@
 import { findNode } from '@udecode/plate-common';
 import {
   getPlatePluginOptions,
+  PlatePluginOptions,
   SPEditor,
   TDescendant,
 } from '@udecode/plate-core';
-import { Path, Transforms } from 'slate';
+import { Node, NodeEntry, Path, Transforms } from 'slate';
 import { ELEMENT_LI, ELEMENT_OL, ELEMENT_UL } from './defaults';
 
 export const getListInsertFragment = (editor: SPEditor) => {
   const { insertFragment } = editor;
 
+  const li = getPlatePluginOptions(editor, ELEMENT_LI);
+  const ul = getPlatePluginOptions(editor, ELEMENT_UL);
+  const ol = getPlatePluginOptions(editor, ELEMENT_OL);
+
+  const isListRoot = (node: TDescendant): boolean =>
+    [ul.type, ol.type].includes(node.type);
+
+  const getFirstAncestorOfType = (
+    root: TDescendant,
+    entry: NodeEntry,
+    { type }: PlatePluginOptions
+  ): NodeEntry<TDescendant> => {
+    let ancestor: Path = Path.parent(entry[1]);
+    while ((Node.get(root, ancestor) as TDescendant).type !== type) {
+      ancestor = Path.parent(ancestor);
+    }
+
+    return [Node.get(root, ancestor), ancestor];
+  };
+
+  /**
+   * Removes the "empty" leading lis. Empty in this context means lis only with other lis as children.
+   *
+   * @returns If argument is not a list root, returns it, otherwise returns ul[] or li[].
+   */
+  const trimList = <T extends TDescendant>(listRoot: T): T[] => {
+    if (!isListRoot(listRoot)) {
+      return [listRoot];
+    }
+
+    const textEntries = Array.from(Node.texts(listRoot));
+
+    const commonAncestorEntry = textEntries.reduce<NodeEntry<TDescendant>>(
+      (commonAncestor, textEntry) =>
+        Path.isAncestor(commonAncestor[1], textEntry[1])
+          ? commonAncestor
+          : Node.common(listRoot, textEntry[1], commonAncestor[1]),
+      // any list item would do, we grab the first one
+      getFirstAncestorOfType(listRoot, textEntries[0], li)
+    );
+
+    return isListRoot(commonAncestorEntry[0])
+      ? commonAncestorEntry[0].children
+      : [commonAncestorEntry[0]];
+  };
+
   return (fragment: TDescendant[]) => {
-    const li = getPlatePluginOptions(editor, ELEMENT_LI);
-    const ul = getPlatePluginOptions(editor, ELEMENT_UL);
-    const ol = getPlatePluginOptions(editor, ELEMENT_OL);
-
-    const liEntry = findNode(editor, { match: { type: li.type } });
-
-    let filtered: TDescendant[] = [];
+    const liEntry = findNode(editor, {
+      match: { type: li.type },
+      mode: 'lowest',
+    });
 
     if (liEntry) {
       const [, liPath] = liEntry;
 
-      fragment.forEach((node) => {
-        if ([ul.type, ol.type].includes(node.type)) {
-          filtered.push(...node.children);
-          return;
-        }
-
-        filtered.push(node);
-      });
-
       // FIXME: fork insertFragment for edge cases
-      Transforms.insertNodes(editor, filtered, {
-        at: Path.next(liPath),
-        select: true,
-      });
-      return;
+      return Transforms.insertNodes(
+        editor,
+        fragment.flatMap((node) => trimList(node)),
+        { at: Path.next(liPath), select: true }
+      );
     }
-    filtered = fragment;
 
-    const firstNode = fragment[0];
-
-    if ([ul.type, ol.type].includes(firstNode.type)) {
-      filtered = [{ text: '' }, ...filtered];
-    }
+    const filtered: TDescendant[] = isListRoot(fragment[0])
+      ? [{ text: '' }, ...fragment]
+      : fragment;
 
     return insertFragment(filtered);
   };


### PR DESCRIPTION
Insert all nested list items next to the lowest li in selection.

**Description**

The current logic inserts lis next to top level li, and fails to insert nested lis altogether. See example for more details.

**Example**

![Peek 2021-09-07 21-41](https://user-images.githubusercontent.com/10130001/132401677-340cb3f0-5295-4f42-9f27-d66aba3d897e.gif)

## Notes

* refactored `findNode` to use Editor.nodes, as it appears to have been doing the same thing, but was missing certain functionality from Editor.nodes such as `mode`
* open to suggestions on `getFirstAncestorOfType`

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)