### PR TITLE
Remove unnecessary peer dep in combobox

### DIFF
--- a/.changeset/cold-falcons-crash.md
+++ b/.changeset/cold-falcons-crash.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-combobox": patch
+---
+
+Remove unnecessary peer dep in combobox

--- a/packages/editor/combobox/package.json
+++ b/packages/editor/combobox/package.json
@@ -42,8 +42,7 @@
     "react-dom": ">=16.8.0",
     "slate": ">=0.66.1",
     "slate-history": ">=0.66.0",
-    "slate-react": ">=0.74.2",
-    "styled-components": ">=5.0.0"
+    "slate-react": ">=0.74.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
**Description**

`@udecode/plate-combobox` has an unnecessary peer dep on `styled-components` which prevents installing `@udecode/plate-headless` without also adding `styled-components`
