### PR TITLE
Adds more natural default header option when inserting table columns

### DIFF
--- a/.changeset/blue-camels-cry.md
+++ b/.changeset/blue-camels-cry.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-table": patch
+---
+
+Adds more natural default header option when inserting table columns

--- a/packages/elements/table/src/transforms/addColumn.ts
+++ b/packages/elements/table/src/transforms/addColumn.ts
@@ -32,7 +32,7 @@ export const addColumn = (editor: SPEditor, { header }: TablePluginOptions) => {
 
       currentTableItem[0].children.forEach((row: TElement, rowIdx) => {
         newCellPath[replacePathPos] = rowIdx;
-        const isHeaderRow = header || row.children[0].type === ELEMENT_TH;
+        const isHeaderRow = header === undefined ? row.children[0].type === ELEMENT_TH : header;
 
         insertNodes<TElement>(editor, getEmptyCellNode(editor, { header: isHeaderRow }), {
           at: newCellPath,

--- a/packages/elements/table/src/transforms/addColumn.ts
+++ b/packages/elements/table/src/transforms/addColumn.ts
@@ -8,20 +8,20 @@ import { getEmptyCellNode } from '../utils/getEmptyCellNode';
 export const addColumn = (editor: SPEditor, { header }: TablePluginOptions) => {
   if (
     someNode(editor, {
-      match: { type: getPlatePluginType(editor, ELEMENT_TABLE) }
+      match: { type: getPlatePluginType(editor, ELEMENT_TABLE) },
     })
   ) {
     const currentCellItem = getAbove(editor, {
       match: {
         type: [
           getPlatePluginType(editor, ELEMENT_TH),
-          getPlatePluginType(editor, ELEMENT_TD)
-        ]
-      }
+          getPlatePluginType(editor, ELEMENT_TD),
+        ],
+      },
     });
 
     const currentTableItem = getAbove(editor, {
-      match: { type: getPlatePluginType(editor, ELEMENT_TABLE) }
+      match: { type: getPlatePluginType(editor, ELEMENT_TABLE) },
     });
 
     if (currentCellItem && currentTableItem) {
@@ -32,12 +32,17 @@ export const addColumn = (editor: SPEditor, { header }: TablePluginOptions) => {
 
       currentTableItem[0].children.forEach((row: TElement, rowIdx) => {
         newCellPath[replacePathPos] = rowIdx;
-        const isHeaderRow = header === undefined ? row.children[0].type === ELEMENT_TH : header;
+        const isHeaderRow =
+          header === undefined ? row.children[0].type === ELEMENT_TH : header;
 
-        insertNodes<TElement>(editor, getEmptyCellNode(editor, { header: isHeaderRow }), {
-          at: newCellPath,
-          select: rowIdx === currentRowIdx
-        });
+        insertNodes<TElement>(
+          editor,
+          getEmptyCellNode(editor, { header: isHeaderRow }),
+          {
+            at: newCellPath,
+            select: rowIdx === currentRowIdx,
+          }
+        );
       });
     }
   }

--- a/packages/elements/table/src/transforms/addColumn.ts
+++ b/packages/elements/table/src/transforms/addColumn.ts
@@ -22,7 +22,7 @@ export const addColumn = (editor: SPEditor, { header }: TablePluginOptions) => {
 
     const currentTableItem = getAbove(editor, {
       match: { type: getPlatePluginType(editor, ELEMENT_TABLE) }
-    })
+    });
 
     if (currentCellItem && currentTableItem) {
       const nextCellPath = Path.next(currentCellItem[1]);

--- a/packages/elements/table/src/transforms/addColumn.ts
+++ b/packages/elements/table/src/transforms/addColumn.ts
@@ -8,36 +8,37 @@ import { getEmptyCellNode } from '../utils/getEmptyCellNode';
 export const addColumn = (editor: SPEditor, { header }: TablePluginOptions) => {
   if (
     someNode(editor, {
-      match: { type: getPlatePluginType(editor, ELEMENT_TABLE) },
+      match: { type: getPlatePluginType(editor, ELEMENT_TABLE) }
     })
   ) {
     const currentCellItem = getAbove(editor, {
       match: {
         type: [
           getPlatePluginType(editor, ELEMENT_TH),
-          getPlatePluginType(editor, ELEMENT_TD),
-        ],
-      },
-    });
+          getPlatePluginType(editor, ELEMENT_TD)
+        ]
+      }
+    })
 
     const currentTableItem = getAbove(editor, {
-      match: { type: getPlatePluginType(editor, ELEMENT_TABLE) },
-    });
+      match: { type: getPlatePluginType(editor, ELEMENT_TABLE) }
+    })
 
     if (currentCellItem && currentTableItem) {
-      const nextCellPath = Path.next(currentCellItem[1]);
-      const newCellPath = nextCellPath.slice();
-      const replacePathPos = newCellPath.length - 2;
-      const currentRowIdx = nextCellPath[replacePathPos];
+      const nextCellPath = Path.next(currentCellItem[1])
+      const newCellPath = nextCellPath.slice()
+      const replacePathPos = newCellPath.length - 2
+      const currentRowIdx = nextCellPath[replacePathPos]
 
-      currentTableItem[0].children.forEach((row, rowIdx) => {
-        newCellPath[replacePathPos] = rowIdx;
+      currentTableItem[0].children.forEach((row: TElement, rowIdx) => {
+        newCellPath[replacePathPos] = rowIdx
+        const isHeaderRow = header || row.children[0].type === ELEMENT_TH
 
-        insertNodes<TElement>(editor, getEmptyCellNode(editor, { header }), {
+        insertNodes<TElement>(editor, getEmptyCellNode(editor, { header: isHeaderRow }), {
           at: newCellPath,
-          select: rowIdx === currentRowIdx,
-        });
-      });
+          select: rowIdx === currentRowIdx
+        })
+      })
     }
   }
