### PR TITLE
Ensure styled-components doesn't get bundled with `@udecode/plate-ui-button`

### DIFF
--- a/.changeset/fast-eagles-camp.md
+++ b/.changeset/fast-eagles-camp.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-ui-button': patch
+---
+
+Ensure styled-components is not bundled in the compiled package

--- a/packages/ui/button/package.json
+++ b/packages/ui/button/package.json
@@ -41,7 +41,8 @@
     "react-dom": ">=16.8.0",
     "slate": ">=0.66.1",
     "slate-history": ">=0.66.0",
-    "slate-react": ">=0.66.1"
+    "slate-react": ">=0.66.1",
+    "styled-components": ">=5.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
I noticed this error in my app:

> react_devtools_backend.js:2540 It looks like there are several instances of 'styled-components' initialized in this application. This may cause dynamic styles to not render properly, errors during the rehydration process, a missing theme prop, and makes your application bigger without good reason.

It didn't manifest in any bugs but after tracing things down I was pretty confident we weren't loading 2 versions of the styled components module (I've seen this error many times over the years 🤦 ). From the error I noticed it was coming from `@udecode/plate-ui-button`, and upon inspection I saw that it wasn't listing `styled-components` as a peer dependency even though it does get used. It was also compiled to a 74kb size. After listing `styled-components` as a peer dep the compiled output is down to 6kb, which I think probably tells me this did the trick.