### PR TITLE
Fix first LIC normalize on paste

### DIFF
--- a/.changeset/long-impalas-occur.md
+++ b/.changeset/long-impalas-occur.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-list': patch
+---
+
+Fix first LIC normalize on paste

--- a/packages/elements/list/src/getListInsertFragment.spec.tsx
+++ b/packages/elements/list/src/getListInsertFragment.spec.tsx
@@ -181,4 +181,59 @@ describe('when pasting ul > 2 li fragment', () => {
       editorTest(input, fragment, expected);
     });
   });
+
+  describe('when pasted lis not contain lic', () => {
+    it('should normalize li children', () => {
+      const input = ((
+        <editor>
+          <hp>
+            P
+            <cursor />
+          </hp>
+        </editor>
+      ) as any) as SPEditor;
+
+      const fragment = ((
+        <fragment>
+          <hul>
+            <hli>
+              <hp>one</hp>
+            </hli>
+            <hli>
+              <hp>two</hp>
+            </hli>
+            <hul>
+              <hli>
+                <hp>three</hp>
+              </hli>
+            </hul>
+          </hul>
+        </fragment>
+      ) as any) as TDescendant[];
+
+      const expected = ((
+        <editor>
+          <hp>
+            P
+            <cursor />
+          </hp>
+          <hul>
+            <hli>
+              <hlic>one</hlic>
+            </hli>
+            <hli>
+              <hlic>two</hlic>
+            </hli>
+            <hul>
+              <hli>
+                <hlic>three</hlic>
+              </hli>
+            </hul>
+          </hul>
+        </editor>
+      ) as any) as SPEditor;
+
+      editorTest(input, fragment, expected);
+    });
+  });
 });

--- a/packages/elements/list/src/normalizers/normalizeListItem.ts
+++ b/packages/elements/list/src/normalizers/normalizeListItem.ts
@@ -90,9 +90,15 @@ export const normalizeListItem = (
       type: getPlatePluginType(editor, ELEMENT_LIC),
     })
   ) {
-    setNodes<TElement>(editor, {
-      type: getPlatePluginType(editor, ELEMENT_LIC),
-    });
+    setNodes<TElement>(
+      editor,
+      {
+        type: getPlatePluginType(editor, ELEMENT_LIC),
+      },
+      {
+        at: firstLiChildPath,
+      }
+    );
     changed = true;
   }
 


### PR DESCRIPTION
**Description**
When pasting list item, normalize first li child is ignored. Specify the location of the firstLiChildPath should fix it


<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

**Issue**
Pasting list first child not getting normalized

Fixes: 

**Example**
https://codesandbox.io/s/plate-playground-forked-7i3w8?file=/index.tsx
https://user-images.githubusercontent.com/11587066/133574631-4a57a653-eaf2-4dd5-809e-e2493ff59300.mp4




<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
