### PR TITLE
Make ComboboxProps a generic with an TItemData parameter

### DIFF
--- a/.changeset/hungry-spies-rest.md
+++ b/.changeset/hungry-spies-rest.md
@@ -1,0 +1,6 @@
+---
+'@udecode/plate-mention-ui': patch
+'@udecode/plate-combobox': patch
+---
+
+Parametrize ComboboxProps to allow for tweaking of item data type.

--- a/docs/src/live/config/mentionables.ts
+++ b/docs/src/live/config/mentionables.ts
@@ -1,6 +1,6 @@
-import { ComboboxItemData } from '@udecode/plate';
+import { TComboboxItem } from '@udecode/plate';
 
-export const MENTIONABLES: ComboboxItemData[] = [
+export const MENTIONABLES: TComboboxItem<{ email: string }>[] = [
   { key: '0', text: 'Aayla Secura', data: { email: 'aayla_secura@force.com' } },
   { key: '1', text: 'Adi Gallia', data: { email: 'adi_gallia@force.com' } },
   {

--- a/packages/elements/mention-ui/src/MentionCombobox/MentionCombobox.tsx
+++ b/packages/elements/mention-ui/src/MentionCombobox/MentionCombobox.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { Combobox, ComboboxProps } from '@udecode/plate-combobox';
+import {
+  Combobox,
+  ComboboxProps,
+  ItemData,
+  NoItemData,
+} from '@udecode/plate-combobox';
 import { PlatePluginKey } from '@udecode/plate-core';
 import {
   COMBOBOX_TRIGGER_MENTION,
@@ -8,7 +13,7 @@ import {
   getMentionOnSelectItem,
 } from '@udecode/plate-mention';
 
-export const MentionCombobox = ({
+export const MentionCombobox = <TItemData extends ItemData = NoItemData>({
   items,
   component,
   onRenderItem,
@@ -17,11 +22,11 @@ export const MentionCombobox = ({
   trigger = COMBOBOX_TRIGGER_MENTION,
   insertSpaceAfterMention,
   createMentionNode,
-}: Pick<ComboboxProps, 'items' | 'component' | 'onRenderItem'> & {
+}: Pick<ComboboxProps<TItemData>, 'items' | 'component' | 'onRenderItem'> & {
   id?: string;
   trigger?: string;
   insertSpaceAfterMention?: boolean;
-  createMentionNode?: CreateMentionNode;
+  createMentionNode?: CreateMentionNode<TItemData>;
 } & PlatePluginKey) => (
   <Combobox
     id={id}

--- a/packages/elements/mention-ui/src/MentionCombobox/MentionCombobox.tsx
+++ b/packages/elements/mention-ui/src/MentionCombobox/MentionCombobox.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  Combobox,
-  ComboboxProps,
-  ItemData,
-  NoItemData,
-} from '@udecode/plate-combobox';
+import { Combobox, ComboboxProps, Data, NoData } from '@udecode/plate-combobox';
 import { PlatePluginKey } from '@udecode/plate-core';
 import {
   COMBOBOX_TRIGGER_MENTION,
@@ -13,7 +8,7 @@ import {
   getMentionOnSelectItem,
 } from '@udecode/plate-mention';
 
-export const MentionCombobox = <TItemData extends ItemData = NoItemData>({
+export const MentionCombobox = <TData extends Data = NoData>({
   items,
   component,
   onRenderItem,
@@ -22,11 +17,11 @@ export const MentionCombobox = <TItemData extends ItemData = NoItemData>({
   trigger = COMBOBOX_TRIGGER_MENTION,
   insertSpaceAfterMention,
   createMentionNode,
-}: Pick<ComboboxProps<TItemData>, 'items' | 'component' | 'onRenderItem'> & {
+}: Pick<ComboboxProps<TData>, 'items' | 'component' | 'onRenderItem'> & {
   id?: string;
   trigger?: string;
   insertSpaceAfterMention?: boolean;
-  createMentionNode?: CreateMentionNode<TItemData>;
+  createMentionNode?: CreateMentionNode<TData>;
 } & PlatePluginKey) => (
   <Combobox
     id={id}

--- a/packages/elements/mention/CHANGELOG.md
+++ b/packages/elements/mention/CHANGELOG.md
@@ -115,9 +115,9 @@
     - `mentionables`: moved to `items` in `comboboxStore`
     - `mentionableFilter`: moved to `filter` in `comboboxStore`
   - removed `matchesTriggerAndPattern` in favor of `getTextFromTrigger`
-  - removed `MentionNodeData` in favor of `ComboboxItemData`
+  - removed `MentionNodeData` in favor of `TComboboxItem`
   ```ts
-  export interface ComboboxItemData {
+  export interface TComboboxItem {
     /**
      * Unique key.
      */

--- a/packages/elements/mention/src/getMentionOnSelectItem.ts
+++ b/packages/elements/mention/src/getMentionOnSelectItem.ts
@@ -2,6 +2,7 @@ import {
   ComboboxItemData,
   ComboboxOnSelectItem,
   comboboxStore,
+  ItemData,
 } from '@udecode/plate-combobox';
 import { getBlockAbove, insertNodes } from '@udecode/plate-common';
 import {
@@ -14,18 +15,18 @@ import { ELEMENT_MENTION, ELEMENT_MENTION_INPUT } from './defaults';
 // FIXME: Cannot figure out the TS for this to work with insertNodes
 // import { MentionNodeData } from './types';
 
-export interface CreateMentionNode {
-  (item: ComboboxItemData): Record<string, unknown>;
+export interface CreateMentionNode<TItemData extends ItemData> {
+  (item: ComboboxItemData<TItemData>): Record<string, unknown>;
 }
 
-export const getMentionOnSelectItem = ({
+export const getMentionOnSelectItem = <TItemData extends ItemData>({
   pluginKey = ELEMENT_MENTION,
   createMentionNode = (item) => ({ value: item.text }),
   insertSpaceAfterMention,
 }: {
-  createMentionNode?: CreateMentionNode;
+  createMentionNode?: CreateMentionNode<TItemData>;
   insertSpaceAfterMention?: boolean;
-} & PlatePluginKey = {}): ComboboxOnSelectItem => (editor, item) => {
+} & PlatePluginKey = {}): ComboboxOnSelectItem<TItemData> => (editor, item) => {
   const targetRange = comboboxStore.get.targetRange();
   if (!targetRange) return;
 

--- a/packages/elements/mention/src/getMentionOnSelectItem.ts
+++ b/packages/elements/mention/src/getMentionOnSelectItem.ts
@@ -1,8 +1,9 @@
 import {
-  ComboboxItemData,
   ComboboxOnSelectItem,
   comboboxStore,
-  ItemData,
+  Data,
+  NoData,
+  TComboboxItem,
 } from '@udecode/plate-combobox';
 import { getBlockAbove, insertNodes } from '@udecode/plate-common';
 import {
@@ -15,18 +16,18 @@ import { ELEMENT_MENTION, ELEMENT_MENTION_INPUT } from './defaults';
 // FIXME: Cannot figure out the TS for this to work with insertNodes
 // import { MentionNodeData } from './types';
 
-export interface CreateMentionNode<TItemData extends ItemData> {
-  (item: ComboboxItemData<TItemData>): Record<string, unknown>;
+export interface CreateMentionNode<TData extends Data> {
+  (item: TComboboxItem<TData>): Record<string, unknown>;
 }
 
-export const getMentionOnSelectItem = <TItemData extends ItemData>({
+export const getMentionOnSelectItem = <TData extends Data = NoData>({
   pluginKey = ELEMENT_MENTION,
   createMentionNode = (item) => ({ value: item.text }),
   insertSpaceAfterMention,
 }: {
-  createMentionNode?: CreateMentionNode<TItemData>;
+  createMentionNode?: CreateMentionNode<TData>;
   insertSpaceAfterMention?: boolean;
-} & PlatePluginKey = {}): ComboboxOnSelectItem<TItemData> => (editor, item) => {
+} & PlatePluginKey = {}): ComboboxOnSelectItem<TData> => (editor, item) => {
   const targetRange = comboboxStore.get.targetRange();
   if (!targetRange) return;
 

--- a/packages/ui/combobox/src/combobox.store.ts
+++ b/packages/ui/combobox/src/combobox.store.ts
@@ -1,10 +1,10 @@
 import { UsePopperOptions } from '@udecode/plate-popper';
 import { createStore, StateActions, StoreApi } from '@udecode/zustood';
 import { Range } from 'slate';
-import { ComboboxItemData, NoItemData } from './components';
+import { NoData, TComboboxItem } from './components';
 import { ComboboxOnSelectItem } from './types';
 
-export type ComboboxStateById<TItemData = NoItemData> = {
+export type ComboboxStateById<TData = NoData> = {
   /**
    * Combobox id.
    */
@@ -14,7 +14,7 @@ export type ComboboxStateById<TItemData = NoItemData> = {
    * Items filter function by text.
    * @default (value) => value.text.toLowerCase().startsWith(search.toLowerCase())
    */
-  filter?: (search: string) => (item: ComboboxItemData<TItemData>) => boolean;
+  filter?: (search: string) => (item: TComboboxItem<TData>) => boolean;
 
   /**
    * Max number of items.
@@ -35,7 +35,7 @@ export type ComboboxStateById<TItemData = NoItemData> = {
   /**
    * Called when an item is selected.
    */
-  onSelectItem: ComboboxOnSelectItem<TItemData> | null;
+  onSelectItem: ComboboxOnSelectItem<TData> | null;
 
   /**
    * Is opening/closing the combobox controlled by the client.
@@ -43,13 +43,13 @@ export type ComboboxStateById<TItemData = NoItemData> = {
   controlled?: boolean;
 };
 
-export type ComboboxStoreById<TItemData = NoItemData> = StoreApi<
+export type ComboboxStoreById<TData = NoData> = StoreApi<
   string,
-  ComboboxStateById<TItemData>,
-  StateActions<ComboboxStateById<TItemData>>
+  ComboboxStateById<TData>,
+  StateActions<ComboboxStateById<TData>>
 >;
 
-export type ComboboxState<TItemData = NoItemData> = {
+export type ComboboxState<TData = NoData> = {
   /**
    * Active id (combobox id which is opened).
    */
@@ -64,12 +64,12 @@ export type ComboboxState<TItemData = NoItemData> = {
   /**
    * Unfiltered items.
    */
-  items: ComboboxItemData<TItemData>[];
+  items: TComboboxItem<TData>[];
 
   /**
    * Filtered items
    */
-  filteredItems: ComboboxItemData<TItemData>[];
+  filteredItems: TComboboxItem<TData>[];
 
   /**
    * Highlighted index.
@@ -111,9 +111,7 @@ export const comboboxStore = createStore('combobox')<ComboboxState>({
   text: null,
 })
   .extendActions((set, get) => ({
-    setComboboxById: <TItemData = NoItemData>(
-      state: ComboboxStateById<TItemData>
-    ) => {
+    setComboboxById: <TData = NoData>(state: ComboboxStateById<TData>) => {
       if (get.byId()[state.id]) return;
 
       set.state((draft) => {

--- a/packages/ui/combobox/src/combobox.store.ts
+++ b/packages/ui/combobox/src/combobox.store.ts
@@ -1,10 +1,10 @@
 import { UsePopperOptions } from '@udecode/plate-popper';
 import { createStore, StateActions, StoreApi } from '@udecode/zustood';
 import { Range } from 'slate';
-import { ComboboxItemData } from './components/Combobox.types';
-import { ComboboxOnSelectItem } from './types/ComboboxOnSelectItem';
+import { ComboboxItemData, NoItemData } from './components';
+import { ComboboxOnSelectItem } from './types';
 
-export type ComboboxStateById = {
+export type ComboboxStateById<TItemData = NoItemData> = {
   /**
    * Combobox id.
    */
@@ -14,7 +14,7 @@ export type ComboboxStateById = {
    * Items filter function by text.
    * @default (value) => value.text.toLowerCase().startsWith(search.toLowerCase())
    */
-  filter?: (search: string) => (item: ComboboxItemData) => boolean;
+  filter?: (search: string) => (item: ComboboxItemData<TItemData>) => boolean;
 
   /**
    * Max number of items.
@@ -35,7 +35,7 @@ export type ComboboxStateById = {
   /**
    * Called when an item is selected.
    */
-  onSelectItem: ComboboxOnSelectItem | null;
+  onSelectItem: ComboboxOnSelectItem<TItemData> | null;
 
   /**
    * Is opening/closing the combobox controlled by the client.
@@ -43,13 +43,13 @@ export type ComboboxStateById = {
   controlled?: boolean;
 };
 
-export type ComboboxStoreById = StoreApi<
+export type ComboboxStoreById<TItemData = NoItemData> = StoreApi<
   string,
-  ComboboxStateById,
-  StateActions<ComboboxStateById>
+  ComboboxStateById<TItemData>,
+  StateActions<ComboboxStateById<TItemData>>
 >;
 
-export type ComboboxState = {
+export type ComboboxState<TItemData = NoItemData> = {
   /**
    * Active id (combobox id which is opened).
    */
@@ -64,12 +64,12 @@ export type ComboboxState = {
   /**
    * Unfiltered items.
    */
-  items: ComboboxItemData[];
+  items: ComboboxItemData<TItemData>[];
 
   /**
    * Filtered items
    */
-  filteredItems: ComboboxItemData[];
+  filteredItems: ComboboxItemData<TItemData>[];
 
   /**
    * Highlighted index.
@@ -111,11 +111,15 @@ export const comboboxStore = createStore('combobox')<ComboboxState>({
   text: null,
 })
   .extendActions((set, get) => ({
-    setComboboxById: (state: ComboboxStateById) => {
+    setComboboxById: <TItemData = NoItemData>(
+      state: ComboboxStateById<TItemData>
+    ) => {
       if (get.byId()[state.id]) return;
 
       set.state((draft) => {
-        draft.byId[state.id] = createComboboxStore(state);
+        draft.byId[state.id] = createComboboxStore(
+          (state as unknown) as ComboboxStateById
+        );
       });
     },
     open: (state: Pick<ComboboxState, 'activeId' | 'targetRange' | 'text'>) => {

--- a/packages/ui/combobox/src/components/Combobox.styles.ts
+++ b/packages/ui/combobox/src/components/Combobox.styles.ts
@@ -1,9 +1,11 @@
 import { createStyles } from '@udecode/plate-styled-components';
 import { css } from 'styled-components';
 import tw from 'twin.macro';
-import { ComboboxStyleProps } from './Combobox.types';
+import { ComboboxStyleProps, ItemData } from './Combobox.types';
 
-export const getComboboxStyles = (props: ComboboxStyleProps) => {
+export const getComboboxStyles = <TItemData extends ItemData>(
+  props: ComboboxStyleProps<TItemData>
+) => {
   const item = [
     tw`flex items-center px-2 cursor-pointer`,
     css`

--- a/packages/ui/combobox/src/components/Combobox.styles.ts
+++ b/packages/ui/combobox/src/components/Combobox.styles.ts
@@ -1,10 +1,10 @@
 import { createStyles } from '@udecode/plate-styled-components';
 import { css } from 'styled-components';
 import tw from 'twin.macro';
-import { ComboboxStyleProps, ItemData } from './Combobox.types';
+import { ComboboxStyleProps, Data } from './Combobox.types';
 
-export const getComboboxStyles = <TItemData extends ItemData>(
-  props: ComboboxStyleProps<TItemData>
+export const getComboboxStyles = <TData extends Data>(
+  props: ComboboxStyleProps<TData>
 ) => {
   const item = [
     tw`flex items-center px-2 cursor-pointer`,

--- a/packages/ui/combobox/src/components/Combobox.tsx
+++ b/packages/ui/combobox/src/components/Combobox.tsx
@@ -14,10 +14,15 @@ import {
 } from '../combobox.store';
 import { useComboboxControls } from '../hooks';
 import { getComboboxStyles } from './Combobox.styles';
-import { ComboboxProps } from './Combobox.types';
+import {
+  ComboboxItemData,
+  ComboboxProps,
+  ItemData,
+  NoItemData,
+} from './Combobox.types';
 
-const ComboboxContent = (
-  props: Pick<ComboboxProps, 'component' | 'items' | 'onRenderItem'>
+const ComboboxContent = <TItemData extends ItemData = NoItemData>(
+  props: Pick<ComboboxProps<TItemData>, 'component' | 'items' | 'onRenderItem'>
 ) => {
   const { component: Component, items, onRenderItem } = props;
 
@@ -100,7 +105,9 @@ const ComboboxContent = (
         {Component ? Component({ store: activeComboboxStore }) : null}
 
         {filteredItems.map((item, index) => {
-          const Item = onRenderItem ? onRenderItem({ item }) : item.text;
+          const Item = onRenderItem
+            ? onRenderItem({ item: item as ComboboxItemData<TItemData> })
+            : item.text;
 
           const highlighted = index === highlightedIndex;
 
@@ -137,14 +144,14 @@ const ComboboxContent = (
  * Register the combobox id, trigger, onSelectItem
  * Renders the combobox if active.
  */
-export const Combobox = ({
+export const Combobox = <TItemData extends ItemData = NoItemData>({
   id,
   trigger,
   searchPattern,
   onSelectItem,
   controlled,
   ...props
-}: ComboboxProps) => {
+}: ComboboxProps<TItemData>) => {
   const editor = useEditorState();
   const focusedEditorId = useEventEditorId('focus');
   const combobox = useComboboxControls();

--- a/packages/ui/combobox/src/components/Combobox.tsx
+++ b/packages/ui/combobox/src/components/Combobox.tsx
@@ -14,15 +14,10 @@ import {
 } from '../combobox.store';
 import { useComboboxControls } from '../hooks';
 import { getComboboxStyles } from './Combobox.styles';
-import {
-  ComboboxItemData,
-  ComboboxProps,
-  ItemData,
-  NoItemData,
-} from './Combobox.types';
+import { ComboboxProps, Data, NoData, TComboboxItem } from './Combobox.types';
 
-const ComboboxContent = <TItemData extends ItemData = NoItemData>(
-  props: Pick<ComboboxProps<TItemData>, 'component' | 'items' | 'onRenderItem'>
+const ComboboxContent = <TData extends Data = NoData>(
+  props: Pick<ComboboxProps<TData>, 'component' | 'items' | 'onRenderItem'>
 ) => {
   const { component: Component, items, onRenderItem } = props;
 
@@ -106,7 +101,7 @@ const ComboboxContent = <TItemData extends ItemData = NoItemData>(
 
         {filteredItems.map((item, index) => {
           const Item = onRenderItem
-            ? onRenderItem({ item: item as ComboboxItemData<TItemData> })
+            ? onRenderItem({ item: item as TComboboxItem<TData> })
             : item.text;
 
           const highlighted = index === highlightedIndex;
@@ -144,14 +139,14 @@ const ComboboxContent = <TItemData extends ItemData = NoItemData>(
  * Register the combobox id, trigger, onSelectItem
  * Renders the combobox if active.
  */
-export const Combobox = <TItemData extends ItemData = NoItemData>({
+export const Combobox = <TData extends Data = NoData>({
   id,
   trigger,
   searchPattern,
   onSelectItem,
   controlled,
   ...props
-}: ComboboxProps<TItemData>) => {
+}: ComboboxProps<TData>) => {
   const editor = useEditorState();
   const focusedEditorId = useEventEditorId('focus');
   const combobox = useComboboxControls();

--- a/packages/ui/combobox/src/components/Combobox.types.ts
+++ b/packages/ui/combobox/src/components/Combobox.types.ts
@@ -7,7 +7,8 @@ import {
   ComboboxStoreById,
 } from '../combobox.store';
 
-export interface ComboboxStyleProps extends ComboboxProps {
+export interface ComboboxStyleProps<TItemData>
+  extends ComboboxProps<TItemData> {
   highlighted?: boolean;
 }
 
@@ -16,7 +17,7 @@ export interface ComboboxStyles {
   highlightedItem: CSSProp;
 }
 
-export interface ComboboxItemData {
+export interface ComboboxItemDataBase {
   /**
    * Unique key.
    */
@@ -32,20 +33,31 @@ export interface ComboboxItemData {
    * @default false
    */
   disabled?: boolean;
+}
 
+export interface ComboboxItemDataWithData<TItemData extends ItemData>
+  extends ComboboxItemDataBase {
   /**
    * Data available to `onRenderItem`.
    */
-  data?: unknown;
+  data: TItemData;
 }
 
-export interface ComboboxItemProps {
-  item: ComboboxItemData;
+export type NoItemData = undefined;
+
+export type ItemData = unknown;
+
+export type ComboboxItemData<TItemData> = TItemData extends NoItemData
+  ? ComboboxItemDataBase
+  : ComboboxItemDataWithData<TItemData>;
+
+export interface ComboboxItemProps<TItemData> {
+  item: ComboboxItemData<TItemData>;
 }
 
-export interface ComboboxProps
-  extends Partial<Pick<ComboboxState, 'items'>>,
-    ComboboxStateById,
+export interface ComboboxProps<TItemData = NoItemData>
+  extends Partial<Pick<ComboboxState<TItemData>, 'items'>>,
+    ComboboxStateById<TItemData>,
     StyledProps<ComboboxStyles> {
   /**
    * Render this component when the combobox is open (useful to inject hooks).
@@ -56,5 +68,5 @@ export interface ComboboxProps
    * Render combobox item.
    * @default text
    */
-  onRenderItem?: RenderFunction<ComboboxItemProps>;
+  onRenderItem?: RenderFunction<ComboboxItemProps<TItemData>>;
 }

--- a/packages/ui/combobox/src/components/Combobox.types.ts
+++ b/packages/ui/combobox/src/components/Combobox.types.ts
@@ -7,8 +7,7 @@ import {
   ComboboxStoreById,
 } from '../combobox.store';
 
-export interface ComboboxStyleProps<TItemData>
-  extends ComboboxProps<TItemData> {
+export interface ComboboxStyleProps<TData> extends ComboboxProps<TData> {
   highlighted?: boolean;
 }
 
@@ -17,7 +16,7 @@ export interface ComboboxStyles {
   highlightedItem: CSSProp;
 }
 
-export interface ComboboxItemDataBase {
+export interface TComboboxItemBase {
   /**
    * Unique key.
    */
@@ -35,29 +34,29 @@ export interface ComboboxItemDataBase {
   disabled?: boolean;
 }
 
-export interface ComboboxItemDataWithData<TItemData extends ItemData>
-  extends ComboboxItemDataBase {
+export interface TComboboxItemWithData<TData extends Data>
+  extends TComboboxItemBase {
   /**
    * Data available to `onRenderItem`.
    */
-  data: TItemData;
+  data: TData;
 }
 
-export type NoItemData = undefined;
+export type NoData = undefined;
 
-export type ItemData = unknown;
+export type Data = unknown;
 
-export type ComboboxItemData<TItemData> = TItemData extends NoItemData
-  ? ComboboxItemDataBase
-  : ComboboxItemDataWithData<TItemData>;
+export type TComboboxItem<TData = NoData> = TData extends NoData
+  ? TComboboxItemBase
+  : TComboboxItemWithData<TData>;
 
-export interface ComboboxItemProps<TItemData> {
-  item: ComboboxItemData<TItemData>;
+export interface ComboboxItemProps<TData> {
+  item: TComboboxItem<TData>;
 }
 
-export interface ComboboxProps<TItemData = NoItemData>
-  extends Partial<Pick<ComboboxState<TItemData>, 'items'>>,
-    ComboboxStateById<TItemData>,
+export interface ComboboxProps<TData = NoData>
+  extends Partial<Pick<ComboboxState<TData>, 'items'>>,
+    ComboboxStateById<TData>,
     StyledProps<ComboboxStyles> {
   /**
    * Render this component when the combobox is open (useful to inject hooks).
@@ -68,5 +67,5 @@ export interface ComboboxProps<TItemData = NoItemData>
    * Render combobox item.
    * @default text
    */
-  onRenderItem?: RenderFunction<ComboboxItemProps<TItemData>>;
+  onRenderItem?: RenderFunction<ComboboxItemProps<TData>>;
 }

--- a/packages/ui/combobox/src/types/ComboboxOnSelectItem.ts
+++ b/packages/ui/combobox/src/types/ComboboxOnSelectItem.ts
@@ -1,7 +1,7 @@
 import { SPEditor } from '@udecode/plate-core';
-import { ComboboxItemData } from '../components';
+import { TComboboxItem } from '../components';
 
-export type ComboboxOnSelectItem<TItemData> = (
+export type ComboboxOnSelectItem<TData> = (
   editor: SPEditor,
-  item: ComboboxItemData<TItemData>
+  item: TComboboxItem<TData>
 ) => any;

--- a/packages/ui/combobox/src/types/ComboboxOnSelectItem.ts
+++ b/packages/ui/combobox/src/types/ComboboxOnSelectItem.ts
@@ -1,7 +1,7 @@
 import { SPEditor } from '@udecode/plate-core';
-import { ComboboxItemData } from '../components/Combobox.types';
+import { ComboboxItemData } from '../components';
 
-export type ComboboxOnSelectItem = (
+export type ComboboxOnSelectItem<TItemData> = (
   editor: SPEditor,
-  item: ComboboxItemData
+  item: ComboboxItemData<TItemData>
 ) => any;


### PR DESCRIPTION
**Description**

Make the MentionCombobox a generic component, as to be able to infer or provide the data property.

**Example**

What we want to achieve:

```tsx
<MentionCombobox<UserData>
  items={users.map(user => ({
    key: user.id,
    text: user.fullName,
    data: {
      fullName: user.fullName,
      avatar: user.avatar,
    },
  }))}
  createMentionNode={item => ({
    fullName: item.data.fullName,
  })}
  onRenderItem={({ item }) => <SuggestedMention user={item.data} />}
/>
```

Basically typescript complains if the data is incorrect, which was not the case so far - it was an unknown.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

