### PR TITLE
set the cursor to the first cell for new table

### DIFF
--- a/.changeset/long-shoes-battle.md
+++ b/.changeset/long-shoes-battle.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-table': patch
+---
+
+fix #1216, set cusor to first cell for newly created table

--- a/packages/nodes/table/src/transforms/insertTable.ts
+++ b/packages/nodes/table/src/transforms/insertTable.ts
@@ -1,10 +1,13 @@
 import {
+  getAbove,
   getPluginType,
   insertNodes,
   PlateEditor,
+  selectEditor,
   someNode,
   TElement,
 } from '@udecode/plate-core';
+import { Editor } from 'slate';
 import { ELEMENT_TABLE } from '../createTablePlugin';
 import { TablePluginOptions } from '../types';
 import { getEmptyTableNode } from '../utils/getEmptyTableNode';
@@ -19,5 +22,15 @@ export const insertTable = (
     })
   ) {
     insertNodes<TElement>(editor, getEmptyTableNode(editor, { header }));
+    if (editor.selection) {
+      const tableEntry = getAbove(editor, {
+        match: { type: getPluginType(editor, ELEMENT_TABLE) },
+      });
+      if (!tableEntry) {
+        return;
+      }
+      const point = Editor.start(editor, tableEntry[1]);
+      selectEditor(editor, { at: point });
+    }
   }
 };

--- a/packages/serializers/docx/src/deserializer/__tests__/testDocxDeserializer.tsx
+++ b/packages/serializers/docx/src/deserializer/__tests__/testDocxDeserializer.tsx
@@ -81,6 +81,7 @@ export const testDocxDeserializer = ({
         }),
         createDeserializeDocxPlugin(),
         createJuicePlugin(),
+        createDeserializeDocxPlugin(),
       ],
       overrideByKey,
     });

--- a/packages/serializers/docx/src/deserializer/__tests__/testDocxDeserializer.tsx
+++ b/packages/serializers/docx/src/deserializer/__tests__/testDocxDeserializer.tsx
@@ -81,7 +81,6 @@ export const testDocxDeserializer = ({
         }),
         createDeserializeDocxPlugin(),
         createJuicePlugin(),
-        createDeserializeDocxPlugin(),
       ],
       overrideByKey,
     });


### PR DESCRIPTION
**Description**

Fixes: #1216 the cursor is not in the first cell for newly created table. because in slate, it always set cursor to end of newly inserted node

**Solution**
set the cursor to the first cell once the table is inserted.
