### PR TITLE
Fixes #1446: Update isType to return expected boolean value.

### DIFF
--- a/.changeset/big-carrots-change.md
+++ b/.changeset/big-carrots-change.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-core': patch
+---
+
+Update isType to correctly return the expected boolean value.

--- a/packages/core/src/common/__tests__/queries/isType/type.spec.tsx
+++ b/packages/core/src/common/__tests__/queries/isType/type.spec.tsx
@@ -1,0 +1,17 @@
+/** @jsx jsx */
+import { jsx } from '@udecode/plate-test-utils';
+import { ELEMENT_PARAGRAPH } from '../../../../../../nodes/paragraph/src/createParagraphPlugin';
+import { PlateEditor } from '../../../../types/PlateEditor';
+import { isType } from '../../../queries/isType';
+
+jsx;
+
+const editor = ((
+  <editor>
+    <hp>test</hp>
+  </editor>
+) as any) as PlateEditor;
+
+it('should return true when type matches', () => {
+  expect(isType(editor, editor.children[0], ELEMENT_PARAGRAPH)).toEqual(true);
+});

--- a/packages/core/src/common/queries/isType.ts
+++ b/packages/core/src/common/queries/isType.ts
@@ -11,8 +11,9 @@ export const isType = (
   key?: string | string[]
 ) => {
   const keys = castArray(key);
-  keys.forEach((_key) => {
-    if (node?.type === getPluginType(editor, _key)) return true;
-  });
-  return false;
+  const types: string[] = [];
+
+  keys.forEach((_key) => types.push(getPluginType(editor, _key)));
+
+  return types.includes(node?.type);
 };


### PR DESCRIPTION
**Description**

This pull request addresses #1446. Instead of attempting to return from within a `forEach`, this solution utilizes the same `forEach` to build a map of plugin types. It then uses `Array.prototype.includes()` to check if the node type exists in the map.

You can see a working example of this solution here: https://codesandbox.io/s/plate-playground-forked-qsd5ly?file=/index.tsx

1. Move the cursor into the paragraph field.
2. Click the Test Type button in the toolbar.
3. Check the console.

Example return values from the sandbox:

<img width="308" alt="Screen Shot 2022-03-20 at 12 29 24 AM" src="https://user-images.githubusercontent.com/427133/159150985-52034d5a-2910-4e8e-92dc-e88cdeae96e6.png">

