### PR TITLE
fix the issue of ComboBox Enter and Tab event propagate to editor on Chrome

### DIFF
--- a/.changeset/small-buckets-help.md
+++ b/.changeset/small-buckets-help.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-combobox": patch
+---
+
+fix the issue of ComboBox Enter and Tab event propagate to editor on Chrome

--- a/packages/editor/combobox/src/onKeyDownCombobox.ts
+++ b/packages/editor/combobox/src/onKeyDownCombobox.ts
@@ -62,6 +62,7 @@ export const onKeyDownCombobox: KeyboardHandler = (editor) => (event) => {
 
   if (['Tab', 'Enter'].includes(event.key)) {
     event.preventDefault();
+    event.stopPropagation();
     if (filteredItems[highlightedIndex]) {
       onSelectItem?.(editor, filteredItems[highlightedIndex]);
     }


### PR DESCRIPTION
**Description**

add event.stopPropagation() in addition to  event.preventDefault();
Fixed the issue on Chrome.

See changesets.
