### PR TITLE
fix(table): only mark first row as table header

### DIFF
--- a/.changeset/tasty-dolls-judge.md
+++ b/.changeset/tasty-dolls-judge.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-table': patch
+---
+
+fix(table): only mark first row as table header

--- a/packages/elements/table/src/utils/getEmptyTableNode.ts
+++ b/packages/elements/table/src/utils/getEmptyTableNode.ts
@@ -11,7 +11,7 @@ export const getEmptyTableNode = (
     type: getPlatePluginType(editor, ELEMENT_TABLE),
     children: [
       getEmptyRowNode(editor, { header, colCount: 2 }),
-      getEmptyRowNode(editor, { header, colCount: 2 }),
+      getEmptyRowNode(editor, { header: false, colCount: 2 }),
     ],
   };
 };


### PR DESCRIPTION
**Description**

`insertTable` with `header=true` marks all cells as header elements. I think it only makes sense to mark the first row as header (if enabled).

What do you think?

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)
