### PR TITLE
use keyPlugins in useMemos of useEditableProps (fix decorate)

### DIFF
--- a/.changeset/long-ravens-talk.md
+++ b/.changeset/long-ravens-talk.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-core': patch
+---
+
+fix useEditableProps plugins memoization

--- a/packages/core/src/hooks/usePlate/useEditableProps.ts
+++ b/packages/core/src/hooks/usePlate/useEditableProps.ts
@@ -21,31 +21,29 @@ export const useEditableProps = ({
   const storeRenderLeaf = usePlateSelectors(id).renderLeaf();
   const storeRenderElement = usePlateSelectors(id).renderElement();
 
-  const isValid = editor && !!keyPlugins;
-
   const decorate = useMemo(() => {
-    if (!isValid) return;
+    if (!(editor && !!keyPlugins)) return;
 
     return pipeDecorate(editor, storeDecorate ?? editableProps?.decorate);
-  }, [editableProps?.decorate, editor, isValid, storeDecorate]);
+  }, [editableProps?.decorate, editor, keyPlugins, storeDecorate]);
 
   const renderElement = useMemo(() => {
-    if (!isValid) return;
+    if (!(editor && !!keyPlugins)) return;
 
     return pipeRenderElement(
       editor,
       storeRenderElement ?? editableProps?.renderElement
     );
-  }, [editableProps?.renderElement, editor, isValid, storeRenderElement]);
+  }, [editableProps?.renderElement, editor, keyPlugins, storeRenderElement]);
 
   const renderLeaf = useMemo(() => {
-    if (!isValid) return;
+    if (!(editor && !!keyPlugins)) return;
 
     return pipeRenderLeaf(editor, storeRenderLeaf ?? editableProps?.renderLeaf);
-  }, [editableProps?.renderLeaf, editor, isValid, storeRenderLeaf]);
+  }, [editableProps?.renderLeaf, editor, keyPlugins, storeRenderLeaf]);
 
   const props: EditableProps = useDeepCompareMemo(() => {
-    if (!isValid) return {};
+    if (!(editor && !!keyPlugins)) return {};
 
     const _props: EditableProps = {
       decorate,
@@ -65,7 +63,7 @@ export const useEditableProps = ({
     });
 
     return _props;
-  }, [decorate, editableProps, isValid, renderElement, renderLeaf]);
+  }, [decorate, editableProps, renderElement, renderLeaf]);
 
   return useDeepCompareMemo(
     () => ({


### PR DESCRIPTION
Fixes #1357.

`keyPlugins` was updating whenever plugins changed _but_ since `keyPlugins` was outside of the `useMemo` calls, `isValid` never updated.

I initially attempted to wrap `isValid` in a `useMemo` but doing that caused the type refinement to think that `editor` _could_ be `undefined`. As a result, I removed `isValid` and instead passed `keyPlugins` to everywhere that used `isValid` as a defendency to the `useMemo`.

This is now working as desired.

![fixPlateIssue](https://user-images.githubusercontent.com/1024544/156863903-7f177e52-160c-46b2-83a1-af0ec4a9fdc1.gif)

