### PR TITLE
prevent double new lines when pressing enter with soft/exit break plugins

### DIFF
--- a/.changeset/spicy-foxes-poke.md
+++ b/.changeset/spicy-foxes-poke.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-break": patch
+---
+
+prevent double new lines when pressing enter with soft/exit break plugins

--- a/packages/editor/break/src/exit-break/onKeyDownExitBreak.ts
+++ b/packages/editor/break/src/exit-break/onKeyDownExitBreak.ts
@@ -14,6 +14,7 @@ export const onKeyDownExitBreak: KeyboardHandler<{}, ExitBreakPlugin> = (
     if (isHotkey(hotkey, event as any) && queryNode(entry, rule.query)) {
       if (exitBreak(editor, rule)) {
         event.preventDefault();
+        event.stopPropagation();
       }
     }
   });

--- a/packages/editor/break/src/soft-break/onKeyDownSoftBreak.ts
+++ b/packages/editor/break/src/soft-break/onKeyDownSoftBreak.ts
@@ -12,6 +12,7 @@ export const onKeyDownSoftBreak: KeyboardHandler<{}, SoftBreakPlugin> = (
   rules.forEach(({ hotkey, query }) => {
     if (isHotkey(hotkey, event as any) && queryNode(entry, query)) {
       event.preventDefault();
+      event.stopPropagation();
 
       editor.insertText('\n');
     }


### PR DESCRIPTION
**Description**

Latest version of chrome seems to have changed some behavior with regards to input events, which results in newlines being added multiple times when enter is pressed with soft/exit break plugins enabled.

Similar to the issue fixed for combo boxes, in https://github.com/udecode/plate/pull/1483

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Before

https://user-images.githubusercontent.com/3934894/163037178-49c0975c-1872-4a77-b073-4d41fd74df8f.mov

## After


https://user-images.githubusercontent.com/3934894/163037194-9a9481a1-63b3-4a8c-aef9-708019ef47ae.mov




