### PR TITLE
fix: toggleList

### DIFF
--- a/.changeset/strange-impalas-protect.md
+++ b/.changeset/strange-impalas-protect.md
@@ -1,0 +1,8 @@
+---
+"@udecode/plate-list": patch
+---
+
+fix: 
+- `toggleList` works as expected
+- `moveListItemDown` wrap transformations in `withoutNormalizing` (it caused a pathing issue since the normalization would remove the created empty list)
+

--- a/.changeset/strong-cars-shave.md
+++ b/.changeset/strong-cars-shave.md
@@ -1,0 +1,7 @@
+---
+"@udecode/plate-list": minor
+---
+
+Normalizer:
+- now merges lists with the same type next to each other
+- if a list has no lic and it has children it moves those childrens up a level

--- a/.changeset/tame-mails-chew.md
+++ b/.changeset/tame-mails-chew.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-list-ui": patch
+---
+
+fix: `ToolbarList` is now using `active` prop because the default `ToolbarElement` solution was activating both button when there was an unordered list within an ordered list

--- a/.changeset/twelve-wolves-sell.md
+++ b/.changeset/twelve-wolves-sell.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-toolbar": fix
+---
+
+`ToolbarElement` now uses the provided `active` prop

--- a/packages/elements/list-ui/src/ToolbarList/ToolbarList.tsx
+++ b/packages/elements/list-ui/src/ToolbarList/ToolbarList.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { getPreventDefaultHandler } from '@udecode/plate-common';
 import { useEventEditorId, useStoreEditorState } from '@udecode/plate-core';
-import { ELEMENT_UL, toggleList } from '@udecode/plate-list';
+import { ELEMENT_UL, getListItemEntry, toggleList } from '@udecode/plate-list';
 import { ToolbarButtonProps, ToolbarElement } from '@udecode/plate-toolbar';
 
 export const ToolbarList = ({
@@ -10,8 +10,11 @@ export const ToolbarList = ({
 }: ToolbarButtonProps & { type?: string }) => {
   const editor = useStoreEditorState(useEventEditorId('focus'));
 
+  const res = !!editor?.selection && getListItemEntry(editor);
+
   return (
     <ToolbarElement
+      active={!!res && res.list[0].type === type}
       type={type}
       onMouseDown={
         editor &&

--- a/packages/elements/list/src/normalizers/getListNormalizer.spec.tsx
+++ b/packages/elements/list/src/normalizers/getListNormalizer.spec.tsx
@@ -1,0 +1,163 @@
+/** @jsx jsx */
+
+import { createEditorPlugins } from '@udecode/plate/src';
+import { getNode } from '@udecode/plate-common';
+import { SPEditor } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { createListPlugin } from '../createListPlugin';
+
+jsx;
+
+describe('merge lists', () => {
+  it('should not merge lists with different type', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>1</hlic>
+          </hli>
+        </hul>
+        <hol>
+          <hli>
+            <hlic>2</hlic>
+          </hli>
+        </hol>
+      </editor>
+    ) as any) as SPEditor;
+
+    const output = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>1</hlic>
+          </hli>
+        </hul>
+        <hol>
+          <hli>
+            <hlic>2</hlic>
+          </hli>
+        </hol>
+      </editor>
+    ) as any) as SPEditor;
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    const path = [0];
+    const node = getNode(editor, path);
+
+    editor.normalizeNode([node!, path]);
+
+    expect(input.children).toEqual(output.children);
+  });
+
+  it('should merge the next list if it has the same type', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>1</hlic>
+          </hli>
+        </hul>
+        <hul>
+          <hli>
+            <hlic>2</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const output = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>1</hlic>
+          </hli>
+          <hli>
+            <hlic>2</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    const path = [0];
+    const node = getNode(editor, path);
+
+    editor.normalizeNode([node!, path]);
+
+    expect(input.children).toEqual(output.children);
+  });
+
+  it('should merge the previous list if it has the same type', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>1</hlic>
+          </hli>
+        </hul>
+        <hul>
+          <hli>
+            <hlic>2</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const output = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>1</hlic>
+          </hli>
+          <hli>
+            <hlic>2</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    const path = [1];
+    const node = getNode(editor, path);
+
+    editor.normalizeNode([node!, path]);
+
+    expect(input.children).toEqual(output.children);
+  });
+});
+
+describe('clean up lists', () => {
+  it('should remove list without list items', () => {
+    const input = ((
+      <editor>
+        <hul />
+      </editor>
+    ) as any) as SPEditor;
+
+    const output = ((<editor />) as any) as SPEditor;
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    const path = [0];
+    const node = getNode(editor, path);
+
+    editor.normalizeNode([node!, path]);
+
+    expect(input.children).toEqual(output.children);
+  });
+});

