### PR TITLE
Syntax highlighting propagation

### DIFF
--- a/.changeset/fast-pandas-dance.md
+++ b/.changeset/fast-pandas-dance.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-code-block-ui': patch
+---
+
+Prevent event propagation for clicking on syntax highlight language selector

--- a/packages/elements/code-block-ui/src/CodeBlockElement/CodeBlockSelectElement.tsx
+++ b/packages/elements/code-block-ui/src/CodeBlockElement/CodeBlockSelectElement.tsx
@@ -17,6 +17,9 @@ export const CodeBlockSelectElement = ({
     <select
       value={value}
       style={{ float: 'right' }}
+      onClick={(e) => {
+        e.stopPropagation();
+      }}
       onChange={(e) => {
         onChange(e.target.value);
         setValue(e.target.value);


### PR DESCRIPTION
**Description**

Click events on the select element were bleeding click events up the tree to causing the select element to close prematurely due to focus events firing on the editor.

**Issue**

Fixes: dropdown won't close prematurely.

**Example**

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)