### PR TITLE
fix-onChange-memo

### DIFF
--- a/.changeset/thick-phones-listen.md
+++ b/.changeset/thick-phones-listen.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-core": patch
+---
+
+fix: performance issue when passing `value` prop to `Plate`

--- a/packages/core/src/hooks/usePlate/useSlateProps.ts
+++ b/packages/core/src/hooks/usePlate/useSlateProps.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { usePlateActions } from '../../stores/plate/plate.actions';
 import { useStoreEditorRef } from '../../stores/plate/selectors/useStoreEditorRef';
 import { useStoreEditorValue } from '../../stores/plate/selectors/useStoreEditorValue';
@@ -20,23 +20,28 @@ export const useSlateProps = ({
   const value = useStoreEditorValue(id);
   const plugins = useStorePlate(id);
 
+  const onChange = useCallback(
+    (newValue: TNode[]) => {
+      if (!editor) return;
+
+      const eventIsHandled = pipeOnChange(editor, plugins)(newValue);
+
+      if (!eventIsHandled) {
+        _onChange?.(newValue);
+      }
+
+      setValue(newValue);
+    },
+    [_onChange, editor, plugins, setValue]
+  );
+
   return useMemo(
     () => ({
       key: editor?.key,
       editor,
-      onChange: (newValue: TNode[]) => {
-        if (!editor) return;
-
-        const eventIsHandled = pipeOnChange(editor, plugins)(newValue);
-
-        if (!eventIsHandled) {
-          _onChange?.(newValue);
-        }
-
-        setValue(newValue);
-      },
+      onChange,
       value,
     }),
-    [_onChange, editor, plugins, setValue, value]
+    [editor, onChange, value]
   );
 };


### PR DESCRIPTION
> If I pass the state value to plate it re-renders the whole editor for each change and the editor was insanely slow. But after stops passing the value to plate, the editor performance was good.

Fix: memoize onChange