### PR TITLE
feat: handle edge case scenarios when it comes to deleteForward

### DIFF
--- a/.changeset/forty-socks-grin.md
+++ b/.changeset/forty-socks-grin.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-list": minor
+---
+
+feat: handle more `deleteForward` edge case scenarios

--- a/packages/elements/list/src/getListDeleteForward.spec.tsx
+++ b/packages/elements/list/src/getListDeleteForward.spec.tsx
@@ -1,0 +1,227 @@
+/** @jsx jsx */
+
+import { SPEditor } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { createEditorPlugins } from '../../../plate/src/utils/createEditorPlugins';
+import { createListPlugin } from './createListPlugin';
+
+jsx;
+
+describe('p (empty) + list when selection not in list', () => {
+  it('should remove the p', () => {
+    const input = ((
+      <editor>
+        <hp>
+          <cursor />
+        </hp>
+        <hul>
+          <hli>
+            <hlic>two</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const expected = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>two</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    editor.deleteForward('character');
+
+    expect(editor.children).toEqual(expected.children);
+  });
+});
+
+describe('p /w text + list when selection not in list', () => {
+  it('should merge the texts', () => {
+    const input = ((
+      <editor>
+        <hp>
+          one
+          <cursor />
+        </hp>
+        <hul>
+          <hli>
+            <hlic>two</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const expected = ((
+      <editor>
+        <hp>onetwo</hp>
+      </editor>
+    ) as any) as SPEditor;
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    editor.deleteForward('character');
+
+    expect(editor.children).toEqual(expected.children);
+  });
+
+  it('should merge the texts but keep the rest of the list', () => {
+    const input = ((
+      <editor>
+        <hp>
+          one
+          <cursor />
+        </hp>
+        <hul>
+          <hli>
+            <hlic>two</hlic>
+          </hli>
+          <hli>
+            <hlic>three</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const expected = ((
+      <editor>
+        <hp>onetwo</hp>
+        <hul>
+          <hli>
+            <hlic>three</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    editor.deleteForward('character');
+
+    expect(editor.children).toEqual(expected.children);
+  });
+
+  it('should merge the texts and move up its first child', () => {
+    const input = ((
+      <editor>
+        <hp>
+          one
+          <cursor />
+        </hp>
+        <hul>
+          <hli>
+            <hlic>two</hlic>
+            <hul>
+              <hli>
+                <hlic>twoone</hlic>
+              </hli>
+              <hli>
+                <hlic>twotwo</hlic>
+              </hli>
+            </hul>
+          </hli>
+          <hli>
+            <hlic>three</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const expected = ((
+      <editor>
+        <hp>onetwo</hp>
+        <hul>
+          <hli>
+            <hlic>twoone</hlic>
+            <hul>
+              <hli>
+                <hlic>twotwo</hlic>
+              </hli>
+            </hul>
+          </hli>
+          <hli>
+            <hlic>three</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    editor.deleteForward('character');
+
+    expect(editor.children).toEqual(expected.children);
+  });
+});
+
+describe('list + list when selection not in list', () => {
+  it('should merge the two list together', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>oneone</hlic>
+          </hli>
+          <hli>
+            <hlic>
+              onetwo
+              <cursor />
+            </hlic>
+          </hli>
+        </hul>
+        <hul>
+          <hli>
+            <hlic>twoone</hlic>
+          </hli>
+          <hli>
+            <hlic>twotwo</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const expected = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>oneone</hlic>
+          </hli>
+          <hli>
+            <hlic>onetwo</hlic>
+          </hli>
+          <hli>
+            <hlic>twoone</hlic>
+          </hli>
+          <hli>
+            <hlic>twotwo</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    editor.deleteForward('character');
+
+    expect(editor.children).toEqual(expected.children);
+  });
+});

--- a/packages/elements/list/src/getListDeleteForward.spec.tsx
+++ b/packages/elements/list/src/getListDeleteForward.spec.tsx
@@ -170,7 +170,7 @@ describe('p /w text + list when selection not in list', () => {
   });
 });
 
-describe('list + list when selection not in list', () => {
+describe('list + list when selection is at the end of the first list', () => {
   it('should merge the two list together', () => {
     const input = ((
       <editor>

--- a/packages/elements/list/src/getListDeleteForward.ts
+++ b/packages/elements/list/src/getListDeleteForward.ts
@@ -3,7 +3,6 @@ import {
   getChildren,
   getNode,
   getText,
-  hasTexts,
   isSelectionAtBlockEnd,
 } from '@udecode/plate-common';
 import {

--- a/packages/elements/list/src/getListDeleteForward.ts
+++ b/packages/elements/list/src/getListDeleteForward.ts
@@ -26,145 +26,168 @@ const pathToEntry = <T extends Node>(
   path: Path
 ): NodeEntry<T> => Editor.node(editor, path) as NodeEntry<T>;
 
-export const getListDeleteForward = (editor: SPEditor) => {
-  const res = getListItemEntry(editor, {});
+const selectionIsNotInAListHandler = (editor: SPEditor): boolean => {
+  const pointAfterSelection = Editor.after(
+    editor,
+    editor.selection!.focus.path
+  );
 
-  let moved: boolean | undefined = false;
-  if (!isSelectionAtBlockEnd(editor)) {
-    return moved;
-  }
+  if (pointAfterSelection) {
+    // there is a block after it
+    const nextSiblingListRes = getListItemEntry(editor, {
+      at: pointAfterSelection,
+    });
 
-  if (!res) {
-    const afterPoint = Editor.after(editor, editor.selection!.focus.path);
-
-    if (afterPoint) {
-      // there is a block after it
-      const nextSiblingListRes = getListItemEntry(editor, {
-        at: afterPoint.path,
+    if (nextSiblingListRes) {
+      // the next block is a list
+      const { listItem } = nextSiblingListRes;
+      const parentBlockEntity = getBlockAbove(editor, {
+        at: editor.selection!.anchor,
       });
 
-      if (nextSiblingListRes) {
-        // the next block is a list
-        const { listItem } = nextSiblingListRes;
-        const parentBlockEntity = getBlockAbove(editor, {
-          at: editor.selection!.anchor,
+      if (!getText(editor, parentBlockEntity![1])) {
+        // the selected block is empty
+        Transforms.removeNodes(editor);
+
+        return true;
+      }
+
+      if (hasListChild(editor, listItem[0])) {
+        // the next block has children, so we have to move the first item up
+        const sublistRes = getListItemEntry(editor, {
+          at: [...listItem[1], 1, 0, 0],
         });
 
-        if (!getText(editor, parentBlockEntity![1])) {
-          // the selected block is empty
-          Transforms.removeNodes(editor, { at: editor.selection!.focus });
-
-          return true;
-        }
-
-        if (hasListChild(editor, listItem[0])) {
-          // the next block has children, so we have to move the first item up
-          const sublistRes = getListItemEntry(editor, {
-            at: [...listItem[1], 1, 0, 0],
-          });
-
-          moveListItemUp(editor, sublistRes!);
-        }
+        moveListItemUp(editor, sublistRes!);
       }
     }
-    return false;
+  }
+
+  return false;
+};
+
+const selectionIsInAListHandler = (
+  editor: SPEditor,
+  res: { list: NodeEntry<TElement>; listItem: NodeEntry<TElement> }
+): boolean | undefined => {
+  const { listItem } = res;
+  let skipDefaultDelete: boolean | undefined = false;
+
+  // if it has no children
+  if (!hasListChild(editor, listItem[0])) {
+    const liType = getPlatePluginType(editor, ELEMENT_LI);
+    const liWithSiblings = Array.from(
+      Editor.nodes(editor, {
+        at: listItem[1],
+        mode: 'lowest',
+        match: (node: TDescendant, path) => {
+          if (path.length === 0) {
+            return false;
+          }
+
+          const isNodeLi = node.type === liType;
+          const isSiblingOfNodeLi =
+            (getNode(editor, Path.next(path)) as TDescendant)?.type === liType;
+
+          return isNodeLi && isSiblingOfNodeLi;
+        },
+      }),
+      (entry) => entry[1]
+    )[0];
+
+    if (!liWithSiblings) {
+      // there are no more list item in the list
+      const pointAfterListItem = Editor.after(editor, listItem[1]);
+
+      if (pointAfterListItem) {
+        // there is a block after it
+        const nextSiblingListRes = getListItemEntry(editor, {
+          at: pointAfterListItem,
+        });
+
+        if (nextSiblingListRes) {
+          // it is a list so we merge the lists
+          const listRoot = getListRoot(
+            editor,
+            listItem[1]
+          ) as NodeEntry<TElement>;
+
+          moveListItemsToList(editor, {
+            fromList: nextSiblingListRes.list,
+            toList: listRoot,
+            deleteFromList: true,
+          });
+
+          skipDefaultDelete = true;
+          return skipDefaultDelete;
+        }
+      }
+
+      return skipDefaultDelete;
+    }
+
+    const siblingListItem: NodeEntry<TDescendant> = pathToEntry(
+      editor,
+      Path.next(liWithSiblings)
+    );
+
+    const siblingList: NodeEntry<TDescendant> = Editor.parent(
+      editor,
+      siblingListItem[1]
+    );
+
+    skipDefaultDelete = removeListItem(editor, {
+      list: siblingList,
+      listItem: siblingListItem,
+      reverse: false,
+    });
+
+    return skipDefaultDelete;
+  }
+
+  // if it has children
+  const nestedList = pathToEntry<TDescendant>(
+    editor,
+    Path.next([...listItem[1], 0])
+  );
+  const nestedListItem = getChildren<TDescendant>(nestedList)[0];
+
+  skipDefaultDelete = removeFirstListItem(editor, {
+    list: nestedList,
+    listItem: nestedListItem,
+  });
+
+  if (skipDefaultDelete) return skipDefaultDelete;
+
+  skipDefaultDelete = removeListItem(editor, {
+    list: nestedList,
+    listItem: nestedListItem,
+  });
+
+  return skipDefaultDelete;
+};
+
+export const getListDeleteForward = (editor: SPEditor) => {
+  let skipDefaultDelete: boolean | undefined = false;
+
+  if (!editor?.selection) {
+    return skipDefaultDelete;
+  }
+
+  if (!isSelectionAtBlockEnd(editor)) {
+    return skipDefaultDelete;
   }
 
   Editor.withoutNormalizing(editor, () => {
-    const { listItem } = res;
+    const res = getListItemEntry(editor, {});
 
-    // if it has no children
-    if (!hasListChild(editor, listItem[0])) {
-      const liType = getPlatePluginType(editor, ELEMENT_LI);
-      const liWithSiblings = Array.from(
-        Editor.nodes(editor, {
-          at: listItem[1],
-          mode: 'lowest',
-          match: (node: TDescendant, path) => {
-            if (path.length === 0) {
-              return false;
-            }
-
-            const isNodeLi = node.type === liType;
-            const isSiblingOfNodeLi =
-              (getNode(editor, Path.next(path)) as TDescendant)?.type ===
-              liType;
-
-            return isNodeLi && isSiblingOfNodeLi;
-          },
-        }),
-        (entry) => entry[1]
-      )[0];
-
-      if (!liWithSiblings) {
-        // there are no more list item in the list
-        const afterPoint = Editor.after(editor, listItem[1]);
-
-        if (afterPoint) {
-          // there is a block after it
-          const nextSiblingListRes = getListItemEntry(editor, {
-            at: afterPoint.path,
-          });
-
-          if (nextSiblingListRes) {
-            // it is a list so we merge the lists
-            const listRoot = getListRoot(
-              editor,
-              listItem[1]
-            ) as NodeEntry<TElement>;
-
-            moveListItemsToList(editor, {
-              fromList: nextSiblingListRes.list,
-              toList: listRoot,
-              deleteFromList: true,
-            });
-
-            moved = true;
-
-            return;
-          }
-        }
-
-        return;
-      }
-
-      const siblingListItem: NodeEntry<TDescendant> = pathToEntry(
-        editor,
-        Path.next(liWithSiblings)
-      );
-
-      const siblingList: NodeEntry<TDescendant> = Editor.parent(
-        editor,
-        siblingListItem[1]
-      );
-
-      moved = removeListItem(editor, {
-        list: siblingList,
-        listItem: siblingListItem,
-        reverse: false,
-      });
-
+    if (!res) {
+      skipDefaultDelete = selectionIsNotInAListHandler(editor);
       return;
     }
 
-    // if it has children
-    const nestedList = pathToEntry<TDescendant>(
-      editor,
-      Path.next([...listItem[1], 0])
-    );
-    const nestedListItem = getChildren<TDescendant>(nestedList)[0];
-
-    moved = removeFirstListItem(editor, {
-      list: nestedList,
-      listItem: nestedListItem,
-    });
-    if (moved) return;
-
-    moved = removeListItem(editor, {
-      list: nestedList,
-      listItem: nestedListItem,
-    });
+    skipDefaultDelete = selectionIsInAListHandler(editor, res);
   });
 
-  return moved;
+  return skipDefaultDelete;
 };

--- a/packages/elements/list/src/getListDeleteForward.ts
+++ b/packages/elements/list/src/getListDeleteForward.ts
@@ -142,6 +142,8 @@ const selectionIsInAListHandler = (
       reverse: false,
     });
 
+    // if (skipDefaultDelete) return skipDefaultDelete;
+
     return skipDefaultDelete;
   }
 

--- a/packages/elements/list/src/queries/getListItemEntry.ts
+++ b/packages/elements/list/src/queries/getListItemEntry.ts
@@ -1,46 +1,45 @@
 import {
   getAbove,
+  getNode,
   getParent,
   isCollapsed,
-  someNode,
 } from '@udecode/plate-common';
 import { getPlatePluginType, SPEditor, TElement } from '@udecode/plate-core';
-import { Location, NodeEntry, Range } from 'slate';
+import { Location, NodeEntry, Path, Range } from 'slate';
 import { ELEMENT_LI } from '../defaults';
 
 /**
- * If at (default = selection) is in ul>li>p, return li and ul node entries.
+ * Returns the nearest li and ul / ol wrapping node entries for a given path (default = selection)
  */
 export const getListItemEntry = (
   editor: SPEditor,
   { at = editor.selection }: { at?: Location | null } = {}
 ): { list: NodeEntry<TElement>; listItem: NodeEntry<TElement> } | undefined => {
   const liType = getPlatePluginType(editor, ELEMENT_LI);
-  if (at && someNode(editor, { at, match: { type: liType } })) {
-    const selectionParent = getParent(editor, at);
-    if (!selectionParent) return;
-    const [, paragraphPath] = selectionParent;
 
-    // If selection range includes root list item
-    if (Range.isRange(at) && !isCollapsed(at) && paragraphPath.length === 1) {
-      at = at.focus.path;
+  let _at: Path;
+
+  if (Range.isRange(at) && !isCollapsed(at)) {
+    _at = at.focus.path;
+  } else if (Range.isRange(at)) {
+    _at = at.anchor.path;
+  } else {
+    _at = at as Path;
+  }
+
+  if (_at) {
+    const node = getNode(editor, _at) as TElement;
+    if (node) {
+      const listItem = getAbove(editor, {
+        at: _at,
+        match: { type: liType },
+      }) as NodeEntry<TElement>;
+
+      if (listItem) {
+        const list = getParent(editor, listItem[1]) as NodeEntry<TElement>;
+
+        return { list, listItem };
+      }
     }
-
-    const listItem =
-      getAbove<TElement>(editor, { at, match: { type: liType } }) ||
-      getParent<TElement>(editor, paragraphPath);
-
-    if (!listItem) return;
-    const [listItemNode, listItemPath] = listItem;
-
-    if (listItemNode.type !== liType) return;
-
-    const list = getParent<TElement>(editor, listItemPath);
-    if (!list) return;
-
-    return {
-      list,
-      listItem,
-    };
   }
 };

--- a/packages/elements/list/src/withList.spec.tsx
+++ b/packages/elements/list/src/withList.spec.tsx
@@ -326,11 +326,7 @@ describe('withList', () => {
               </hlic>
             </hli>
           </hul>
-          <hul>
-            <hli>
-              <hlic>level 2</hlic>
-            </hli>
-          </hul>
+          <hp>level 2</hp>
         </editor>
       ) as any) as Editor;
 


### PR DESCRIPTION
**Description**

There are a couple of scenarios that the current `deleteForward` in the list plugin does not handle properly.

I made a couple of tests that describe these scenarios

Also I reworked the `getListItemEntry` so it would be a bit more lenient when it comes to finding listItem and list.

It should not affect the earlier applications, but with this it is not so hard to provide a proper path for it.