### PR TITLE
prevent tab key event in table  propagate to editor

### DIFF
--- a/.changeset/eight-ties-behave.md
+++ b/.changeset/eight-ties-behave.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-table": patch
+---
+
+prevent tab key event in table  propagate to editor

--- a/packages/nodes/table/src/onKeyDownTable.ts
+++ b/packages/nodes/table/src/onKeyDownTable.ts
@@ -7,6 +7,7 @@ import { getTableCellEntry } from './queries/getTableCellEntry';
 export const onKeyDownTable: KeyboardHandler = (editor, { type }) => (e) => {
   if (e.key === 'Tab') {
     e.preventDefault();
+    e.stopPropagation();
     const res = getTableCellEntry(editor, {});
     if (!res) return;
     const { tableRow, tableCell } = res;


### PR DESCRIPTION
add event.stopPropagation() to tab key event handling in Table plugin to prevent the unwanted indent action.

