### PR TITLE
fix(table): jump to next header cell on TAB

### DIFF
--- a/.changeset/selfish-rockets-compare.md
+++ b/.changeset/selfish-rockets-compare.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-table': patch
+---
+
+fix(table): jump to next header cell on TAB

--- a/packages/elements/table/src/queries/getTableCellEntry.ts
+++ b/packages/elements/table/src/queries/getTableCellEntry.ts
@@ -42,9 +42,8 @@ export const getTableCellEntry = (
     const [tableCellNode, tableCellPath] = tableCell;
 
     if (
-      tableCellNode.type !==
-      (getPlatePluginType(editor, ELEMENT_TD) ||
-        getPlatePluginType(editor, ELEMENT_TH))
+      tableCellNode.type !== getPlatePluginType(editor, ELEMENT_TD) &&
+      tableCellNode.type !== getPlatePluginType(editor, ELEMENT_TH)
     )
       return;
 


### PR DESCRIPTION
**Description**

A tiny if-condition fix to check for both `ELEMENT_TD` AND `ELEMENT_TH` in the `getTableCellEntry` helper. That enables pressing TAB to jump to the next Header cell and SHIFT+TAB to jump to the previous one

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)