--- a/packages/elements/list/src/normalizers/getListNormalizer.ts
+++ b/packages/elements/list/src/normalizers/getListNormalizer.ts
@@ -33,7 +33,7 @@ export const getListNormalizer = (
   const licType = getPlatePluginType(editor, ELEMENT_LIC);
   const defaultType = getPlatePluginType(editor, ELEMENT_DEFAULT);
 
-  return ([node, path]: NodeEntry<TElement>) => {
+  return ([node, path]: NodeEntry) => {
     if (!isElement(node)) return;
 
     // remove empty list

--- a/packages/elements/list/src/normalizers/getListNormalizer.ts
+++ b/packages/elements/list/src/normalizers/getListNormalizer.ts
@@ -1,12 +1,24 @@
-import { ELEMENT_DEFAULT, getNode, getParent, match, setNodes } from '@udecode/plate-common';
-import { getPlatePluginType, isElement, SPEditor, TDescendant, TElement } from '@udecode/plate-core';
+import {
+  ELEMENT_DEFAULT,
+  getNode,
+  getParent,
+  match,
+  setNodes,
+} from '@udecode/plate-common';
+import {
+  getPlatePluginType,
+  isElement,
+  SPEditor,
+  TDescendant,
+  TElement,
+} from '@udecode/plate-core';
 import { NodeEntry, Transforms } from 'slate';
 import { ELEMENT_LI, ELEMENT_LIC } from '../defaults';
 import { getListTypes } from '../queries/getListTypes';
+import { moveListItemsToList } from '../transforms';
 import { ListNormalizerOptions } from '../types';
 import { normalizeListItem } from './normalizeListItem';
 import { normalizeNestedList } from './normalizeNestedList';
-import { moveListItemsToList } from '../transforms';
 
 /**
  * Normalize list node to force the ul>li>p+ul structure.
@@ -56,7 +68,7 @@ export const getListNormalizer = (
         }
       }
 
-      normalizeNestedList(editor, { nestedListItem: [node, path] })
+      normalizeNestedList(editor, { nestedListItem: [node, path] });
 
       return;
     }

--- a/packages/elements/list/src/normalizers/normalizeListItem.spec.tsx
+++ b/packages/elements/list/src/normalizers/normalizeListItem.spec.tsx
@@ -1,0 +1,49 @@
+/** @jsx jsx */
+
+import { createEditorPlugins } from '@udecode/plate/src';
+import { getNode } from '@udecode/plate-common';
+import { SPEditor } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { createListPlugin } from '../createListPlugin';
+
+jsx;
+
+describe('clean up list items', () => {
+  it('should move children up from sublis if their parent has no lic', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hul>
+              <hli>
+                <hlic>1</hlic>
+              </hli>
+            </hul>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const output = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>1</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    const path = [0, 0];
+    const node = getNode(editor, path);
+
+    editor.normalizeNode([node!, path]);
+
+    expect(input.children).toEqual(output.children);
+  });
+});

--- a/packages/elements/list/src/normalizers/normalizeListItem.ts
+++ b/packages/elements/list/src/normalizers/normalizeListItem.ts
@@ -14,7 +14,7 @@ import {
 import { Editor, NodeEntry, Path, PathRef, Transforms } from 'slate';
 import { ELEMENT_LIC, ELEMENT_OL, ELEMENT_UL } from '../defaults';
 import { getListTypes } from '../queries';
-import { moveListItemsToList, moveListItemUp, unwrapList } from '../transforms';
+import { moveListItemUp } from '../transforms';
 import { ListNormalizerOptions } from '../types';
 
 /**

--- a/packages/elements/list/src/transforms/moveListItemDown.ts
+++ b/packages/elements/list/src/transforms/moveListItemDown.ts
@@ -1,7 +1,7 @@
 import { match, wrapNodes } from '@udecode/plate-common';
 import { SPEditor, TElement } from '@udecode/plate-core';
 import { Ancestor, Editor, Element, NodeEntry, Path, Transforms } from 'slate';
-import { getListTypes } from '../queries/getListTypes';
+import { getListTypes } from '../queries';
 
 export interface MoveListItemDownOptions {
   list: NodeEntry<TElement>;
@@ -39,19 +39,21 @@ export const moveListItemDown = (
       sublist ? [1, sublist.children.length] : [1]
     );
 
-    if (!sublist) {
-      // Create new sublist
-      wrapNodes(
-        editor,
-        { type: listNode.type, children: [] },
-        { at: listItemPath }
-      );
-    }
+    Editor.withoutNormalizing(editor, () => {
+      if (!sublist) {
+        // Create new sublist
+        wrapNodes(
+          editor,
+          { type: listNode.type, children: [] },
+          { at: listItemPath }
+        );
+      }
 
-    // Move the current item to the sublist
-    Transforms.moveNodes(editor, {
-      at: listItemPath,
-      to: newPath,
+      // Move the current item to the sublist
+      Transforms.moveNodes(editor, {
+        at: listItemPath,
+        to: newPath,
+      });
     });
   }
 };

--- a/packages/elements/list/src/transforms/moveListItems.ts
+++ b/packages/elements/list/src/transforms/moveListItems.ts
@@ -52,24 +52,26 @@ export const moveListItems = (
     ? highestLicPathRefs
     : highestLicPathRefs.reverse();
 
-  licPathRefsToMove.forEach((licPathRef) => {
-    const licPath = licPathRef.unref();
-    if (!licPath) return;
+  Editor.withoutNormalizing(editor, () => {
+    licPathRefsToMove.forEach((licPathRef) => {
+      const licPath = licPathRef.unref();
+      if (!licPath) return;
 
-    const listItem = getParent(editor, licPath);
-    if (!listItem) return;
-    const listEntry = getParent(editor, listItem[1]);
+      const listItem = getParent(editor, licPath);
+      if (!listItem) return;
+      const listEntry = getParent(editor, listItem[1]);
 
-    if (increase) {
-      moveListItemDown(editor, {
-        list: listEntry as any,
-        listItem: listItem as any,
-      });
-    } else if (listEntry && isListNested(editor, listEntry[1])) {
-      moveListItemUp(editor, {
-        list: listEntry as any,
-        listItem: listItem as any,
-      });
-    }
+      if (increase) {
+        moveListItemDown(editor, {
+          list: listEntry as any,
+          listItem: listItem as any,
+        });
+      } else if (listEntry && isListNested(editor, listEntry[1])) {
+        moveListItemUp(editor, {
+          list: listEntry as any,
+          listItem: listItem as any,
+        });
+      }
+    });
   });
 };

--- a/packages/elements/list/src/transforms/removeListItem.ts
+++ b/packages/elements/list/src/transforms/removeListItem.ts
@@ -33,69 +33,76 @@ export const removeListItem = (
 
   const previousLiPath = getPreviousPath(liPath);
 
-  /**
-   * If there is a previous li, we need to move sub-lis to the previous li.
-   * As we need to delete first, we will:
-   * 1. insert a temporary li: tempLi
-   * 2. move sub-lis to tempLi
-   * 3. delete
-   * 4. move sub-lis from tempLi to the previous li.
-   * 5. remove tempLi
-   */
-  if (previousLiPath) {
-    const previousLi = Editor.node(
-      editor,
-      previousLiPath
-    ) as NodeEntry<TElement>;
+  let success = false;
 
-    // 1
-    let tempLiPath = Path.next(liPath);
-    insertNodes<TElement>(
-      editor,
-      {
-        type: getPlatePluginType(editor, ELEMENT_LI),
-        children: [
-          {
-            type: getPlatePluginType(editor, ELEMENT_LIC),
-            children: [{ text: '' }],
-          },
-        ],
-      },
-      { at: tempLiPath }
-    );
+  Editor.withoutNormalizing(editor, () => {
+    /**
+     * If there is a previous li, we need to move sub-lis to the previous li.
+     * As we need to delete first, we will:
+     * 1. insert a temporary li: tempLi
+     * 2. move sub-lis to tempLi
+     * 3. delete
+     * 4. move sub-lis from tempLi to the previous li.
+     * 5. remove tempLi
+     */
+    if (previousLiPath) {
+      const previousLi = Editor.node(
+        editor,
+        previousLiPath
+      ) as NodeEntry<TElement>;
 
-    const tempLi = Editor.node(editor, tempLiPath) as NodeEntry<TElement>;
-    const tempLiPathRef = Editor.pathRef(editor, tempLi[1]);
+      // 1
+      let tempLiPath = Path.next(liPath);
+      insertNodes<TElement>(
+        editor,
+        {
+          type: getPlatePluginType(editor, ELEMENT_LI),
+          children: [
+            {
+              type: getPlatePluginType(editor, ELEMENT_LIC),
+              children: [{ text: '' }],
+            },
+          ],
+        },
+        { at: tempLiPath }
+      );
 
-    // 2
-    moveListItemSublistItemsToListItemSublist(editor, {
+      const tempLi = Editor.node(editor, tempLiPath) as NodeEntry<TElement>;
+      const tempLiPathRef = Editor.pathRef(editor, tempLi[1]);
+
+      // 2
+      moveListItemSublistItemsToListItemSublist(editor, {
+        fromListItem: listItem,
+        toListItem: tempLi,
+      });
+
+      // 3
+      deleteFragment(editor, {
+        reverse,
+      });
+
+      tempLiPath = tempLiPathRef.unref()!;
+
+      // 4
+      moveListItemSublistItemsToListItemSublist(editor, {
+        fromListItem: [tempLi[0], tempLiPath],
+        toListItem: previousLi,
+      });
+
+      // 5
+      Transforms.removeNodes(editor, { at: tempLiPath });
+
+      success = true;
+      return;
+    }
+
+    // If it's the first li, move the sublist to the parent list
+    moveListItemsToList(editor, {
       fromListItem: listItem,
-      toListItem: tempLi,
+      toList: list,
+      toListIndex: 1,
     });
-
-    // 3
-    deleteFragment(editor, {
-      reverse,
-    });
-
-    tempLiPath = tempLiPathRef.unref()!;
-
-    // 4
-    moveListItemSublistItemsToListItemSublist(editor, {
-      fromListItem: [tempLi[0], tempLiPath],
-      toListItem: previousLi,
-    });
-
-    // 5
-    Transforms.removeNodes(editor, { at: tempLiPath });
-
-    return true;
-  }
-
-  // If it's the first li, move the sublist to the parent list
-  moveListItemsToList(editor, {
-    fromListItem: listItem,
-    toList: list,
-    toListIndex: 1,
   });
+
+  return success;
 };

--- a/packages/elements/list/src/transforms/toggleList.spec.tsx
+++ b/packages/elements/list/src/transforms/toggleList.spec.tsx
@@ -1,0 +1,348 @@
+/** @jsx jsx */
+
+import { createEditorPlugins } from '@udecode/plate/src';
+import { getPlatePluginType, SPEditor } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { createListPlugin } from '../createListPlugin';
+import { ELEMENT_OL, ELEMENT_UL } from '../defaults';
+import { toggleList } from './toggleList';
+
+jsx;
+
+describe('toggle on', () => {
+  it('should turn a p to list', () => {
+    const input = ((
+      <editor>
+        <hp>
+          1<cursor />
+        </hp>
+      </editor>
+    ) as any) as SPEditor;
+
+    const output = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>1</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    toggleList(editor, { type: getPlatePluginType(editor, ELEMENT_UL) });
+
+    expect(input.children).toEqual(output.children);
+  });
+
+  it('should turn multiple p to list', () => {
+    const input = ((
+      <editor>
+        <hp>
+          <anchor />1
+        </hp>
+        <hp>2</hp>
+        <hp>
+          3<focus />
+        </hp>
+      </editor>
+    ) as any) as SPEditor;
+
+    const output = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>1</hlic>
+          </hli>
+          <hli>
+            <hlic>2</hlic>
+          </hli>
+          <hli>
+            <hlic>3</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    toggleList(editor, { type: getPlatePluginType(editor, ELEMENT_UL) });
+
+    expect(input.children).toEqual(output.children);
+  });
+});
+
+describe('toggle off', () => {
+  it('should spit a simple list to two', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>1</hlic>
+          </hli>
+          <hli>
+            <hlic>
+              2
+              <cursor />
+            </hlic>
+          </hli>
+          <hli>
+            <hlic>3</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const output = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>1</hlic>
+          </hli>
+        </hul>
+        <hp>2</hp>
+        <hul>
+          <hli>
+            <hlic>3</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    toggleList(editor, { type: getPlatePluginType(editor, ELEMENT_UL) });
+
+    expect(input.children).toEqual(output.children);
+  });
+
+  it('should split a nested list', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>1</hlic>
+            <hul>
+              <hli>
+                <hlic>11</hlic>
+              </hli>
+              <hli>
+                <hlic>
+                  12
+                  <cursor />
+                </hlic>
+              </hli>
+              <hli>
+                <hlic>13</hlic>
+              </hli>
+            </hul>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const output = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>1</hlic>
+            <hul>
+              <hli>
+                <hlic>11</hlic>
+              </hli>
+            </hul>
+          </hli>
+        </hul>
+        <hp>12</hp>
+        <hul>
+          <hli>
+            <hlic>13</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    toggleList(editor, { type: getPlatePluginType(editor, ELEMENT_UL) });
+
+    expect(input.children).toEqual(output.children);
+  });
+
+  it('should turn a list to multiple p', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>
+              <anchor />1
+            </hlic>
+          </hli>
+          <hli>
+            <hlic>2</hlic>
+          </hli>
+          <hli>
+            <hlic>
+              3<focus />
+            </hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const output = ((
+      <editor>
+        <hp>1</hp>
+        <hp>2</hp>
+        <hp>3</hp>
+      </editor>
+    ) as any) as SPEditor;
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    toggleList(editor, { type: getPlatePluginType(editor, ELEMENT_UL) });
+
+    expect(input.children).toEqual(output.children);
+  });
+});
+
+describe('toggle over', () => {
+  it('should toggle different list types', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>
+              1<cursor />
+            </hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const output = ((
+      <editor>
+        <hol>
+          <hli>
+            <hlic>1</hlic>
+          </hli>
+        </hol>
+      </editor>
+    ) as any) as SPEditor;
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    toggleList(editor, { type: getPlatePluginType(editor, ELEMENT_OL) });
+
+    expect(input.children).toEqual(output.children);
+  });
+
+  it('should only toggle the nested list', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>1</hlic>
+            <hul>
+              <hli>
+                <hlic>
+                  11
+                  <cursor />
+                </hlic>
+              </hli>
+            </hul>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const output = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>1</hlic>
+            <hol>
+              <hli>
+                <hlic>11</hlic>
+              </hli>
+            </hol>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    toggleList(editor, { type: getPlatePluginType(editor, ELEMENT_OL) });
+
+    expect(input.children).toEqual(output.children);
+  });
+
+  it('should only toggle everything that selected', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>
+              <anchor />1
+            </hlic>
+            <hul>
+              <hli>
+                <hlic>
+                  11
+                  <focus />
+                </hlic>
+              </hli>
+            </hul>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as SPEditor;
+
+    const output = ((
+      <editor>
+        <hol>
+          <hli>
+            <hlic>1</hlic>
+            <hol>
+              <hli>
+                <hlic>11</hlic>
+              </hli>
+            </hol>
+          </hli>
+        </hol>
+      </editor>
+    ) as any) as SPEditor;
+
+    const editor = createEditorPlugins({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    toggleList(editor, { type: getPlatePluginType(editor, ELEMENT_OL) });
+
+    expect(input.children).toEqual(output.children);
+  });
+});

--- a/packages/elements/list/src/transforms/toggleList.spec.tsx
+++ b/packages/elements/list/src/transforms/toggleList.spec.tsx
@@ -80,7 +80,7 @@ describe('toggle on', () => {
 });
 
 describe('toggle off', () => {
-  it('should spit a simple list to two', () => {
+  it('should split a simple list to two', () => {
     const input = ((
       <editor>
         <hul>
@@ -300,7 +300,7 @@ describe('toggle over', () => {
     expect(input.children).toEqual(output.children);
   });
 
-  it('should only toggle everything that selected', () => {
+  it('should only toggle everything that is selected', () => {
     const input = ((
       <editor>
         <hul>

--- a/packages/elements/list/src/transforms/toggleList.ts
+++ b/packages/elements/list/src/transforms/toggleList.ts
@@ -12,12 +12,12 @@ import { ELEMENT_LI, ELEMENT_LIC } from '../defaults';
 import { getListItemEntry, getListTypes } from '../queries';
 import { unwrapList } from './unwrapList';
 
-export const toggleList = (editor: SPEditor, { type }: { type: string }) => {
-  if (!editor.selection) {
-    return;
-  }
-
+export const toggleList = (editor: SPEditor, { type }: { type: string }) =>
   Editor.withoutNormalizing(editor, () => {
+    if (!editor.selection) {
+      return;
+    }
+
     if (isCollapsed(editor.selection)) {
       // selection is collapsed
       const res = getListItemEntry(editor);
@@ -29,7 +29,7 @@ export const toggleList = (editor: SPEditor, { type }: { type: string }) => {
             editor,
             { type },
             {
-              at: editor.selection as Range,
+              at: editor.selection,
               match: (n) => getListTypes(editor).includes(n.type),
               mode: 'lowest',
             }
@@ -61,13 +61,9 @@ export const toggleList = (editor: SPEditor, { type }: { type: string }) => {
       }
     } else {
       // selection is a range
-      const [statPoint, endPoint] = Range.edges(editor.selection!);
+      const [startPoint, endPoint] = Range.edges(editor.selection!);
 
-      const commonEntry: NodeEntry<Node> = Node.common(
-        editor,
-        statPoint.path,
-        endPoint.path
-      );
+      const commonEntry = Node.common(editor, startPoint.path, endPoint.path);
 
       if (
         getListTypes(editor).includes((commonEntry[0] as TElement).type) ||
@@ -76,12 +72,12 @@ export const toggleList = (editor: SPEditor, { type }: { type: string }) => {
       ) {
         if ((commonEntry[0] as TElement).type !== type) {
           const startList = findNode(editor, {
-            at: Range.start(editor.selection as Range).path,
+            at: Range.start(editor.selection),
             match: { type: getListTypes(editor) },
             mode: 'lowest',
           });
           const endList = findNode(editor, {
-            at: Range.end(editor.selection as Range).path,
+            at: Range.end(editor.selection),
             match: { type: getListTypes(editor) },
             mode: 'lowest',
           });
@@ -93,7 +89,7 @@ export const toggleList = (editor: SPEditor, { type }: { type: string }) => {
             editor,
             { type },
             {
-              at: editor.selection as Range,
+              at: editor.selection,
               match: (n: TElement, path: Path) =>
                 getListTypes(editor).includes(n.type) &&
                 path.length >= rangeLength,
@@ -138,4 +134,3 @@ export const toggleList = (editor: SPEditor, { type }: { type: string }) => {
       }
     }
   });
-};

--- a/packages/elements/list/src/transforms/unwrapList.ts
+++ b/packages/elements/list/src/transforms/unwrapList.ts
@@ -1,35 +1,37 @@
 import {
   ELEMENT_DEFAULT,
+  getAbove,
   setNodes,
-  someNode,
   unwrapNodes,
 } from '@udecode/plate-common';
 import { getPlatePluginType, SPEditor } from '@udecode/plate-core';
-import { Path } from 'slate';
+import { Editor, Path } from 'slate';
 import { ELEMENT_LI, ELEMENT_OL, ELEMENT_UL } from '../defaults';
 import { getListTypes } from '../queries';
 
 export const unwrapList = (editor: SPEditor, { at }: { at?: Path } = {}) => {
-  do {
-    setNodes(editor, {
-      type: getPlatePluginType(editor, ELEMENT_DEFAULT),
-    });
+  Editor.withoutNormalizing(editor, () => {
+    do {
+      setNodes(editor, {
+        type: getPlatePluginType(editor, ELEMENT_DEFAULT),
+      });
 
-    unwrapNodes(editor, {
-      at,
-      match: { type: getPlatePluginType(editor, ELEMENT_LI) },
-      split: true,
-    });
+      unwrapNodes(editor, {
+        at,
+        match: { type: getPlatePluginType(editor, ELEMENT_LI) },
+        split: true,
+      });
 
-    unwrapNodes(editor, {
-      at,
-      match: {
-        type: [
-          getPlatePluginType(editor, ELEMENT_UL),
-          getPlatePluginType(editor, ELEMENT_OL),
-        ],
-      },
-      split: true,
-    });
-  } while (someNode(editor, { match: { type: getListTypes(editor) } }));
+      unwrapNodes(editor, {
+        at,
+        match: {
+          type: [
+            getPlatePluginType(editor, ELEMENT_UL),
+            getPlatePluginType(editor, ELEMENT_OL),
+          ],
+        },
+        split: true,
+      });
+    } while (getAbove(editor, { match: { type: getListTypes(editor), at } }));
+  });
 };

--- a/packages/elements/list/src/transforms/unwrapList.ts
+++ b/packages/elements/list/src/transforms/unwrapList.ts
@@ -1,30 +1,35 @@
-import { ELEMENT_DEFAULT, setNodes, unwrapNodes } from '@udecode/plate-common';
+import {
+  ELEMENT_DEFAULT,
+  setNodes,
+  someNode,
+  unwrapNodes,
+} from '@udecode/plate-common';
 import { getPlatePluginType, SPEditor } from '@udecode/plate-core';
 import { Path } from 'slate';
 import { ELEMENT_LI, ELEMENT_OL, ELEMENT_UL } from '../defaults';
+import { getListTypes } from '../queries';
 
 export const unwrapList = (editor: SPEditor, { at }: { at?: Path } = {}) => {
-  setNodes(
-    editor,
-    {
+  do {
+    setNodes(editor, {
       type: getPlatePluginType(editor, ELEMENT_DEFAULT),
-    },
-    { at }
-  );
+    });
 
-  unwrapNodes(editor, {
-    at,
-    match: { type: getPlatePluginType(editor, ELEMENT_LI) },
-  });
+    unwrapNodes(editor, {
+      at,
+      match: { type: getPlatePluginType(editor, ELEMENT_LI) },
+      split: true,
+    });
 
-  unwrapNodes(editor, {
-    at,
-    match: {
-      type: [
-        getPlatePluginType(editor, ELEMENT_UL),
-        getPlatePluginType(editor, ELEMENT_OL),
-      ],
-    },
-    split: true,
-  });
+    unwrapNodes(editor, {
+      at,
+      match: {
+        type: [
+          getPlatePluginType(editor, ELEMENT_UL),
+          getPlatePluginType(editor, ELEMENT_OL),
+        ],
+      },
+      split: true,
+    });
+  } while (someNode(editor, { match: { type: getListTypes(editor) } }));
 };

--- a/packages/ui/toolbar/src/ToolbarElement/ToolbarElement.tsx
+++ b/packages/ui/toolbar/src/ToolbarElement/ToolbarElement.tsx
@@ -5,7 +5,7 @@ import {
   toggleNodeType,
 } from '@udecode/plate-common';
 import { useEventEditorId, useStoreEditorState } from '@udecode/plate-core';
-import { ToolbarButton } from '../ToolbarButton/ToolbarButton';
+import { ToolbarButton } from '../ToolbarButton';
 import { ToolbarElementProps } from './ToolbarElement.types';
 
 /**
@@ -14,13 +14,16 @@ import { ToolbarElementProps } from './ToolbarElement.types';
 export const ToolbarElement = ({
   type,
   inactiveType,
+  active,
   ...props
 }: ToolbarElementProps) => {
   const editor = useStoreEditorState(useEventEditorId('focus'));
 
   return (
     <ToolbarButton
-      active={!!editor?.selection && someNode(editor, { match: { type } })}
+      active={
+        active ?? (!!editor?.selection && someNode(editor, { match: { type } }))
+      }
       onMouseDown={
         editor &&
         getPreventDefaultHandler(toggleNodeType, editor, {


### PR DESCRIPTION
List toggle had some issues when it came to changing type or revering it back to standard paragraphs this PR intends to fix those issues and it has a couple of test for the different usecases.

* Normalizer now merges lists with the same type next to each other also if a list has no lic and it has children it moves those childrens up a level 
* toggleList works as expected (check tests)
* ToolbarElement now uses the provided active prop
* ToolbarList leverages this since the default ToolbarElement solution would activate both button if there is an unordered list within a ordered list.
* moveListItemDown wrap transformations in withoutNormalizing (it caused a pathing issue since the normalization would remove the created empty list)