### PR TITLE
feat: refactor removeMark with multiple marks and location options

### DIFF
--- a/.changeset/good-points-reply.md
+++ b/.changeset/good-points-reply.md
@@ -1,0 +1,7 @@
+---
+"@udecode/plate-common": minor
+---
+
+`removeMark`:
+- `key` can be an array (to remove multiple marks)
+- `options` are extended so we can use other location than `editor.selection`

--- a/packages/autoformat/src/transforms/autoformatMark.ts
+++ b/packages/autoformat/src/transforms/autoformatMark.ts
@@ -65,7 +65,7 @@ export const autoformatMark = (
     });
     Transforms.collapse(editor, { edge: 'end' });
     marks.forEach((mark) => {
-      removeMark(editor, { key: mark, shouldChange: false });
+      removeMark(editor, { key: mark });
     });
 
     Transforms.delete(editor, {

--- a/packages/autoformat/src/transforms/autoformatMark.ts
+++ b/packages/autoformat/src/transforms/autoformatMark.ts
@@ -65,7 +65,7 @@ export const autoformatMark = (
     });
     Transforms.collapse(editor, { edge: 'end' });
     marks.forEach((mark) => {
-      removeMark(editor, { key: mark });
+      removeMark(editor, { key: mark, shouldChange: false });
     });
 
     Transforms.delete(editor, {

--- a/packages/common/src/transforms/removeMark.ts
+++ b/packages/common/src/transforms/removeMark.ts
@@ -1,31 +1,18 @@
 import { TEditor } from '@udecode/plate-core';
-import { Editor, Range, Text, Transforms } from 'slate';
+import { Text, Transforms } from 'slate';
+import { SetNodesOptions } from '../types';
 
 /**
  * Remove mark and trigger `onChange` if collapsed selection.
  */
 export const removeMark = (
   editor: TEditor,
-  {
-    key,
-    shouldChange = true,
-  }: {
-    key: string;
-    shouldChange?: boolean;
-  }
+  key: string | string[],
+  options: Omit<SetNodesOptions, 'match' | 'split'>
 ) => {
-  const { selection } = editor;
-  if (selection) {
-    if (Range.isExpanded(selection)) {
-      Transforms.unsetNodes(editor, key, {
-        match: Text.isText,
-        split: true,
-      });
-    } else {
-      const marks = { ...(Editor.marks(editor) || {}) };
-      delete marks[key];
-      editor.marks = marks;
-      shouldChange && editor.onChange();
-    }
-  }
+  Transforms.unsetNodes(editor, key, {
+    match: Text.isText,
+    split: true,
+    ...options,
+  });
 };

--- a/packages/common/src/transforms/removeMark.ts
+++ b/packages/common/src/transforms/removeMark.ts
@@ -1,18 +1,53 @@
 import { TEditor } from '@udecode/plate-core';
-import { Text, Transforms } from 'slate';
+import { castArray } from 'lodash';
+import { Editor, Range, Text, Transforms } from 'slate';
 import { SetNodesOptions } from '../types';
+
+export interface RemoveMarkOptions
+  extends Omit<SetNodesOptions, 'match' | 'split'> {
+  /**
+   * Mark or the array of marks that will be removed
+   */
+  key: string | string[];
+
+  /**
+   * When location is not a Range,
+   * setting this to false can prevent the onChange event of the editor to fire
+   * @default true
+   */
+  shouldChange?: boolean;
+
+  /**
+   * Range where the mark(s) will be removed
+   */
+  at?: Range;
+}
 
 /**
  * Remove mark and trigger `onChange` if collapsed selection.
  */
 export const removeMark = (
   editor: TEditor,
-  key: string | string[],
-  options: Omit<SetNodesOptions, 'match' | 'split'>
+  { key, at, shouldChange = true, ...rest }: RemoveMarkOptions
 ) => {
-  Transforms.unsetNodes(editor, key, {
-    match: Text.isText,
-    split: true,
-    ...options,
-  });
+  const selection = at ?? editor.selection;
+  key = castArray(key);
+
+  if (selection) {
+    if (Range.isRange(selection) && Range.isExpanded(selection)) {
+      Transforms.unsetNodes(editor, key, {
+        at: selection,
+        match: Text.isText,
+        split: true,
+        ...rest,
+      });
+    } else if (editor.selection) {
+      const marks = { ...(Editor.marks(editor) || {}) };
+      key.forEach((k) => {
+        delete marks[k];
+      });
+      editor.marks = marks;
+      shouldChange && editor.onChange();
+    }
+  }
 };


### PR DESCRIPTION
* it simplifies `removeMark`
* enables the usage of array of marks 
* adds the ability to specify the location of the operation instead of just limiting it to editor.selection