### PR TITLE
Allow deserializeHTMLToDocumentFragment, serializeHTMLFromNodes to retain whitespace

### DIFF
--- a/.changeset/rare-dingos-mix.md
+++ b/.changeset/rare-dingos-mix.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-html-serializer': patch
+---
+
+Adds the ability to not strip whitespace when converting to and from plate/html syntax

--- a/packages/autoformat/src/transforms/autoformatMark.ts
+++ b/packages/autoformat/src/transforms/autoformatMark.ts
@@ -1,8 +1,8 @@
-import { getPointBefore, getText, removeMark } from '@udecode/plate-common';
+import { getText, removeMark } from '@udecode/plate-common';
 import { TEditor } from '@udecode/plate-core';
 import castArray from 'lodash/castArray';
 import { Point, Range, Transforms } from 'slate';
-import { AutoformatMarkRule, MatchRange } from '../types';
+import { AutoformatMarkRule } from '../types';
 import { getMatchPoints } from '../utils/getMatchPoints';
 import { getMatchRange } from '../utils/getMatchRange';
 

--- a/packages/serializers/html-serializer/src/deserializer/__tests__/deserializeHTMLToDocumentFragment/codeblock.spec.tsx
+++ b/packages/serializers/html-serializer/src/deserializer/__tests__/deserializeHTMLToDocumentFragment/codeblock.spec.tsx
@@ -1,0 +1,25 @@
+/** @jsx jsx */
+
+import { PlatePlugin } from '@udecode/plate-core';
+import { getHtmlDocument, jsx } from '@udecode/plate-test-utils';
+import { createEditorPlugins } from '../../../../../../plate/src/utils/createEditorPlugins';
+import { deserializeHTMLToDocumentFragment } from '../../utils/deserializeHTMLToDocumentFragment';
+
+const html = `<blockquote>test \n code</blockquote>`;
+const input1: PlatePlugin[] = [];
+const input2 = getHtmlDocument(html).body.innerHTML;
+
+const expectedOutput = [{ text: 'test \n code' }];
+
+it('should have the break line', () => {
+  const convertedDocumentFragment = deserializeHTMLToDocumentFragment(
+    createEditorPlugins(),
+    {
+      plugins: input1,
+      element: input2,
+      stripWhitespace: false,
+    }
+  );
+
+  expect(convertedDocumentFragment).toEqual(expectedOutput);
+});

