### PR TITLE
Fix deserialization outside code block

### DIFF
--- a/.changeset/sour-jars-hope.md
+++ b/.changeset/sour-jars-hope.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-code-block': patch
+---
+
+Limit disabling deserialization only when selection in code line.

--- a/packages/elements/code-block/src/getCodeBlockDeserialize.spec.tsx
+++ b/packages/elements/code-block/src/getCodeBlockDeserialize.spec.tsx
@@ -1,0 +1,75 @@
+/** @jsx jsx */
+
+import { createEditorPlugins } from '@udecode/plate';
+import {
+  astDeserializerId,
+  createDeserializeAstPlugin,
+} from '@udecode/plate-ast-serializer';
+import { SPEditor } from '@udecode/plate-core';
+import {
+  createDeserializeHTMLPlugin,
+  htmlDeserializerId,
+} from '@udecode/plate-html-serializer';
+import { createParagraphPlugin } from '@udecode/plate-paragraph';
+import { jsx } from '@udecode/plate-test-utils';
+import { createCodeBlockPlugin } from './createCodeBlockPlugin';
+import { getCodeBlockDeserialize } from './getCodeBlockDeserialize';
+
+jsx;
+
+const createCodeBlockDeserialize = <TEditor extends SPEditor = SPEditor>(
+  input: TEditor
+) => {
+  const plugins = [createParagraphPlugin(), createCodeBlockPlugin()];
+
+  plugins.push(
+    createDeserializeHTMLPlugin({ plugins }),
+    createDeserializeAstPlugin({ plugins })
+  );
+
+  return getCodeBlockDeserialize()(
+    createEditorPlugins({
+      editor: input,
+      plugins,
+    })
+  );
+};
+
+describe('code block deserialization', () => {
+  describe('when selection in code line', () => {
+    it('should disable all deserializers except the ast serializer', () => {
+      const input = ((
+        <editor>
+          <hcodeblock>
+            <hcodeline>
+              <htext />
+              <cursor />
+            </hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any) as SPEditor;
+
+      const { isDisabled } = createCodeBlockDeserialize(input);
+
+      expect(isDisabled?.(astDeserializerId)).toEqual(false);
+      expect(isDisabled?.(htmlDeserializerId)).toEqual(true);
+    });
+  });
+
+  describe('when selection outside of code line', () => {
+    it('should not affect deserialization', () => {
+      const input = ((
+        <editor>
+          <hp>
+            <htext />
+          </hp>
+        </editor>
+      ) as any) as SPEditor;
+
+      const { isDisabled } = createCodeBlockDeserialize(input);
+
+      expect(isDisabled?.(astDeserializerId)).toEqual(false);
+      expect(isDisabled?.(htmlDeserializerId)).toEqual(false);
+    });
+  });
+});

--- a/packages/elements/code-block/src/getCodeBlockDeserialize.ts
+++ b/packages/elements/code-block/src/getCodeBlockDeserialize.ts
@@ -1,4 +1,4 @@
-import { getElementDeserializer } from '@udecode/plate-common';
+import { findNode, getElementDeserializer } from '@udecode/plate-common';
 import { Deserialize, getSlateClass } from '@udecode/plate-core';
 import { getCodeBlockPluginOptions, getCodeLinePluginOptions } from './options';
 
@@ -7,8 +7,15 @@ export const getCodeBlockDeserialize = (): Deserialize => (editor) => {
   const code_line = getCodeLinePluginOptions(editor);
 
   return {
-    isDisabled: (deserializerId) =>
-      !code_block.deserializers?.includes(deserializerId),
+    isDisabled: (deserializerId) => {
+      const isSelectionInCodeLine =
+        findNode(editor, { match: { type: code_line.type } }) !== undefined;
+
+      return (
+        isSelectionInCodeLine &&
+        !code_block.deserializers?.includes(deserializerId)
+      );
+    },
     element: [
       ...getElementDeserializer({
         type: code_block.type,


### PR DESCRIPTION
**Description**

The code block plugin was disabling deserialization outside of code blocks. This PR limits fixes it so that deserialization is only disabled inside code blocks.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
