### PR TITLE
fix error popup in browser console  when adding a code block

### DIFF
--- a/.changeset/green-lobsters-judge.md
+++ b/.changeset/green-lobsters-judge.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-code-block": patch
+---
+
+fix: "decorateCodeLine don't check the path of nodeEntry"  when adding a code block

--- a/packages/nodes/code-block/src/decorateCodeLine.ts
+++ b/packages/nodes/code-block/src/decorateCodeLine.ts
@@ -59,6 +59,7 @@ export const decorateCodeLine: Decorate = (editor, { type }) => {
   return (entry: NodeEntry) => {
     const ranges: any = [];
     const [node, path] = entry;
+    if (path.length === 0) return;
     const codeBlock = getParent(editor, path);
 
     if (!codeBlock) return;


### PR DESCRIPTION
**Description**

1. Open the plate playground,
2. Go to developer Tools of Chrome, click the Sources tab
  enable the Pause on caught exceptions
3. add a Code block from plate editor
4. Browser paused and complain `Error: Cannot get the parent path of the root path [].`

**Issue**

decorateCodeLine don't check the path of nodeEntry

Fixes: 

in decorateCodeLine.ts
if path length is equal to zero, just return


**Example**

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

