### PR TITLE
update ci workflow to show correct name in each matrix command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: 12
 
-      - name: Run lint
+      - name: Run ${{ matrix.command }}
         run: yarn && yarn build && yarn ${{ matrix.command }}
         env:
           CI: true


### PR DESCRIPTION
**Description**

both lint and test commands show "Run lint".

Using ${{ matrix.command }} in the name makes it clear which command is being run.

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->

Demo of change:

https://www.loom.com/share/ed638eeccc8247039648a37a18f15837
