### PR TITLE
Copy/paste inside a list now works properly with pasting text

### DIFF
--- a/.changeset/chatty-bananas-chew.md
+++ b/.changeset/chatty-bananas-chew.md
@@ -1,0 +1,7 @@
+---
+"@udecode/plate-list": patch
+---
+
+Copy/paste inside a list now works properly with pasting text:
+The text was not pasted at all.
+For other kind of nodes like "p", there were pasted but inside the same bullet.

--- a/packages/nodes/list/src/insertFragmentList.spec.tsx
+++ b/packages/nodes/list/src/insertFragmentList.spec.tsx
@@ -237,3 +237,45 @@ describe('when pasting ul > 2 li fragment', () => {
     });
   });
 });
+
+describe('when pasting text fragment inside li fragment', () => {
+  it('should normalize text as li and insert it', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>
+              one
+              <cursor />
+            </hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const fragment = ((
+      <fragment>
+        <hp>two</hp>
+        <hp>three</hp>
+      </fragment>
+    ) as any) as TDescendant[];
+
+    const expected = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>one</hlic>
+          </hli>
+          <hli>
+            <hlic>two</hlic>
+          </hli>
+          <hli>
+            <hlic>three</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as PlateEditor;
+
+    editorTest(input, fragment, expected);
+  });
+});

--- a/packages/nodes/list/src/insertFragmentList.ts
+++ b/packages/nodes/list/src/insertFragmentList.ts
@@ -57,6 +57,19 @@ export const insertFragmentList = (editor: PlateEditor) => {
       : [commonAncestorEntry[0]];
   };
 
+  const convertFragmentToList = (fragment: TDescendant[]) => {
+    const trimmedFragment = fragment.flatMap((node) => trimList(node));
+
+    if (trimmedFragment.every((node) => node.type === ELEMENT_LI)) {
+      return trimmedFragment;
+    }
+
+    return trimmedFragment.map((node) => ({
+      type: ELEMENT_LI,
+      children: node.children ?? [node],
+    }));
+  };
+
   return (fragment: TDescendant[]) => {
     const liEntry = findNode(editor, {
       match: { type: li.type },
@@ -67,11 +80,10 @@ export const insertFragmentList = (editor: PlateEditor) => {
       const [, liPath] = liEntry;
 
       // FIXME: fork insertFragment for edge cases
-      return Transforms.insertNodes(
-        editor,
-        fragment.flatMap((node) => trimList(node)),
-        { at: Path.next(liPath), select: true }
-      );
+      return Transforms.insertNodes(editor, convertFragmentToList(fragment), {
+        at: Path.next(liPath),
+        select: true,
+      });
     }
 
     const filtered: TDescendant[] = isListRoot(fragment[0])


### PR DESCRIPTION
**Description**

Text pasting (and other non-list node) did not have the proper behavior.
The text was not pasted at all.
For other kind of nodes like "p", there were pasted but inside the same bullet.
Cf video:
https://user-images.githubusercontent.com/12655829/148397132-cc796d0a-b801-42a8-a6cb-6cb17e499259.mov


In this PR, when pasting during the insert fragment, there are two cases:
- if we are pasting a list, it is the old behavior
- if we are pasting something else, we convert this something into a list to be pasted

Here is the final behavior in video:
https://user-images.githubusercontent.com/12655829/148397570-21554c88-c81d-436e-8a7c-8accd1872591.mov