### PR TITLE
Mention improvements

### DIFF
--- a/.changeset/chilled-drinks-train.md
+++ b/.changeset/chilled-drinks-train.md
@@ -3,4 +3,5 @@
 '@udecode/plate-combobox': patch
 ---
 
-Improve type definitions for MentionCombobox
+* Improve type definitions for MentionCombobox
+* Allow override of id, trigger when invoking MentionCombobox

--- a/packages/elements/mention-ui/src/MentionCombobox.tsx
+++ b/packages/elements/mention-ui/src/MentionCombobox.tsx
@@ -12,22 +12,25 @@ import {
 
 const onSelectMentionItem = getMentionOnSelectItem();
 
-const id = ELEMENT_MENTION;
-
 export const MentionCombobox = ({
   items,
   component,
   onRenderItem,
-}: Pick<ComboboxProps, 'items' | 'component' | 'onRenderItem'>) => {
+  id,
+  trigger,
+}: Pick<ComboboxProps, 'items' | 'component' | 'onRenderItem'> & {
+  id?: string;
+  trigger?: string;
+}) => {
   const activeId = comboboxStore.use.activeId();
 
   useEffect(() => {
     comboboxStore.set.setComboboxById({
-      id,
-      trigger: COMBOBOX_TRIGGER_MENTION,
+      id: id || ELEMENT_MENTION,
+      trigger: trigger || COMBOBOX_TRIGGER_MENTION,
       onSelectItem: onSelectMentionItem,
     });
-  }, []);
+  }, [id, trigger]);
 
   if (activeId !== id) return null;
 

--- a/packages/ui/combobox/src/combobox.store.ts
+++ b/packages/ui/combobox/src/combobox.store.ts
@@ -30,7 +30,7 @@ export type ComboboxStateById = {
   /**
    * Called when an item is selected.
    */
-  onSelectItem?: ComboboxOnSelectItem;
+  onSelectItem: ComboboxOnSelectItem | null;
 };
 
 export type ComboboxStoreById = StoreApi<


### PR DESCRIPTION
**Description**

A couple of small type improvements to improve the flexibility of the new `Mention` and `Combobox`.

**Issue**

* Could not specify custom `onRenderItem` or `component` for `MentionCombobox`
* ~`Combobox` required `onSelectItem` to be specified or null, instead of being optional.~ (reverted as it breaks things)
* Allow `MentionCombobox` to accept `trigger` and `id` without need to completely override `ComboboxStore`

Fixes: 

Two issues listed.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)