### PR TITLE
Fixes link upsert on space 

### DIFF
--- a/.changeset/four-llamas-join.md
+++ b/.changeset/four-llamas-join.md
@@ -1,0 +1,7 @@
+---
+"@udecode/plate-core": patch
+"@udecode/plate-link": patch
+---
+
+- fix link upsert on space 
+- `getPointBefore`: will return early if the point before is in another block. Removed `multiPaths` option as it's not used anymore.

--- a/packages/core/src/common/queries/getPointBefore.ts
+++ b/packages/core/src/common/queries/getPointBefore.ts
@@ -3,6 +3,7 @@ import castArray from 'lodash/castArray';
 import map from 'lodash/map';
 import { Editor, Location, Path, Point } from 'slate';
 import { TEditor } from '../../types/slate/TEditor';
+import { isRangeAcrossBlocks } from './isRangeAcrossBlocks';
 
 export interface BeforeOptions {
   distance?: number | undefined;
@@ -35,11 +36,6 @@ export interface PointBeforeOptions extends BeforeOptions {
    * If false, lookup until the first invalid character.
    */
   skipInvalid?: boolean;
-
-  /**
-   * Allow lookup across multiple node paths.
-   */
-  multiPaths?: boolean;
 }
 
 /**
@@ -78,10 +74,14 @@ export const getPointBefore = (
       // not found
       if (!beforePoint) return;
 
-      // different path
+      // stop looking outside of current block
       if (
-        !options.multiPaths &&
-        !Path.equals(beforePoint.path, previousBeforePoint.path)
+        isRangeAcrossBlocks(editor, {
+          at: {
+            anchor: beforePoint,
+            focus: previousBeforePoint,
+          },
+        })
       ) {
         return;
       }

--- a/packages/elements/link/src/__tests__/withLink/insertText/space-after-url-across-blocks.spec.tsx
+++ b/packages/elements/link/src/__tests__/withLink/insertText/space-after-url-across-blocks.spec.tsx
@@ -1,0 +1,53 @@
+/** @jsx jsx */
+
+import { createPlateEditor } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { createLinkPlugin } from '../../../createLinkPlugin';
+
+jsx;
+
+const input = (
+  <editor>
+    <hp>
+      link:{' '}
+      <element type="a" url="http://google.com">
+        http://google.com
+      </element>
+    </hp>
+    <hp>
+      test
+      <cursor />
+    </hp>
+  </editor>
+) as any;
+
+const text = ' ';
+
+const output = (
+  <editor>
+    <hp>
+      link:{' '}
+      <element type="a" url="http://google.com">
+        http://google.com
+      </element>
+    </hp>
+    <hp>
+      {'test '}
+      {/* keep above as string in quotes to force trailing space */}
+      <cursor />
+    </hp>
+  </editor>
+) as any;
+
+describe('when inserting a space with a link element in a preceeding block', () => {
+  it('should run default insertText', () => {
+    const editor = createPlateEditor({
+      editor: input,
+      plugins: [createLinkPlugin()],
+    });
+
+    editor.insertText(text);
+
+    expect(input.children).toEqual(output.children);
+  });
+});

--- a/packages/elements/link/src/createLinkPlugin.ts
+++ b/packages/elements/link/src/createLinkPlugin.ts
@@ -26,7 +26,7 @@ export const createLinkPlugin = createPluginFactory<LinkPlugin>({
       matchString: ' ',
       skipInvalid: true,
       afterMatch: true,
-      multiPaths: true,
+      multiPaths: false,
     },
     hotkey: 'mod+k',
   },

--- a/packages/elements/link/src/createLinkPlugin.ts
+++ b/packages/elements/link/src/createLinkPlugin.ts
@@ -26,7 +26,6 @@ export const createLinkPlugin = createPluginFactory<LinkPlugin>({
       matchString: ' ',
       skipInvalid: true,
       afterMatch: true,
-      multiPaths: false,
     },
     hotkey: 'mod+k',
   },


### PR DESCRIPTION
**Description**

Closes #1215 

Looks like the call to `getRangeBefore` was spanning across multiple paths. I don't know if this was intentional or if there are any downstream consequences of changing this, but setting `multiPaths: false` in the `rangeBeforeOptions` object seems to fix the bug in #1215.

**Note:** lots of tests are currently failing, so could not test to pass successfully / build etc. I'm getting lots of "Unable to resolve path to module" errors. See screenshot below. Is this just me? If so, how do I fix?

<img width="1377" alt="Screenshot 2021-12-01 at 16 48 33" src="https://user-images.githubusercontent.com/5517057/144276941-597fedbd-786b-4cb4-9ce9-591ecb4affad.png">

## Checklist

- [x] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [ ] The relevant examples still work: (Run examples with `yarn docs`.)

