### PR TITLE
refactor: functions that use removeMark

### DIFF
--- a/packages/autoformat/src/transforms/autoformatMark.ts
+++ b/packages/autoformat/src/transforms/autoformatMark.ts
@@ -64,9 +64,7 @@ export const autoformatMark = (
       editor.addMark(mark, true);
     });
     Transforms.collapse(editor, { edge: 'end' });
-    marks.forEach((mark) => {
-      removeMark(editor, { key: mark, shouldChange: false });
-    });
+    removeMark(editor, { key: marks, shouldChange: false });
 
     Transforms.delete(editor, {
       at: {

--- a/packages/common/src/transforms/setMarks.ts
+++ b/packages/common/src/transforms/setMarks.ts
@@ -1,6 +1,6 @@
 import { TEditor } from '@udecode/plate-core';
 import castArray from 'lodash/castArray';
-import { isMarkActive } from '../queries/isMarkActive';
+import { Editor } from 'slate';
 import { removeMark } from './removeMark';
 
 /**
@@ -13,18 +13,13 @@ export const setMarks = (
 ) => {
   if (!editor.selection) return;
 
-  const clears: string[] = castArray(clear);
-  clears.forEach((item) => {
-    removeMark(editor, { key: item });
-  });
+  Editor.withoutNormalizing(editor, () => {
+    const clears: string[] = castArray(clear);
+    removeMark(editor, { key: clears });
+    removeMark(editor, { key: Object.keys(marks) });
 
-  Object.keys(marks).forEach((key) => {
-    const markIsActive = isMarkActive(editor, key);
-
-    if (markIsActive) {
-      removeMark(editor, { key });
-    }
-
-    editor.addMark(key, marks[key]);
+    Object.keys(marks).forEach((key) => {
+      editor.addMark(key, marks[key]);
+    });
   });
 };

--- a/packages/common/src/transforms/toggleMark.ts
+++ b/packages/common/src/transforms/toggleMark.ts
@@ -1,10 +1,12 @@
 import { TEditor } from '@udecode/plate-core';
 import castArray from 'lodash/castArray';
+import { Editor } from 'slate';
 import { isMarkActive } from '../queries/isMarkActive';
 import { removeMark } from './removeMark';
 
 /**
  * Add/remove marks in the selection.
+ * @param editor
  * @param key mark to toggle
  * @param clear marks to clear when adding mark
  */
@@ -15,17 +17,17 @@ export const toggleMark = (
 ) => {
   if (!editor.selection) return;
 
-  const isActive = isMarkActive(editor, key);
+  Editor.withoutNormalizing(editor, () => {
+    const isActive = isMarkActive(editor, key);
 
-  if (isActive) {
-    removeMark(editor, { key });
-    return;
-  }
+    if (isActive) {
+      removeMark(editor, { key });
+      return;
+    }
 
-  const clears: string[] = castArray(clear);
-  clears.forEach((item) => {
-    removeMark(editor, { key: item });
+    const clears: string[] = castArray(clear);
+    removeMark(editor, { key: clears });
+
+    editor.addMark(key, true);
   });
-
-  editor.addMark(key, true);
 };


### PR DESCRIPTION
Remove mark can now handle arrays as input, so functions that uses removeMark could be leverage that.

@zbeyens I added `withoutNormalize` to some of the functions I'm not 100% sure if it's needed, but it seemed logical to me, please check them.