### PR TITLE
fix broken test

### DIFF
--- a/packages/autoformat/src/__tests__/withAutoformat/block/code-block.spec.tsx
+++ b/packages/autoformat/src/__tests__/withAutoformat/block/code-block.spec.tsx
@@ -34,7 +34,7 @@ describe('when ``` at block start', () => {
     const output = (
       <editor>
         <hp>hello</hp>
-        <hcodeblock lang="">
+        <hcodeblock>
           <hcodeline>new</hcodeline>
         </hcodeblock>
       </editor>
@@ -64,7 +64,7 @@ describe('when ``` at block start, but customising with query we get the most re
     const output = (
       <editor>
         <hp>hello</hp>
-        <hcodeblock lang="">
+        <hcodeblock>
           <hcodeline>inside code-block</hcodeline>
         </hcodeblock>
       </editor>
@@ -124,7 +124,7 @@ describe('when ```', () => {
     const output = (
       <editor>
         <hp>helloworld</hp>
-        <hcodeblock lang="">
+        <hcodeblock>
           <hcodeline>new</hcodeline>
         </hcodeblock>
       </editor>


### PR DESCRIPTION
**Description**

One of the tests was broken from the recent work in #1055

**Issue**

Fixes: broken test cases

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)