--- a/packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLToDocumentFragment.ts
+++ b/packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLToDocumentFragment.ts
@@ -17,7 +17,7 @@ export const deserializeHTMLToDocumentFragment = <
   }: {
     plugins: PlatePlugin<T>[];
     element: HTMLElement | string;
-    stripWhitespace: boolean;
+    stripWhitespace?: boolean;
   }
 ): TDescendant[] => {
   if (typeof element === 'string') {

--- a/packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLToDocumentFragment.ts
+++ b/packages/serializers/html-serializer/src/deserializer/utils/deserializeHTMLToDocumentFragment.ts
@@ -13,13 +13,15 @@ export const deserializeHTMLToDocumentFragment = <
   {
     plugins,
     element,
+    stripWhitespace = true,
   }: {
     plugins: PlatePlugin<T>[];
     element: HTMLElement | string;
+    stripWhitespace: boolean;
   }
 ): TDescendant[] => {
   if (typeof element === 'string') {
-    element = htmlStringToDOMNode(element);
+    element = htmlStringToDOMNode(element, stripWhitespace);
   }
 
   const fragment = deserializeHTMLElement(editor, {

--- a/packages/serializers/html-serializer/src/serializer/__tests__/elements.spec.ts
+++ b/packages/serializers/html-serializer/src/serializer/__tests__/elements.spec.ts
@@ -65,12 +65,30 @@ it('serialize blockquote to html', () => {
         nodes: [
           {
             type: 'blockquote',
-            children: [{ text: 'Blockquoted text here...' }],
+            children: [{ text: 'Blockquoted text\n here...' }],
           },
         ],
       })
     ).getElementsByTagName('blockquote')[0].textContent
   ).toEqual('Blockquoted text here...');
+});
+
+it('serialize blockquote to html, without trimming whitespace', () => {
+  const html = serializeHTMLFromNodes(editor, {
+    plugins: [createBlockquotePlugin()],
+    nodes: [
+      {
+        type: 'blockquote',
+        children: [{ text: 'Blockquoted text\nhere...' }],
+      },
+    ],
+    stripWhitespace: false,
+  });
+
+  const node = htmlStringToDOMNode(html, false);
+  expect(node.getElementsByTagName('blockquote')[0].textContent).toEqual(
+    'Blockquoted text\nhere...'
+  );
 });
 
 it('serialize headings to html', () => {

--- a/packages/serializers/html-serializer/src/serializer/serializeHTMLFromNodes.ts
+++ b/packages/serializers/html-serializer/src/serializer/serializeHTMLFromNodes.ts
@@ -194,8 +194,8 @@ export const serializeHTMLFromNodes = (
     slateProps?: Partial<SlateProps>;
 
     /**
-     * Enable/Disable stripping of whitespace from serialised HTML
-     * Note: Disabling is useful to retain whitespace (e.g codeblocks)
+     * Whether stripping whitespaces from serialized HTML
+     * @default true
      */
     stripWhitespace?: boolean;
   }

--- a/packages/serializers/html-serializer/src/serializer/serializeHTMLFromNodes.ts
+++ b/packages/serializers/html-serializer/src/serializer/serializeHTMLFromNodes.ts
@@ -166,12 +166,13 @@ export const serializeHTMLFromNodes = (
     slateProps,
     stripDataAttributes = true,
     preserveClassNames,
+    stripWhitespace = true,
   }: {
     /**
      * Plugins with renderElement or renderLeaf.
      */
-
     plugins: PlatePlugin[];
+
     /**
      * Slate nodes to convert to HTML.
      */
@@ -191,6 +192,12 @@ export const serializeHTMLFromNodes = (
      * Slate props to provide if the rendering depends on slate hooks
      */
     slateProps?: Partial<SlateProps>;
+
+    /**
+     * Enable/Disable stripping of whitespace from serialised HTML
+     * Note: Disabling is useful to retain whitespace (e.g codeblocks)
+     */
+    stripWhitespace?: boolean;
   }
 ): string => {
   let result = nodes
@@ -220,6 +227,7 @@ export const serializeHTMLFromNodes = (
               plugins,
               nodes: node.children,
               preserveClassNames,
+              stripWhitespace,
             })
           ) as any,
           attributes: { 'data-slate-node': 'element', ref: null },
@@ -230,7 +238,11 @@ export const serializeHTMLFromNodes = (
     })
     .join('');
 
-  result = trimWhitespace(decodeURIComponent(result));
+  result = decodeURIComponent(result);
+
+  if (stripWhitespace) {
+    result = trimWhitespace(result);
+  }
 
   if (stripDataAttributes) {
     result = stripSlateDataAttributes(result);

--- a/packages/serializers/html-serializer/src/serializer/utils/htmlStringToDOMNode.ts
+++ b/packages/serializers/html-serializer/src/serializer/utils/htmlStringToDOMNode.ts
@@ -1,8 +1,16 @@
 /**
  * Convert HTML string into HTML element.
  */
-export const htmlStringToDOMNode = (rawHtml: string) => {
+export const htmlStringToDOMNode = (
+  rawHtml: string,
+  stripWhitespace = true
+) => {
   const node = document.createElement('body');
-  node.innerHTML = rawHtml.replace(/(\r\n|\n|\r|\t)/gm, '');
+  node.innerHTML = rawHtml;
+
+  if (stripWhitespace) {
+    node.innerHTML = node.innerHTML.replace(/(\r\n|\n|\r|\t)/gm, '');
+  }
+
   return node;
 };


### PR DESCRIPTION
## Description
As described in #954, this PR adds the ability to turn off whitespace stripping from the html de/serialize. Which in turn allows codeblocks/blockquotes to have new lines.

**Broken Example**
```
const hello = 'world';
console.log(hello);
```
ran through serializeHTMLFromNodes

becomes:

<pre class="slate-CodeBlockElement"><code>const hello = 'world';console.log(hello);</code></pre>

This PR corrects that by retaining the whitespace.

## Attention
- Not really a TS developer
- Not sure how much these changes will break existing functionality.


## Checklist
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)