### PR TITLE
Bug Fix - Color picker does not close on first selection

### DIFF
--- a/.changeset/afraid-doors-own.md
+++ b/.changeset/afraid-doors-own.md
@@ -1,0 +1,6 @@
+---
+'@udecode/plate-core': patch
+'@udecode/plate-font-ui': patch
+---
+
+Fixes Issue #1271 - Color Picker does not close on first selection

--- a/.changeset/afraid-doors-own.md
+++ b/.changeset/afraid-doors-own.md
@@ -1,5 +1,4 @@
 ---
-'@udecode/plate-core': patch
 '@udecode/plate-font-ui': patch
 ---
 

--- a/packages/core/src/common/queries/getPointBefore.ts
+++ b/packages/core/src/common/queries/getPointBefore.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-constant-condition */
 import castArray from 'lodash/castArray';
 import map from 'lodash/map';
-import { Editor, Location, Path, Point } from 'slate';
+import { Editor, Location, Point } from 'slate';
 import { TEditor } from '../../types/slate/TEditor';
 import { isRangeAcrossBlocks } from './isRangeAcrossBlocks';
 

--- a/packages/marks/font-ui/src/ColorPicker/ColorPicker.spec.tsx
+++ b/packages/marks/font-ui/src/ColorPicker/ColorPicker.spec.tsx
@@ -20,10 +20,12 @@ describe('ColorPicker', () => {
     color,
     colors,
     customColors,
+    open,
   }: {
     color?: string;
     colors?: ColorType[];
     customColors?: ColorType[];
+    open?: boolean;
   }) => (
     <ColorPicker
       color={color}
@@ -33,6 +35,7 @@ describe('ColorPicker', () => {
       updateColor={updateColor}
       updateCustomColor={updateCustomColor}
       clearColor={clearColor}
+      open={open}
     />
   );
 
@@ -122,6 +125,24 @@ describe('ColorPicker', () => {
       container.rerender(
         <Component color="#FFFFFF" customColors={[...DEFAULT_CUSTOM_COLORS]} />
       );
+      expect(spyColorPickerStyles).toHaveBeenCalledTimes(2);
+    });
+    it('should render once with same open value', () => {
+      const spyColorPickerStyles = jest.spyOn(
+        ColorPickerStyles,
+        'getColorPickerStyles'
+      );
+      const container = render(<Component color="#FFFFFF" open />);
+      container.rerender(<Component color="#FFFFFF" open />);
+      expect(spyColorPickerStyles).toHaveBeenCalledTimes(1);
+    });
+    it('should render twice with different open value', () => {
+      const spyColorPickerStyles = jest.spyOn(
+        ColorPickerStyles,
+        'getColorPickerStyles'
+      );
+      const container = render(<Component color="#FFFFFF" open />);
+      container.rerender(<Component color="#FFFFFF" open={false} />);
       expect(spyColorPickerStyles).toHaveBeenCalledTimes(2);
     });
   });

--- a/packages/marks/font-ui/src/ColorPicker/ColorPicker.tsx
+++ b/packages/marks/font-ui/src/ColorPicker/ColorPicker.tsx
@@ -14,6 +14,7 @@ type ColorPickerProps = {
   updateColor: (color: string) => void;
   updateCustomColor: (color: string) => void;
   clearColor: () => void;
+  open?: boolean;
 };
 
 const ColorPickerInternal = ({
@@ -61,5 +62,6 @@ export const ColorPicker = React.memo(
   (prev, next) =>
     prev.color === next.color &&
     prev.colors === next.colors &&
-    prev.customColors === next.customColors
+    prev.customColors === next.customColors &&
+    prev.open === next.open
 );

--- a/packages/marks/font-ui/src/ColorPickerToolbarDropdown/ColorPickerToolbarDropdown.spec.tsx
+++ b/packages/marks/font-ui/src/ColorPickerToolbarDropdown/ColorPickerToolbarDropdown.spec.tsx
@@ -100,15 +100,17 @@ describe('ColorPickerToolbarDropdown', () => {
       });
 
       it('should open the color picker', () => {
+        expect(screen.getByTestId('ColorPicker')).not.toBeVisible();
+
         openToolbar();
 
         expect(screen.getByTestId('ColorPicker')).toBeVisible();
       });
 
-      it(`should apply ${target}`, () => {
-        openToolbar();
+      it(`should apply ${target}`, async () => {
+        await openToolbar();
 
-        applyColor();
+        await applyColor();
 
         expect(editor.children).toEqual([
           {
@@ -121,13 +123,17 @@ describe('ColorPickerToolbarDropdown', () => {
             ],
           },
         ]);
+
+        const value = await screen.findByTestId('ColorPicker');
+        expect(value).not.toBeVisible();
       });
 
-      it(`should clear selected ${target}`, () => {
-        openToolbar();
-        applyColor();
+      it(`should clear selected ${target}`, async () => {
+        await openToolbar();
+        await applyColor();
+        await openToolbar();
 
-        clearColor();
+        await clearColor();
 
         expect(editor.children).toEqual([
           {
@@ -139,6 +145,9 @@ describe('ColorPickerToolbarDropdown', () => {
             ],
           },
         ]);
+
+        const value = await screen.findByTestId('ColorPicker');
+        expect(value).not.toBeVisible();
       });
     });
   };

--- a/packages/marks/font-ui/src/ColorPickerToolbarDropdown/ColorPickerToolbarDropdown.tsx
+++ b/packages/marks/font-ui/src/ColorPickerToolbarDropdown/ColorPickerToolbarDropdown.tsx
@@ -113,6 +113,7 @@ export const ColorPickerToolbarDropdown = ({
         updateColor={updateColorAndClose}
         updateCustomColor={updateColor}
         clearColor={clearColor}
+        open={open}
       />
     </ToolbarDropdown>
   );


### PR DESCRIPTION
added additional property to check the open status in react memo comparison.



<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->



Fixes: 

#1271 



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
