### PR TITLE
Fix Url encoded HTML nodes on adding an image #1189

### DIFF
--- a/.changeset/hip-experts-punch.md
+++ b/.changeset/hip-experts-punch.md
@@ -1,0 +1,8 @@
+---
+'@udecode/plate-core': minor
+---
+
+Fix Url encoded HTML nodes on adding an image #1189
+
+- Updated function `serializeHtml` to use `decodeURIComponent` per node, instead of complete text.
+  This is fixing problem when combination of image and i.e. paragraph nodes would result in paragraph node not decoded.

--- a/packages/core/src/plugins/html-serializer/__tests__/elements.spec.ts
+++ b/packages/core/src/plugins/html-serializer/__tests__/elements.spec.ts
@@ -158,8 +158,7 @@ it('serialize image to html', () => {
         nodes: [
           {
             type: 'img',
-            url:
-              'https://i.kym-cdn.com/photos/images/original/001/358/546/3fa.jpg',
+            url: 'https://i.kym-cdn.com/photos/images/original/001/358/546/3fa.jpg',
             children: [],
           },
         ],
@@ -250,4 +249,24 @@ it('serialize align className to html', () => {
   ).toBe(
     '<p class="slate-p slate-align-center" style="text-align:center">I am centered text!</p>'
   );
+});
+
+it('serialize image and paragraph to html', () => {
+  const plugins = [createParagraphPlugin(), createImagePlugin()];
+  const render = serializeHtml(createPlateUIEditor({ plugins }), {
+    nodes: [
+      {
+        type: ELEMENT_PARAGRAPH,
+        children: [{ text: 'I am centered text!' }],
+      },
+      {
+        type: 'img',
+        url: 'https://i.kym-cdn.com/photos/images/original/001/358/546/3fa.jpg',
+        children: [],
+      },
+    ],
+  });
+  const result =
+    '<p class="slate-p">I am centered text!</p><div class="slate-img"><div contenteditable="false"><figure class="slate-ImageElement-figure"><div style="position:relative;user-select:auto;width:100%;height:100%;max-width:100%;min-width:92px;box-sizing:border-box;flex-shrink:0" class="slate-ImageElement-resizable"><img class="slate-ImageElement-img" src="https://i.kym-cdn.com/photos/images/original/001/358/546/3fa.jpg" alt=""/><div><div  style="position:absolute;user-select:none;width:10px;height:100%;top:0px;left:0;cursor:col-resize"><div class="slate-ImageElement-handleLeft"></div></div><div  style="position:absolute;user-select:none;width:10px;height:100%;top:0px;right:0;cursor:col-resize"><div class="slate-ImageElement-handleRight"></div></div></div></div></figure></div></div>';
+  expect(render).toBe(result);
 });

--- a/packages/core/src/plugins/html-serializer/serializeHtml.ts
+++ b/packages/core/src/plugins/html-serializer/serializeHtml.ts
@@ -82,11 +82,8 @@ export const serializeHtml = (
         preserveClassNames,
       });
     })
+    .map((e) => (isEncoded(e) ? decodeURIComponent(e) : e))
     .join('');
-
-  if (isEncoded(result)) {
-    result = decodeURIComponent(result);
-  }
 
   if (stripWhitespace) {
     result = trimWhitespace(result);


### PR DESCRIPTION
**Description**
(from the original issue  #1189)
On adding a image into editor the serialized nodes gets url encoded.
This HTML serialized node
<p class="slate-p">the post body without any images and a smiley ✅</p><p class="slate-p"></p>
becomes
<p class="slate-p">the%20post%20body%20without%a%20image%20and%20a%20smiley%20%E2%9C%85</p>
On adding a image url using <ToolbarImage />

**Solution**
The fix is to perform decoding per node, rather than full object.

