### PR TITLE
Support case-insensitive matching

### DIFF
--- a/.changeset/calm-parents-type.md
+++ b/.changeset/calm-parents-type.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-find-replace": patch
+---
+
+Support case-insensitive matching

--- a/packages/decorators/find-replace/src/__tests__/decorateSearchHighlight/search/text.spec.ts
+++ b/packages/decorators/find-replace/src/__tests__/decorateSearchHighlight/search/text.spec.ts
@@ -37,3 +37,21 @@ it('should be', () => {
     output
   );
 });
+
+it('should be', () => {
+  const editor = createPlateEditor({
+    plugins: [
+      createFindReplacePlugin({
+        options: {
+          search: 'Test',
+        },
+      }),
+    ],
+  });
+
+  const plugin = getPlugin(editor, MARK_SEARCH_HIGHLIGHT);
+
+  expect(plugin.decorate?.(editor, plugin)([{ text: 'test' }, [0, 0]])).toEqual(
+    output
+  );
+});

--- a/packages/decorators/find-replace/src/__tests__/decorateSearchHighlight/search/text.spec.ts
+++ b/packages/decorators/find-replace/src/__tests__/decorateSearchHighlight/search/text.spec.ts
@@ -1,24 +1,8 @@
 import { createPlateEditor, getPlugin } from '@udecode/plate-core';
-import { Range } from 'slate';
 import {
   createFindReplacePlugin,
   MARK_SEARCH_HIGHLIGHT,
 } from '../../../createFindReplacePlugin';
-
-const output: Range[] = [
-  {
-    anchor: {
-      offset: 0,
-      path: [0, 0],
-    },
-    focus: {
-      offset: 4,
-      path: [0, 0],
-    },
-    search: 'test',
-    [MARK_SEARCH_HIGHLIGHT]: true,
-  } as any,
-];
 
 it('should be', () => {
   const editor = createPlateEditor({
@@ -34,7 +18,20 @@ it('should be', () => {
   const plugin = getPlugin(editor, MARK_SEARCH_HIGHLIGHT);
 
   expect(plugin.decorate?.(editor, plugin)([{ text: 'test' }, [0, 0]])).toEqual(
-    output
+    [
+      {
+        anchor: {
+          offset: 0,
+          path: [0, 0],
+        },
+        focus: {
+          offset: 4,
+          path: [0, 0],
+        },
+        search: 'test',
+        [MARK_SEARCH_HIGHLIGHT]: true,
+      },
+    ]
   );
 });
 
@@ -52,6 +49,19 @@ it('should be', () => {
   const plugin = getPlugin(editor, MARK_SEARCH_HIGHLIGHT);
 
   expect(plugin.decorate?.(editor, plugin)([{ text: 'test' }, [0, 0]])).toEqual(
-    output
+    [
+      {
+        anchor: {
+          offset: 0,
+          path: [0, 0],
+        },
+        focus: {
+          offset: 4,
+          path: [0, 0],
+        },
+        search: 'Test',
+        [MARK_SEARCH_HIGHLIGHT]: true,
+      },
+    ]
   );
 });

--- a/packages/decorators/find-replace/src/decorateFindReplace.ts
+++ b/packages/decorators/find-replace/src/decorateFindReplace.ts
@@ -14,7 +14,7 @@ export const decorateFindReplace: Decorate<{}, FindReplacePlugin> = (
   }
 
   const { text } = node;
-  const parts = text.split(search);
+  const parts = text.toLowerCase().split(search.toLowerCase());
   let offset = 0;
   parts.forEach((part, i) => {
     if (i !== 0) {


### PR DESCRIPTION
**Description**
`find-replace` should highlight case-insensitive findings as the default behaviour (https://github.com/udecode/plate/discussions/1411)