### PR TITLE
Syntax highlighting not editable

### DIFF
--- a/.changeset/odd-plums-join.md
+++ b/.changeset/odd-plums-join.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-code-block-ui': patch
+---
+
+Syntax highlighting select element should not be editable

--- a/packages/elements/code-block-ui/src/CodeBlockElement/CodeBlockSelectElement.tsx
+++ b/packages/elements/code-block-ui/src/CodeBlockElement/CodeBlockSelectElement.tsx
@@ -21,6 +21,7 @@ export const CodeBlockSelectElement = ({
         onChange(e.target.value);
         setValue(e.target.value);
       }}
+      contentEditable="false"
       {...props}
     >
       <option value="">Plain text</option>


### PR DESCRIPTION
**Description**

Syntax highlighting select element was editable which causes all sorts of issues.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

**Issue**

Fixes: Crashes when trying to edit a selection with the select element

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)