-};
+}

--- a/packages/elements/table/src/transforms/addColumn.ts
+++ b/packages/elements/table/src/transforms/addColumn.ts
@@ -18,21 +18,21 @@ export const addColumn = (editor: SPEditor, { header }: TablePluginOptions) => {
           getPlatePluginType(editor, ELEMENT_TD)
         ]
       }
-    })
+    });
 
     const currentTableItem = getAbove(editor, {
       match: { type: getPlatePluginType(editor, ELEMENT_TABLE) }
     })
 
     if (currentCellItem && currentTableItem) {
-      const nextCellPath = Path.next(currentCellItem[1])
-      const newCellPath = nextCellPath.slice()
-      const replacePathPos = newCellPath.length - 2
-      const currentRowIdx = nextCellPath[replacePathPos]
+      const nextCellPath = Path.next(currentCellItem[1]);
+      const newCellPath = nextCellPath.slice();
+      const replacePathPos = newCellPath.length - 2;
+      const currentRowIdx = nextCellPath[replacePathPos];
 
       currentTableItem[0].children.forEach((row: TElement, rowIdx) => {
-        newCellPath[replacePathPos] = rowIdx
-        const isHeaderRow = header || row.children[0].type === ELEMENT_TH
+        newCellPath[replacePathPos] = rowIdx;
+        const isHeaderRow = header || row.children[0].type === ELEMENT_TH;
 
         insertNodes<TElement>(editor, getEmptyCellNode(editor, { header: isHeaderRow }), {
           at: newCellPath,

--- a/packages/elements/table/src/transforms/addColumn.ts
+++ b/packages/elements/table/src/transforms/addColumn.ts
@@ -37,8 +37,8 @@ export const addColumn = (editor: SPEditor, { header }: TablePluginOptions) => {
         insertNodes<TElement>(editor, getEmptyCellNode(editor, { header: isHeaderRow }), {
           at: newCellPath,
           select: rowIdx === currentRowIdx
-        })
-      })
+        });
+      });
     }
   }
-}
+};


### PR DESCRIPTION
**Description**

When inserting a new column to an existing table, the current implementation of the `addColumn` transform only allows for all table cells to be a header at once (`TH`) or none at all. However, most of the time, you usually want the top row of cells to remain as a table header and all other instances as standard `TD` cells.

This PR allows the flexibility for the header option to be more consistent with the current table row that we're iterating through when inserting a new column 🙂  

To maintain backwards compatibility, I've made sure that this only happens if the header option is not set. If the header option is already configured when calling `addColumn`, then this will override the default behaviour for all table cell instances.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)
