### PR TITLE
Create readOnlyDisplay.tsx 

### DIFF
--- a/packages/core/src/utils/readOnlyDisplay.tsx
+++ b/packages/core/src/utils/readOnlyDisplay.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { isText, PlateEditor } from "../types";
+  /*
+  The strategy is to take each node, read its type, find the corresponding component to render 
+  this type, and then render it.
+  
+  Because this is for read only content, we need not worry about changes.
+  */
+
+  const renderNode = (node:any, index:number, editor:PlateEditor<any>) => {
+    let type = node.type;
+    // get the component corresponding to the node's type
+    let component = editor.pluginsByKey[type].component;
+    if (isText(node)) {
+      // process soft breaks
+      let encodedText = encodeURI(node.text);
+      let softBreaked = encodedText.split('%0A');
+      return (
+        <span key={index}>
+          {softBreaked.map((txt, index) => {
+            return (
+              <span key={index}>
+                {decodeURI(txt)}
+                {index === softBreaked.length - 1 ? null : <br />}
+              </span>
+            );
+          })}
+        </span>
+      );
+    }
+    let children = node.children.map((node,index)=>renderNode(node,index,editor));
+    return React.createElement(
+      component,
+      { element: { ...node }, attributes: {}, prefix: '', children, key: index },
+      // recursively render the children
+      children
+    );
+  };
+  
+  export const ReadOnlyDisplay =  (props: { nodes: any[], editor:PlateEditor<any> }) => {
+    let components = props.nodes.map((node,index)=>renderNode(node,index,props.editor));
+    return <>{components}</>;
+  };


### PR DESCRIPTION
A component that efficiently renders a read-only display of a given slate document. 
(addresses https://github.com/udecode/plate/issues/1250)

It takes an editor as a prop, and uses the editor's plugin components to render - this circumvents the need to write custom serializing code.

The types are not quite right, and will need to be modified a bit to have it work. I'm not quite familiar with the repository yet - I'd appreciate some help getting the right type interfaces. The following problems stand out to me:
1. I'm not quite sure what type interface node should have. 
2. I think it could be better if the ReadOnlyDisplay function took a template parameter T and fed it to PlateEditor<T>. 
3. My editor shows the error 'JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.' wherever there's JSX. A cursory Google search shows that installing the React types should resolve this problem. I'm not sure how the monorepo is set up, so it's possible that this isn't an issue at all. 

These are just off the top of my head, please let me know if I missed anything.

