### PR TITLE
feat(link): Unwrap selected links when pasting a URL

### DIFF
--- a/.changeset/cyan-bulldogs-attend.md
+++ b/.changeset/cyan-bulldogs-attend.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-link": minor
+---
+
+feat(link): Unwrap selected links when pasting a URL. Previously, pasting any text (including a URL) with an existing link selected would insert plain text. With this change, pasting a URL will unwrap any selected links and wrap a new link.

--- a/packages/elements/link/src/__tests__/withLink/insertData/insert-url-over-link.spec.tsx
+++ b/packages/elements/link/src/__tests__/withLink/insertData/insert-url-over-link.spec.tsx
@@ -1,0 +1,50 @@
+/** @jsx jsx */
+
+import { withInlineVoid } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { withReact } from 'slate-react';
+import { ELEMENT_LINK } from '../../../defaults';
+import { withLink } from '../../../withLink';
+
+jsx;
+
+const input = (
+  <editor>
+    <hp>
+      test{' '}
+      <ha url="http://google.com">
+        please
+        <anchor />
+        click
+      </ha>{' '}
+      here
+      <focus />.
+    </hp>
+  </editor>
+) as any;
+
+const data = { getData: () => 'http://google.com/test' };
+
+const output = (
+  <editor>
+    <hp>
+      test please
+      <element type="a" url="http://google.com/test">
+        click here
+      </element>
+      .
+    </hp>
+  </editor>
+) as any;
+
+it('should unwrap the existing link', () => {
+  jest.spyOn(JSON, 'parse').mockReturnValue(<fragment>docs</fragment>);
+
+  const editor = withLink()(
+    withInlineVoid({ inlineTypes: [ELEMENT_LINK] })(withReact(input))
+  );
+
+  editor.insertData(data);
+
+  expect(input.children).toEqual(output.children);
+});

--- a/packages/elements/link/src/withLink.ts
+++ b/packages/elements/link/src/withLink.ts
@@ -108,12 +108,12 @@ export const withLink = ({
     const text = data.getData('text/plain');
 
     if (text) {
-      if (someNode(editor, { match: { type } })) {
-        return insertText(text);
-      }
-
       if (isUrl(text)) {
         return upsertLinkAtSelection(editor, { url: text });
+      }
+
+      if (someNode(editor, { match: { type } })) {
+        return insertText(text);
       }
     }
 


### PR DESCRIPTION
Hi folks. 👋🏼 Just a small behavior change to get started as a contributor.

## Description

This PR modifies the behavior of the `link` plugin when **pasting a URL**.

Previously, pasting any text (including a URL) with an existing link selected would insert plain text. With this change, pasting a URL will unwrap any selected links and wrap a new link.

## Example

For example, if the pipes below represents the editor selection:

> For more information [please |**click**](https://google.com) **here**|.

and the user pastes a URL, e.g. `https://yahoo.com`, then the result would be:

> For more information, please [click here](https://yahoo.com).


## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)
