### PR TITLE
Syntax highlight missing export

### DIFF
--- a/.changeset/selfish-carrots-shout.md
+++ b/.changeset/selfish-carrots-shout.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-code-block-ui': patch
+---
+
+Add missing export from index barrel for code-block-ui

--- a/packages/elements/code-block-ui/src/CodeBlockElement/index.ts
+++ b/packages/elements/code-block-ui/src/CodeBlockElement/index.ts
@@ -6,3 +6,4 @@ export * from './CodeBlockElement.styles';
 export * from './CodeBlockElement';
 export * from './CodeLineElement.styles';
 export * from './CodeLineElement';
+export * from './CodeBlockSelectElement';


### PR DESCRIPTION
**Description**

Missed an export in the barrel for code-block-ui

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

**Issue**

Fixes: Missed an export in the barrel for code-block-ui

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)