### PR TITLE
add missing key for iterating over languages for syntax highlighting

### DIFF
--- a/.changeset/smooth-squids-vanish.md
+++ b/.changeset/smooth-squids-vanish.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-code-block-ui": patch
+---
+
+add missing key for iterating over languages for syntax highlighting

--- a/packages/elements/code-block-ui/src/CodeBlockElement/CodeBlockSelectElement.tsx
+++ b/packages/elements/code-block-ui/src/CodeBlockElement/CodeBlockSelectElement.tsx
@@ -25,7 +25,9 @@ export const CodeBlockSelectElement = ({
     >
       <option value="">Plain text</option>
       {Object.entries(CODE_BLOCK_LANGUAGES).map(([key, val]) => (
-        <option value={key}>{val}</option>
+        <option key={key} value={key}>
+          {val}
+        </option>
       ))}
     </select>
   );


### PR DESCRIPTION
**Description**

Missed key when interating over map of language names in #1055 .

<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)