### PR TITLE
avoid plugins array been changed

### DIFF
--- a/packages/core/src/plugins/createInsertDataPlugin.ts
+++ b/packages/core/src/plugins/createInsertDataPlugin.ts
@@ -10,7 +10,7 @@ export const withInsertData: WithOverride = (editor) => {
   const { insertData } = editor;
 
   editor.insertData = (dataTransfer) => {
-    const inserted = editor.plugins.reverse().some((plugin) => {
+    const inserted = [...editor.plugins].reverse().some((plugin) => {
       const insertDataOptions = plugin.editor.insertData;
       if (!insertDataOptions) return false;
 

--- a/packages/core/src/plugins/html-deserializer/utils/pipeDeserializeHtmlElement.ts
+++ b/packages/core/src/plugins/html-deserializer/utils/pipeDeserializeHtmlElement.ts
@@ -10,7 +10,7 @@ export const pipeDeserializeHtmlElement = <T = {}>(
 ) => {
   let result: (Nullable<DeserializeHtml> & { node: AnyObject }) | undefined;
 
-  editor.plugins.reverse().some((plugin) => {
+  [...editor.plugins].reverse().some((plugin) => {
     result = pluginDeserializeHtml(plugin, { element });
 
     return !!result;

--- a/packages/core/src/plugins/html-deserializer/utils/pipeDeserializeHtmlLeaf.ts
+++ b/packages/core/src/plugins/html-deserializer/utils/pipeDeserializeHtmlLeaf.ts
@@ -8,7 +8,7 @@ export const pipeDeserializeHtmlLeaf = <T = {}>(
 ) => {
   let node: AnyObject = {};
 
-  editor.plugins.reverse().forEach((plugin) => {
+  [...editor.plugins].reverse().forEach((plugin) => {
     const deserialized = pluginDeserializeHtml(plugin, {
       element,
       deserializeLeaf: true,

--- a/packages/serializers/docx/src/deserializer/__tests__/testDocxDeserializer.tsx
+++ b/packages/serializers/docx/src/deserializer/__tests__/testDocxDeserializer.tsx
@@ -79,8 +79,8 @@ export const testDocxDeserializer = ({
         createBasicElementsPlugin(),
         createBasicMarksPlugin(),
         createTablePlugin(),
-        createDeserializeDocxPlugin(),
         createJuicePlugin(),
+        createDeserializeDocxPlugin(),
       ],
       overrideByKey,
     });


### PR DESCRIPTION
**Description**

when trying to add customized insertData plugin for insertData, after the call, because of the change of the plugins order, our own plugin is not get called first. this change is to ensure the execution of plugin logics consistent every time.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
