### PR TITLE
Fix list delete forward

### DIFF
--- a/.changeset/perfect-bobcats-tickle.md
+++ b/.changeset/perfect-bobcats-tickle.md
@@ -1,6 +1,7 @@
 ---
 '@udecode/plate-common': patch
 '@udecode/plate-list': patch
+'@udecode/plate-list': patch
 ---
 
 Fix list delete forward

--- a/.changeset/perfect-bobcats-tickle.md
+++ b/.changeset/perfect-bobcats-tickle.md
@@ -1,0 +1,6 @@
+---
+'@udecode/plate-common': patch
+'@udecode/plate-list': patch
+---
+
+Fix list delete forward

--- a/packages/common/src/queries/isSelectionAtBlockEnd.ts
+++ b/packages/common/src/queries/isSelectionAtBlockEnd.ts
@@ -5,8 +5,8 @@ import { isEnd } from './isEnd';
 /**
  * Is the selection focus at the end of its parent block.
  */
-export const isSelectionAtBlockEnd = (editor: TEditor) => {
+export const isSelectionAtBlockEnd = (editor: TEditor): boolean => {
   const path = getBlockAbove(editor)?.[1];
 
-  return path && isEnd(editor, editor.selection?.focus, path);
+  return !!path && isEnd(editor, editor.selection?.focus, path);
 };

--- a/packages/elements/list/src/getListDeleteForward.ts
+++ b/packages/elements/list/src/getListDeleteForward.ts
@@ -1,0 +1,97 @@
+import {
+  getChildren,
+  getNode,
+  isSelectionAtBlockEnd,
+} from '@udecode/plate-common';
+import {
+  getPlatePluginOptions,
+  SPEditor,
+  TDescendant,
+} from '@udecode/plate-core';
+import { Editor, Node, NodeEntry, Path } from 'slate';
+import { ELEMENT_LI } from './defaults';
+import { getListItemEntry, hasListChild } from './queries';
+import { removeFirstListItem, removeListItem } from './transforms';
+
+const pathToEntry = <T extends Node>(
+  editor: SPEditor,
+  path: Path
+): NodeEntry<T> => Editor.node(editor, path) as NodeEntry<T>;
+
+export const getListDeleteForward = (editor: SPEditor) => {
+  const res = getListItemEntry(editor, {});
+
+  let moved: boolean | undefined = false;
+  if (!isSelectionAtBlockEnd(editor) || !res) {
+    return moved;
+  }
+
+  Editor.withoutNormalizing(editor, () => {
+    const { listItem } = res;
+
+    if (!hasListChild(editor, listItem[0])) {
+      const li = getPlatePluginOptions(editor, ELEMENT_LI);
+      const liWithSiblings = Array.from(
+        Editor.nodes(editor, {
+          at: listItem[1],
+          mode: 'lowest',
+          match: (node: TDescendant, path) => {
+            if (path.length === 0) {
+              return false;
+            }
+
+            const isNodeLi = node.type === li.type;
+            const isSiblingOfNodeLi =
+              (getNode(editor, Path.next(path)) as TDescendant)?.type ===
+              li.type;
+
+            return isNodeLi && isSiblingOfNodeLi;
+          },
+        }),
+        (entry) => entry[1]
+      )[0];
+
+      if (!liWithSiblings) {
+        return;
+      }
+
+      const siblingListItem: NodeEntry<TDescendant> = pathToEntry(
+        editor,
+        Path.next(liWithSiblings)
+      );
+
+      const siblingList: NodeEntry<TDescendant> = Editor.parent(
+        editor,
+        siblingListItem[1]
+      );
+
+      moved = removeListItem(editor, {
+        list: siblingList,
+        listItem: siblingListItem,
+        reverse: false,
+      });
+      if (moved) return;
+
+      return;
+    }
+
+    const nestedList = pathToEntry<TDescendant>(
+      editor,
+      Path.next([...listItem[1], 0])
+    );
+    const nestedListItem = getChildren<TDescendant>(nestedList)[0];
+
+    moved = removeFirstListItem(editor, {
+      list: nestedList,
+      listItem: nestedListItem,
+    });
+    if (moved) return;
+
+    moved = removeListItem(editor, {
+      list: nestedList,
+      listItem: nestedListItem,
+    });
+  });
+
+  return moved;
+};

--- a/packages/elements/list/src/getListOnKeyDown.ts
+++ b/packages/elements/list/src/getListOnKeyDown.ts
@@ -22,7 +22,7 @@ export const getListOnKeyDown = (
 
     if (listSelected) {
       e.preventDefault();
-      moveListItems(editor, !e.shiftKey);
+      moveListItems(editor, { increase: !e.shiftKey });
       return;
     }
   }

--- a/packages/elements/list/src/transforms/indentListItems.ts
+++ b/packages/elements/list/src/transforms/indentListItems.ts
@@ -2,5 +2,5 @@ import { SPEditor } from '@udecode/plate-core';
 import { moveListItems } from './moveListItems';
 
 export const indentListItems = (editor: SPEditor) => {
-  moveListItems(editor, true);
+  moveListItems(editor, { increase: true });
 };

--- a/packages/elements/list/src/transforms/moveListItems.ts
+++ b/packages/elements/list/src/transforms/moveListItems.ts
@@ -1,4 +1,5 @@
 import { getNodes, getParent } from '@udecode/plate-common';
+import { EditorNodesOptions } from '@udecode/plate-common/src';
 import { getPlatePluginType, SPEditor } from '@udecode/plate-core';
 import { Editor, Path, PathRef } from 'slate';
 import { ELEMENT_LIC } from '../defaults';
@@ -6,10 +7,21 @@ import { isListNested } from '../queries/isListNested';
 import { moveListItemDown } from './moveListItemDown';
 import { moveListItemUp } from './moveListItemUp';
 
-export const moveListItems = (editor: SPEditor, increase = true) => {
+export type MoveListItemsOptions = {
+  increase?: boolean;
+  at?: EditorNodesOptions['at'];
+};
+
+export const moveListItems = (
+  editor: SPEditor,
+  {
+    increase = true,
+    at = editor.selection ?? undefined,
+  }: MoveListItemsOptions = {}
+) => {
   // Get the selected lic
   const [...lics] = getNodes(editor, {
-    at: editor.selection!,
+    at,
     match: {
       type: getPlatePluginType(editor, ELEMENT_LIC),
     },

--- a/packages/elements/list/src/transforms/removeListItem.ts
+++ b/packages/elements/list/src/transforms/removeListItem.ts
@@ -14,6 +14,7 @@ import { moveListItemSublistItemsToListItemSublist } from './moveListItemSublist
 export interface RemoveListItemOptions {
   list: NodeEntry<TElement>;
   listItem: NodeEntry<TElement>;
+  reverse?: boolean;
 }
 
 /**
@@ -21,7 +22,7 @@ export interface RemoveListItemOptions {
  */
 export const removeListItem = (
   editor: SPEditor,
-  { list, listItem }: RemoveListItemOptions
+  { list, listItem, reverse = true }: RemoveListItemOptions
 ) => {
   const [liNode, liPath] = listItem;
 
@@ -74,7 +75,7 @@ export const removeListItem = (
 
     // 3
     deleteFragment(editor, {
-      reverse: true,
+      reverse,
     });
 
     tempLiPath = tempLiPathRef.unref()!;

--- a/packages/elements/list/src/transforms/unindentListItems.ts
+++ b/packages/elements/list/src/transforms/unindentListItems.ts
@@ -1,6 +1,9 @@
 import { SPEditor } from '@udecode/plate-core';
-import { moveListItems } from './moveListItems';
+import { moveListItems, MoveListItemsOptions } from './moveListItems';
 
-export const unindentListItems = (editor: SPEditor) => {
-  moveListItems(editor, false);
-};
+export type UnindentListItemsOptions = Omit<MoveListItemsOptions, 'increase'>;
+
+export const unindentListItems = (
+  editor: SPEditor,
+  options: UnindentListItemsOptions = {}
+): void => moveListItems(editor, { ...options, increase: false });

--- a/packages/elements/list/src/withList.spec.tsx
+++ b/packages/elements/list/src/withList.spec.tsx
@@ -458,6 +458,9 @@ describe('withList', () => {
                 </hli>
               </hul>
             </hli>
+            <hli>
+              <hlic>level 1</hlic>
+            </hli>
           </hul>
         </editor>
       ) as any) as Editor;
@@ -484,6 +487,9 @@ describe('withList', () => {
                   <hlic>level 5</hlic>
                 </hli>
               </hul>
+            </hli>
+            <hli>
+              <hlic>level 1</hlic>
             </hli>
           </hul>
         </editor>

--- a/packages/elements/list/src/withList.spec.tsx
+++ b/packages/elements/list/src/withList.spec.tsx
@@ -31,6 +31,17 @@ const testDeleteBackward = (input: any, expected: any) => {
   expect(editor.children).toEqual(expected.children);
 };
 
+const testDeleteForward = (input: any, expected: any) => {
+  const editor = createEditorPlugins({
+    editor: input,
+    plugins: [createParagraphPlugin(), createListPlugin()],
+  });
+
+  editor.deleteForward('character');
+
+  expect(editor.children).toEqual(expected.children);
+};
+
 describe('withList', () => {
   describe('normalizeList', () => {
     describe('when there is no lic in li', () => {
@@ -301,6 +312,184 @@ describe('withList', () => {
 
         testDeleteBackward(input, expected);
       });
+    });
+  });
+
+  describe('when deleteForward at block end', () => {
+    it('should merge the next element when last child', () => {
+      const input = ((
+        <editor>
+          <hul>
+            <hli>
+              <hlic>
+                level 1<cursor />
+              </hlic>
+            </hli>
+          </hul>
+          <hul>
+            <hli>
+              <hlic>level 2</hlic>
+            </hli>
+          </hul>
+        </editor>
+      ) as any) as Editor;
+
+      const expected = ((
+        <editor>
+          <hul>
+            <hli>
+              <hlic>
+                level 1
+                <cursor />
+                level 2
+              </hlic>
+            </hli>
+          </hul>
+        </editor>
+      ) as any) as Editor;
+
+      testDeleteForward(input, expected);
+    });
+
+    it('should merge next sibling li', () => {
+      const input = ((
+        <editor>
+          <hul>
+            <hli>
+              <hlic>
+                level 1<cursor />
+              </hlic>
+            </hli>
+            <hli>
+              <hlic>level 2</hlic>
+            </hli>
+          </hul>
+        </editor>
+      ) as any) as Editor;
+
+      const expected = ((
+        <editor>
+          <hul>
+            <hli>
+              <hlic>
+                level 1
+                <cursor />
+                level 2
+              </hlic>
+            </hli>
+          </hul>
+        </editor>
+      ) as any) as Editor;
+
+      testDeleteForward(input, expected);
+    });
+
+    it('should merge next li and shift one level up', () => {
+      const input = ((
+        <editor>
+          <hul>
+            <hli>
+              <hlic>level 1</hlic>
+              <hul>
+                <hli>
+                  <hlic>
+                    level 2<cursor />
+                  </hlic>
+                </hli>
+              </hul>
+            </hli>
+            <hli>
+              <hlic>level 3</hlic>
+              <hul>
+                <hli>
+                  <hlic>level 4</hlic>
+                </hli>
+              </hul>
+            </hli>
+          </hul>
+        </editor>
+      ) as any) as Editor;
+
+      const expected = ((
+        <editor>
+          <hul>
+            <hli>
+              <hlic>level 1</hlic>
+              <hul>
+                <hli>
+                  <hlic>level 2level 3</hlic>
+                </hli>
+                <hli>
+                  <hlic>level 4</hlic>
+                </hli>
+              </hul>
+            </hli>
+          </hul>
+        </editor>
+      ) as any) as Editor;
+
+      testDeleteForward(input, expected);
+    });
+
+    it('should shift all nested lists one level up', () => {
+      const input = ((
+        <editor>
+          <hul>
+            <hli>
+              <hlic>
+                level 1<cursor />
+              </hlic>
+              <hul>
+                <hli>
+                  <hlic>level 2</hlic>
+                  <hul>
+                    <hli>
+                      <hlic>level 3</hlic>
+                      <hul>
+                        <hli>
+                          <hlic>level 4</hlic>
+                        </hli>
+                      </hul>
+                    </hli>
+                    <hli>
+                      <hlic>level 5</hlic>
+                    </hli>
+                  </hul>
+                </hli>
+              </hul>
+            </hli>
+          </hul>
+        </editor>
+      ) as any) as Editor;
+
+      const expected = ((
+        <editor>
+          <hul>
+            <hli>
+              <hlic>
+                level 1
+                <cursor />
+                level 2
+              </hlic>
+              <hul>
+                <hli>
+                  <hlic>level 3</hlic>
+                  <hul>
+                    <hli>
+                      <hlic>level 4</hlic>
+                    </hli>
+                  </hul>
+                </hli>
+                <hli>
+                  <hlic>level 5</hlic>
+                </hli>
+              </hul>
+            </hli>
+          </hul>
+        </editor>
+      ) as any) as Editor;
+
+      testDeleteForward(input, expected);
     });
   });
 });

--- a/packages/elements/list/src/withList.ts
+++ b/packages/elements/list/src/withList.ts
@@ -1,15 +1,16 @@
 import { SPEditor, WithOverride } from '@udecode/plate-core';
-import { getListNormalizer } from './normalizers/getListNormalizer';
 import { getListDeleteBackward } from './getListDeleteBackward';
+import { getListDeleteForward } from './getListDeleteForward';
 import { getListDeleteFragment } from './getListDeleteFragment';
 import { getListInsertBreak } from './getListInsertBreak';
 import { getListInsertFragment } from './getListInsertFragment';
+import { getListNormalizer } from './normalizers';
 import { WithListOptions } from './types';
 
 export const withList = ({
   validLiChildrenTypes,
 }: WithListOptions = {}): WithOverride<SPEditor> => (editor) => {
-  const { insertBreak, deleteBackward, deleteFragment } = editor;
+  const { insertBreak, deleteBackward, deleteForward, deleteFragment } = editor;
 
   editor.insertBreak = () => {
     if (getListInsertBreak(editor)) return;
@@ -21,6 +22,12 @@ export const withList = ({
     if (getListDeleteBackward(editor, unit)) return;
 
     deleteBackward(unit);
+  };
+
+  editor.deleteForward = (unit) => {
+    if (getListDeleteForward(editor)) return;
+
+    deleteForward(unit);
   };
 
   editor.deleteFragment = () => {


### PR DESCRIPTION
## Description

Fix data loss on list delete forward. This was not implemented before, so nested lists were being deleted.

## Example

Left current, right PR

![Peek 2021-09-11 15-13](https://user-images.githubusercontent.com/10130001/132949042-f67a1d18-db05-4c92-828b-4f587cd5ee26.gif)

## Notes

Have some extra refactorings i made during the process, not really needed but i believe they are useful. I can remove any extra work if needs be.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)
