### PR TITLE
fix: toggleMark: Ensure removeMark is only called when a `clear` value is provided

### DIFF
--- a/packages/core/src/common/transforms/toggleMark.ts
+++ b/packages/core/src/common/transforms/toggleMark.ts
@@ -29,8 +29,10 @@ export const toggleMark = (
       return;
     }
 
-    const clears: string[] = castArray(clear);
-    removeMark(editor, { key: clears });
+    if (clear) {
+      const clears: string[] = castArray(clear);
+      removeMark(editor, { key: clears });
+    }
 
     editor.addMark(key, true);
   });


### PR DESCRIPTION
**Description**

The `clear` argument is optional for `toggleMark`, however, `toggleMark` **_always_** calls `removeMark` even when clear is `undefined`. This ultimately generates an extra, invalid `set_node` operation without a `newProperties` object, which can potentially [cause a crash here in slate](https://github.com/ianstormtaylor/slate/blob/479a759108bc0f903715e08d542307566b077227/packages/slate/src/transforms/general.ts#L222) when applied, because `newProperties` is expected to exist.

Conditionally calling `removeMark` only when `clear` exists resolves the issue, and matches how it worked prior to [this PR](https://github.com/udecode/plate/commit/b83d4313df9975f5409019383f46399c6c52ab73).

<!-- **Example** -->

No public example unfortunately, but we ran into this in real-world code when saving and re-applying the slate operations. We noticed the invalid `set_node` operation shape (missing `newProperties`) and traced it back to here.

