### PR TITLE
Fix code block paste

### DIFF
--- a/.changeset/forty-boats-unite.md
+++ b/.changeset/forty-boats-unite.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-code-block': patch
+---
+
+Pasting into a code block always adds codelines. All non code blocks are converted to text.

--- a/packages/elements/code-block/src/getCodeBlockInsertFragment.spec.tsx
+++ b/packages/elements/code-block/src/getCodeBlockInsertFragment.spec.tsx
@@ -1,0 +1,183 @@
+/** @jsx jsx */
+
+import { createEditorPlugins } from '@udecode/plate/src/utils/createEditorPlugins';
+import { SPEditor, TDescendant } from '@udecode/plate-core';
+import { createParagraphPlugin } from '@udecode/plate-paragraph';
+import { jsx } from '@udecode/plate-test-utils';
+import { createCodeBlockPlugin } from './createCodeBlockPlugin';
+
+jsx;
+
+const editorTest = (input: any, fragment: any, expected: any) => {
+  const editor = createEditorPlugins({
+    editor: input,
+    plugins: [createParagraphPlugin(), createCodeBlockPlugin()],
+  });
+
+  editor.insertFragment(fragment);
+
+  expect(editor.children).toEqual(expected.children);
+};
+
+describe('when pasting a code block', () => {
+  describe('when selection outside of code block', () => {
+    it('should paste only the fragment', () => {
+      const input = ((
+        <editor>
+          <hcodeblock>
+            <hcodeline>
+              <htext />
+            </hcodeline>
+          </hcodeblock>
+          <hp>
+            <cursor />
+          </hp>
+        </editor>
+      ) as any) as SPEditor;
+
+      const fragment = ((
+        <fragment>
+          <hcodeblock>
+            <hcodeline>
+              <htext />
+            </hcodeline>
+          </hcodeblock>
+        </fragment>
+      ) as any) as TDescendant[];
+
+      const expected = ((
+        <editor>
+          <hcodeblock>
+            <hcodeline>
+              <htext />
+            </hcodeline>
+          </hcodeblock>
+          <hcodeblock>
+            <hcodeline>
+              <htext />
+            </hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any) as SPEditor;
+
+      editorTest(input, fragment, expected);
+    });
+  });
+
+  describe('when selection in empty code line', () => {
+    it('should replace the code line', () => {
+      const input = ((
+        <editor>
+          <hcodeblock>
+            <hcodeline>
+              <htext />
+            </hcodeline>
+            <hcodeline>
+              <htext />
+              <cursor />
+            </hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any) as SPEditor;
+
+      const fragment = ((
+        <fragment>
+          <hcodeblock>
+            <hcodeline>hello world</hcodeline>
+          </hcodeblock>
+        </fragment>
+      ) as any) as TDescendant[];
+
+      const expected = ((
+        <editor>
+          <hcodeblock>
+            <hcodeline>
+              <htext />
+            </hcodeline>
+            <hcodeline>hello world</hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any) as SPEditor;
+
+      editorTest(input, fragment, expected);
+    });
+  });
+
+  describe('when selection in non-empty code line', () => {
+    it('should paste after the code line', () => {
+      const input = ((
+        <editor>
+          <hcodeblock>
+            <hcodeline>
+              <htext />
+            </hcodeline>
+            <hcodeline>
+              hello
+              <cursor />
+            </hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any) as SPEditor;
+
+      const fragment = ((
+        <fragment>
+          <hcodeblock>
+            <hcodeline>world</hcodeline>
+          </hcodeblock>
+        </fragment>
+      ) as any) as TDescendant[];
+
+      const expected = ((
+        <editor>
+          <hcodeblock>
+            <hcodeline>
+              <htext />
+            </hcodeline>
+            <hcodeline>hello</hcodeline>
+            <hcodeline>world</hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any) as SPEditor;
+
+      editorTest(input, fragment, expected);
+    });
+  });
+
+  describe('pasting non-code block elements', () => {
+    it('should extract text and paste code line', () => {
+      const input = ((
+        <editor>
+          <hcodeblock>
+            <hcodeline>
+              <htext />
+            </hcodeline>
+            <hcodeline>
+              hello
+              <cursor />
+            </hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any) as SPEditor;
+
+      const fragment = ((
+        <fragment>
+          <hp>world</hp>
+        </fragment>
+      ) as any) as TDescendant[];
+
+      const expected = ((
+        <editor>
+          <hcodeblock>
+            <hcodeline>
+              <htext />
+            </hcodeline>
+            <hcodeline>hello</hcodeline>
+            <hcodeline>world</hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any) as SPEditor;
+
+      editorTest(input, fragment, expected);
+    });
+  });
+});

--- a/packages/elements/code-block/src/getCodeBlockInsertFragment.ts
+++ b/packages/elements/code-block/src/getCodeBlockInsertFragment.ts
@@ -1,0 +1,52 @@
+import { findNode } from '@udecode/plate-common';
+import { getPlatePluginType, SPEditor, TDescendant } from '@udecode/plate-core';
+import { Node, Path, Transforms } from 'slate';
+import { ELEMENT_CODE_BLOCK, ELEMENT_CODE_LINE } from './defaults';
+
+export function getCodeBlockInsertFragment(editor: SPEditor) {
+  const { insertFragment } = editor;
+  const codeBlockType = getPlatePluginType(editor, ELEMENT_CODE_BLOCK);
+  const codeLineType = getPlatePluginType(editor, ELEMENT_CODE_LINE);
+
+  function convertNodeToCodeLine(node: TDescendant) {
+    return {
+      type: codeLineType,
+      children: [{ text: Node.string(node) }],
+    };
+  }
+
+  function extractCodeLinesFromCodeBlock(node: TDescendant) {
+    return node.children;
+  }
+
+  return (fragment: TDescendant[]) => {
+    const codeLineEntry = findNode(editor, {
+      match: { type: codeLineType },
+      mode: 'lowest',
+    });
+
+    if (codeLineEntry) {
+      const [codeLineNode, codeLinePath] = codeLineEntry;
+      const isEmptyCodeLine = Node.string(codeLineNode);
+
+      if (!isEmptyCodeLine) {
+        Transforms.removeNodes(editor, { at: codeLinePath });
+      }
+
+      return Transforms.insertNodes(
+        editor,
+        fragment.flatMap((node) =>
+          node.type === codeBlockType
+            ? extractCodeLinesFromCodeBlock(node)
+            : convertNodeToCodeLine(node)
+        ),
+        {
+          at: isEmptyCodeLine ? Path.next(codeLinePath) : codeLinePath,
+          select: true,
+        }
+      );
+    }
+
+    insertFragment(fragment);
+  };
+}

--- a/packages/elements/code-block/src/index.ts
+++ b/packages/elements/code-block/src/index.ts
@@ -13,3 +13,4 @@ export * from './types';
 export * from './withCodeBlock';
 export * from './queries/index';
 export * from './transforms/index';
+export * from './getCodeBlockInsertFragment';

--- a/packages/elements/code-block/src/withCodeBlock.ts
+++ b/packages/elements/code-block/src/withCodeBlock.ts
@@ -1,8 +1,8 @@
 import { SPEditor, WithOverride } from '@udecode/plate-core';
 import { ReactEditor } from 'slate-react';
-import { getCodeLineEntry } from './queries/getCodeLineEntry';
-import { getIndentDepth } from './queries/getIndentDepth';
-import { insertCodeLine } from './transforms/insertCodeLine';
+import { getCodeBlockInsertFragment } from './getCodeBlockInsertFragment';
+import { getCodeLineEntry, getIndentDepth } from './queries';
+import { insertCodeLine } from './transforms';
 
 export const withCodeBlock = (): WithOverride<ReactEditor & SPEditor> => (
   editor
@@ -30,6 +30,8 @@ export const withCodeBlock = (): WithOverride<ReactEditor & SPEditor> => (
 
     insertBreak();
   };
+
+  editor.insertFragment = getCodeBlockInsertFragment(editor);
 
   return editor;
 };


### PR DESCRIPTION
**Description**

Pasting into a code block should paste only code lines:

* If pasting a code block into a code line, extract the code lines
* If pasting a non-code block block into a code line, extract the text

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)
