### PR TITLE
More markdown nodetypes

### DIFF
--- a/.changeset/polite-owls-taste.md
+++ b/.changeset/polite-owls-taste.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-md-serializer': patch
+---
+
+add additional nodeTypes to markdown deserializer

--- a/packages/serializers/md-serializer/src/deserializer/utils/deserializeMD.ts
+++ b/packages/serializers/md-serializer/src/deserializer/utils/deserializeMD.ts
@@ -1,3 +1,12 @@
+import {
+  MARK_BOLD,
+  MARK_CODE,
+  MARK_ITALIC,
+  MARK_STRIKETHROUGH,
+  // MARK_SUBSCRIPT,
+  // MARK_SUPERSCRIPT,
+  // MARK_UNDERLINE,
+} from '@udecode/plate-basic-marks';
 import { ELEMENT_BLOCKQUOTE } from '@udecode/plate-block-quote';
 import { ELEMENT_CODE_BLOCK } from '@udecode/plate-code-block';
 import { getPlatePluginType, SPEditor } from '@udecode/plate-core';
@@ -28,6 +37,14 @@ export const deserializeMD = (editor: SPEditor, content: string) => {
         paragraph: getPlatePluginType(editor, ELEMENT_PARAGRAPH),
         block_quote: getPlatePluginType(editor, ELEMENT_BLOCKQUOTE),
         link: getPlatePluginType(editor, ELEMENT_LINK),
+        inline_code_mark: getPlatePluginType(editor, MARK_CODE),
+        emphasis_mark: getPlatePluginType(editor, MARK_ITALIC),
+        strong_mark: getPlatePluginType(editor, MARK_BOLD),
+        delete_mark: getPlatePluginType(editor, MARK_STRIKETHROUGH),
+        // FIXME: underline, subscript superscript not yet supported by remark-slate
+        // underline: getPlatePluginType(editor, MARK_UNDERLINE),
+        // subscript: getPlatePluginType(editor, MARK_SUBSCRIPT),
+        // superscript: getPlatePluginType(editor, MARK_SUPERSCRIPT),
         code_block: getPlatePluginType(editor, ELEMENT_CODE_BLOCK),
         ul_list: getPlatePluginType(editor, ELEMENT_UL),
         ol_list: getPlatePluginType(editor, ELEMENT_OL),


### PR DESCRIPTION
**Description**

Add additional nodeTypes to markdown deserializer for marks. Note, I'd like to also add underline, subscript, and superscript, but those are not currently supported by remark-slate so we'll need to raise a PR there first and then revisit here.

**Issue**

Fixes: Clearer deserialization of marks from markdown.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
