### PR TITLE
fix: findNode when path is provided

### DIFF
--- a/.changeset/lucky-boats-drive.md
+++ b/.changeset/lucky-boats-drive.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-common": patch
+---
+
+fix: `findNode` option `at` was ignored

--- a/packages/common/src/queries/findNode.spec.tsx
+++ b/packages/common/src/queries/findNode.spec.tsx
@@ -1,0 +1,89 @@
+/** @jsx jsx */
+
+import { SPEditor } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { findNode } from './findNode';
+
+jsx;
+
+describe('when the cursor is in a list item paragraph', () => {
+  const input = ((
+    <editor>
+      <hul>
+        <hli>
+          <hp>
+            1
+            <cursor />
+          </hp>
+        </hli>
+      </hul>
+    </editor>
+  ) as any) as SPEditor;
+
+  const listNode = (
+    <hul>
+      <hli>
+        <hp>
+          1
+          <cursor />
+        </hp>
+      </hli>
+    </hul>
+  ) as any;
+
+  const listItemNode = (
+    <hli>
+      <hp>
+        1
+        <cursor />
+      </hp>
+    </hli>
+  ) as any;
+
+  it('should be', () => {
+    const res = findNode(input, { match: { type: 'p' } });
+
+    expect(res).toEqual([{ children: [{ text: '1' }], type: 'p' }, [0, 0, 0]]);
+  });
+});
+
+describe('when the cursor is not in a list item and a path is provided instead', () => {
+  const input = ((
+    <editor>
+      <hul>
+        <hli>
+          <hp>1</hp>
+        </hli>
+      </hul>
+      <hp>
+        2<cursor />
+      </hp>
+    </editor>
+  ) as any) as SPEditor;
+
+  const listNode = (
+    <hul>
+      <hli>
+        <hp>
+          1
+          <cursor />
+        </hp>
+      </hli>
+    </hul>
+  ) as any;
+
+  const listItemNode = (
+    <hli>
+      <hp>
+        1
+        <cursor />
+      </hp>
+    </hli>
+  ) as any;
+
+  it('should be', () => {
+    const res = findNode(input, { at: [0, 0, 0, 0], match: { type: 'p' } });
+
+    expect(res).toEqual([{ children: [{ text: '1' }], type: 'p' }, [0, 0, 0]]);
+  });
+});

--- a/packages/common/src/queries/findNode.ts
+++ b/packages/common/src/queries/findNode.ts
@@ -10,13 +10,13 @@ export type FindNodeOptions<T extends TNode = TNode> = EditorNodesOptions<T>;
  */
 export const findNode = <T extends TNode = TNode>(
   editor: TEditor,
-  options: FindNodeOptions<T>
+  options: FindNodeOptions<T> = {}
 ): NodeEntry<T> | undefined => {
   // Slate throws when things aren't found so we wrap in a try catch and return undefined on throw.
   try {
     const nodeEntries = Editor.nodes<T>(editor, {
-      ...options,
       at: editor.selection || [],
+      ...options,
       match: (node) => match<Node>(node, options.match),
     });
 


### PR DESCRIPTION
**Description**

This PR fixes the `findNode` function

**Issue**

If does not respect the given `at` attribute from the options

**Fix**

Provide default `at` value before the `options` spread.