### PR TITLE
docs: fix live code for basic plugins documentation

### DIFF
--- a/docs/docs/getting-started/basic-plugins.mdx
+++ b/docs/docs/getting-started/basic-plugins.mdx
@@ -170,6 +170,9 @@ const options = createPlateOptions();
 
 ```tsx live
 () => {
+  const components = createPlateComponents();
+  const options = createPlateOptions();
+
   // try to remove some plugins!
   const basicNodesPlugins = [
     // editor


### PR DESCRIPTION
**Description**

As I was reading through the docs I came across this error on the "Basic plugins" page: `ReferenceError: components is not defined`. I thought I'll just go ahead and fix it as it looked like an easy one.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

**Issue**

`ReferenceError: components is not defined` error shown on the `"Basic plugins"` documentation page.

Fixes: #1192 

**Example**

https://plate.udecode.io/docs/basic-plugins

<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
