### PR TITLE
Syntax highlighting apply tokens

### DIFF
--- a/.changeset/happy-days-rush.md
+++ b/.changeset/happy-days-rush.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-code-block': patch
+---
+
+Fix check for language attribute for syntax highlighting

--- a/docs/src/live/config/initialValues.tsx
+++ b/docs/src/live/config/initialValues.tsx
@@ -795,6 +795,7 @@ export const initialValueBasicElements: any = [
   createElement('Blockquote', { type: ELEMENT_BLOCKQUOTE }),
   {
     type: ELEMENT_CODE_BLOCK,
+    lang: 'javascript',
     children: [
       {
         type: ELEMENT_CODE_LINE,
@@ -1138,7 +1139,12 @@ export const initialValueSoftBreak: any = [
   },
   {
     type: ELEMENT_CODE_BLOCK,
-    children: [{ text: 'And ⏎ here.' }],
+    children: [
+      {
+        type: ELEMENT_CODE_LINE,
+        children: [{ text: 'And ⏎ here.' }],
+      },
+    ],
   },
 ];
 
@@ -1178,7 +1184,12 @@ export const initialValueExitBreak: any = [
   },
   {
     type: ELEMENT_CODE_BLOCK,
-    children: [{ text: 'And in the middle ⌘⏎ of the block.' }],
+    children: [
+      {
+        type: ELEMENT_CODE_LINE,
+        children: [{ text: 'And in the middle ⌘⏎ of the block.' }],
+      },
+    ],
   },
   {
     type: ELEMENT_PARAGRAPH,

--- a/packages/elements/code-block/src/getCodeBlockDecorate.ts
+++ b/packages/elements/code-block/src/getCodeBlockDecorate.ts
@@ -66,7 +66,7 @@ export const getCodeBlockDecorate = (): Decorate => (editor) => {
     }
     const lang = languages[langName];
 
-    if (!lang || !Text.isText(node)) {
+    if (!lang) {
       return ranges;
     }
 

--- a/packages/elements/code-block/src/getCodeLineDecorate.ts
+++ b/packages/elements/code-block/src/getCodeLineDecorate.ts
@@ -52,17 +52,18 @@ import {
 } from '@udecode/plate-core';
 import { Node, NodeEntry, Text } from 'slate';
 import { getParent } from '@udecode/plate-common';
-import { ELEMENT_CODE_LINE } from './defaults';
+import { ELEMENT_CODE_BLOCK, ELEMENT_CODE_LINE } from './defaults';
 
 export const getCodeLineDecorate = (): Decorate => (editor) => {
   const code_line = getPlatePluginOptions(editor, ELEMENT_CODE_LINE);
+  const code_block = getPlatePluginOptions(editor, ELEMENT_CODE_BLOCK);
 
   return (entry: NodeEntry) => {
     const ranges: any = [];
     const [node, path] = entry;
     const codeBlock = getParent(editor, path);
     let langName = '';
-    if (isElement(codeBlock)) {
+    if (codeBlock?.[0].type === code_block.type) {
       const [codeBlockNode] = codeBlock;
       langName = codeBlockNode?.lang;
     }
@@ -72,7 +73,7 @@ export const getCodeLineDecorate = (): Decorate => (editor) => {
     }
     const lang = languages[langName];
 
-    if (!lang || !Text.isText(node)) {
+    if (!lang) {
       return ranges;
     }
 


### PR DESCRIPTION
**Description**

The condition for verifying the parent of a code_line was a code_block was not quite right. Also restricting to text only was not allowing all syntax highlighting to get applied.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)