### PR TITLE
Added readOnly mode to images and their captions

### DIFF
--- a/.changeset/eighty-days-protect.md
+++ b/.changeset/eighty-days-protect.md
@@ -1,0 +1,6 @@
+---
+'@udecode/plate-core': minor
+'@udecode/plate-ui-image': minor
+---
+
+Added readOnly mode for images and their captions

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2055,7 +2055,7 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
-"@udecode/plate-alignment@10.4.2":
+"@udecode/plate-alignment@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2063,7 +2063,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-autoformat@10.4.2":
+"@udecode/plate-autoformat@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2071,7 +2071,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-basic-elements@10.4.2":
+"@udecode/plate-basic-elements@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2079,7 +2079,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-basic-marks@10.4.2":
+"@udecode/plate-basic-marks@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2087,7 +2087,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-block-quote@10.4.2":
+"@udecode/plate-block-quote@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2095,7 +2095,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-break@10.4.2":
+"@udecode/plate-break@10.6.1":
   version "0.0.0"
   uid ""
 
@@ -2103,7 +2103,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-code-block@10.4.2":
+"@udecode/plate-code-block@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2111,7 +2111,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-combobox@10.4.2":
+"@udecode/plate-combobox@10.6.0":
   version "0.0.0"
   uid ""
 
@@ -2119,7 +2119,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-core@10.4.2":
+"@udecode/plate-core@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2131,7 +2131,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-find-replace@10.4.2":
+"@udecode/plate-find-replace@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2139,7 +2139,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-font@10.4.2":
+"@udecode/plate-font@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2147,7 +2147,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-heading@10.4.2":
+"@udecode/plate-heading@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2155,7 +2155,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-headless@10.4.2":
+"@udecode/plate-headless@10.6.3":
   version "0.0.0"
   uid ""
 
@@ -2163,7 +2163,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-highlight@10.4.2":
+"@udecode/plate-highlight@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2171,7 +2171,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-horizontal-rule@10.4.2":
+"@udecode/plate-horizontal-rule@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2179,7 +2179,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-image@10.4.2":
+"@udecode/plate-image@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2187,7 +2187,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-indent-list@10.4.2":
+"@udecode/plate-indent-list@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2195,7 +2195,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-indent@10.4.2":
+"@udecode/plate-indent@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2203,7 +2203,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-juice@10.4.2":
+"@udecode/plate-juice@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2211,7 +2211,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-kbd@10.4.2":
+"@udecode/plate-kbd@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2219,7 +2219,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-line-height@10.4.2":
+"@udecode/plate-line-height@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2227,7 +2227,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-link@10.4.2":
+"@udecode/plate-link@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2235,7 +2235,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-list@10.4.2":
+"@udecode/plate-list@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2243,7 +2243,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-media-embed@10.4.2":
+"@udecode/plate-media-embed@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2251,7 +2251,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-mention@10.4.2":
+"@udecode/plate-mention@10.6.0":
   version "0.0.0"
   uid ""
 
@@ -2259,7 +2259,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-node-id@10.4.2":
+"@udecode/plate-node-id@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2267,7 +2267,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-normalizers@10.4.2":
+"@udecode/plate-normalizers@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2275,7 +2275,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-paragraph@10.4.2":
+"@udecode/plate-paragraph@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2283,7 +2283,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-reset-node@10.4.2":
+"@udecode/plate-reset-node@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2291,7 +2291,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-select@10.4.2":
+"@udecode/plate-select@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2299,7 +2299,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-serializer-csv@10.4.2":
+"@udecode/plate-serializer-csv@10.6.3":
   version "0.0.0"
   uid ""
 
@@ -2307,7 +2307,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-serializer-docx@10.4.2":
+"@udecode/plate-serializer-docx@10.6.3":
   version "0.0.0"
   uid ""
 
@@ -2315,7 +2315,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-serializer-md@10.4.2":
+"@udecode/plate-serializer-md@10.6.0":
   version "0.0.0"
   uid ""
 
@@ -2323,7 +2323,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-styled-components@10.4.2":
+"@udecode/plate-styled-components@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2331,7 +2331,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-table@10.4.2":
+"@udecode/plate-table@10.6.3":
   version "0.0.0"
   uid ""
 
@@ -2343,7 +2343,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-trailing-block@10.4.2":
+"@udecode/plate-trailing-block@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2351,7 +2351,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-alignment@10.4.2":
+"@udecode/plate-ui-alignment@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2359,7 +2359,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-block-quote@10.4.2":
+"@udecode/plate-ui-block-quote@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2367,7 +2367,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-button@10.4.2":
+"@udecode/plate-ui-button@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2375,7 +2375,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-code-block@10.4.2":
+"@udecode/plate-ui-code-block@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2383,7 +2383,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-combobox@10.4.4":
+"@udecode/plate-ui-combobox@10.6.0":
   version "0.0.0"
   uid ""
 
@@ -2391,7 +2391,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-dnd@10.4.2":
+"@udecode/plate-ui-dnd@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2399,7 +2399,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-find-replace@10.4.2":
+"@udecode/plate-ui-find-replace@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2407,7 +2407,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-font@10.4.2":
+"@udecode/plate-ui-font@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2419,7 +2419,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-image@10.4.2":
+"@udecode/plate-ui-image@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2427,7 +2427,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-line-height@10.4.2":
+"@udecode/plate-ui-line-height@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2435,7 +2435,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-link@10.4.2":
+"@udecode/plate-ui-link@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2443,7 +2443,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-list@10.4.2":
+"@udecode/plate-ui-list@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2451,7 +2451,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-media-embed@10.4.2":
+"@udecode/plate-ui-media-embed@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2459,7 +2459,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-mention@10.4.4":
+"@udecode/plate-ui-mention@10.6.0":
   version "0.0.0"
   uid ""
 
@@ -2467,7 +2467,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-placeholder@10.4.2":
+"@udecode/plate-ui-placeholder@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2475,7 +2475,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-popover@10.4.2":
+"@udecode/plate-ui-popover@10.6.2":
   version "0.0.0"
   uid ""
 
@@ -2483,7 +2483,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-popper@10.4.2":
+"@udecode/plate-ui-popper@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2491,7 +2491,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-table@10.4.2":
+"@udecode/plate-ui-table@10.6.3":
   version "0.0.0"
   uid ""
 
@@ -2499,7 +2499,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui-toolbar@10.4.2":
+"@udecode/plate-ui-toolbar@10.5.3":
   version "0.0.0"
   uid ""
 
@@ -2507,7 +2507,7 @@
   version "0.0.0"
   uid ""
 
-"@udecode/plate-ui@10.4.4":
+"@udecode/plate-ui@10.6.3":
   version "0.0.0"
   uid ""
 

--- a/packages/core/src/plugins/html-serializer/__tests__/elements.spec.ts
+++ b/packages/core/src/plugins/html-serializer/__tests__/elements.spec.ts
@@ -158,7 +158,8 @@ it('serialize image to html', () => {
         nodes: [
           {
             type: 'img',
-            url: 'https://i.kym-cdn.com/photos/images/original/001/358/546/3fa.jpg',
+            url:
+              'https://i.kym-cdn.com/photos/images/original/001/358/546/3fa.jpg',
             children: [],
           },
         ],

--- a/packages/ui/nodes/image/src/ImageElement/ImageElement.fixtures.tsx
+++ b/packages/ui/nodes/image/src/ImageElement/ImageElement.fixtures.tsx
@@ -1,0 +1,15 @@
+/** @jsx jsx */
+
+import React from 'react';
+import { PlateEditor } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+
+jsx;
+
+export const imgInput = ((
+  <editor>
+    <himg url="https://source.unsplash.com/kFrdX5IeQzI" width="75%">
+      <htext />
+    </himg>
+  </editor>
+) as any) as PlateEditor;

--- a/packages/ui/nodes/image/src/ImageElement/ImageElement.spec.tsx
+++ b/packages/ui/nodes/image/src/ImageElement/ImageElement.spec.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as core from '@udecode/plate-core';
+import { Plate } from '@udecode/plate-core/src';
+import { ELEMENT_H1 } from '@udecode/plate-heading';
+import { createImagePlugin } from '@udecode/plate-image';
+import { createPlateUIEditor } from '@udecode/plate-ui';
+import * as slateReact from 'slate-react';
+import { ImageToolbarButton } from '../ImageToolbarButton';
+import { imgInput } from './ImageElement.fixtures';
+
+describe('ImageElement', () => {
+  describe('readOnly mode', () => {
+    it('should disable caption editing in readOnly mode', () => {
+      const editor = createPlateUIEditor({
+        editor: imgInput,
+        plugins: [createImagePlugin()],
+      });
+      jest.spyOn(core, 'usePlateEditorRef').mockReturnValue(editor as any);
+      jest.spyOn(slateReact, 'useSelected').mockReturnValue(true);
+
+      const { container } = render(
+        <Plate editor={editor} editableProps={{ readOnly: true }} />
+      );
+
+      expect(
+        container.querySelector('.slate-ImageElement-img')
+      ).toBeInTheDocument();
+
+      const caption = container.querySelector(
+        '.slate-ImageElement-caption'
+      ) as HTMLTextAreaElement;
+
+      act(() => {
+        userEvent.type(caption, 'a');
+      });
+
+      expect(editor.children).toStrictEqual([
+        {
+          children: [
+            {
+              text: '',
+            },
+          ],
+          type: 'img',
+          url: 'https://source.unsplash.com/kFrdX5IeQzI',
+          width: '75%',
+        },
+      ]);
+    });
+
+    it('should allow caption editing in normal mode', () => {
+      const editor = createPlateUIEditor({
+        editor: imgInput,
+        plugins: [createImagePlugin()],
+      });
+      jest.spyOn(core, 'usePlateEditorRef').mockReturnValue(editor as any);
+      jest.spyOn(slateReact, 'useSelected').mockReturnValue(true);
+
+      const { container, getByTestId } = render(
+        <Plate editor={editor}>
+          <ImageToolbarButton type={ELEMENT_H1} icon={null} />
+        </Plate>
+      );
+
+      expect(
+        container.querySelector('.slate-ImageElement-img')
+      ).toBeInTheDocument();
+
+      const caption = container.querySelectorAll('.slate-ImageElement-caption');
+      expect(caption.length).toEqual(1);
+      fireEvent.click(caption[0]);
+      act(() => {
+        fireEvent.change(caption[0], { target: { value: 'a' } });
+      });
+
+      expect(editor.children).toStrictEqual([
+        {
+          caption: [
+            {
+              text: 'a',
+            },
+          ],
+          children: [
+            {
+              text: '',
+            },
+          ],
+          type: 'img',
+          url: 'https://source.unsplash.com/kFrdX5IeQzI',
+          width: '75%',
+        },
+      ]);
+    });
+  });
+});

--- a/packages/ui/nodes/image/src/ImageElement/ImageElement.tsx
+++ b/packages/ui/nodes/image/src/ImageElement/ImageElement.tsx
@@ -8,9 +8,9 @@ import React, {
 import TextareaAutosize from 'react-textarea-autosize';
 import { setNodes } from '@udecode/plate-core';
 import { getRootProps } from '@udecode/plate-styled-components';
-import { Resizable } from 're-resizable';
+import { Resizable, ResizableProps } from 're-resizable';
 import { Node, Transforms } from 'slate';
-import { ReactEditor, useFocused, useSelected } from 'slate-react';
+import { ReactEditor, useFocused, useReadOnly, useSelected } from 'slate-react';
 import { getImageElementStyles } from './ImageElement.styles';
 import { ImageElementProps } from './ImageElement.types';
 import { ImageHandle } from './ImageHandle';
@@ -28,6 +28,7 @@ export const ImageElement = (props: ImageElementProps) => {
     align = 'center',
     draggable,
     editor,
+    ignoreReadOnly = false,
   } = props;
 
   const rootProps = getRootProps(props);
@@ -41,7 +42,25 @@ export const ImageElement = (props: ImageElementProps) => {
   } = element;
   const focused = useFocused();
   const selected = useSelected();
+  const readOnly = useReadOnly();
   const [width, setWidth] = useState(nodeWidth);
+
+  const resizeProps: ResizableProps =
+    !ignoreReadOnly && readOnly
+      ? {
+          ...resizableProps,
+          enable: {
+            left: false,
+            right: false,
+            top: false,
+            bottom: false,
+            topLeft: false,
+            bottomLeft: false,
+            topRight: false,
+            bottomRight: false,
+          },
+        }
+      : { ...resizableProps };
 
   // const [captionId] = useState(nanoid());
 
@@ -91,6 +110,7 @@ export const ImageElement = (props: ImageElementProps) => {
           className={`group ${styles.figure?.className}`}
         >
           <Resizable
+            data-testid="ImageElementResizable"
             // @ts-ignore
             css={styles.resizable?.css}
             className={styles.resizable?.className}
@@ -124,7 +144,7 @@ export const ImageElement = (props: ImageElementProps) => {
               setWidth(ref.offsetWidth);
             }}
             onResizeStop={(e, direction, ref) => setNodeWidth(ref.offsetWidth)}
-            {...resizableProps}
+            {...resizeProps}
           >
             <img
               data-testid="ImageElementImage"
@@ -139,16 +159,19 @@ export const ImageElement = (props: ImageElementProps) => {
 
           {!caption.disabled && (captionString.length || selected) && (
             <figcaption
+              data-testid="ImageElementCaption"
               style={{ width }}
               css={styles.figcaption?.css}
               className={styles.figcaption?.className}
             >
               <TextareaAutosize
+                data-testid="ImageElementTextArea"
                 css={styles.caption?.css}
                 className={styles.caption?.className}
                 value={nodeCaption[0].text}
                 placeholder={placeholder}
                 onChange={onChangeCaption}
+                readOnly={(!ignoreReadOnly && readOnly) || caption.readOnly}
               />
 
               {/* <div css={styles.caption?.css}> */}

--- a/packages/ui/nodes/image/src/ImageElement/ImageElement.types.ts
+++ b/packages/ui/nodes/image/src/ImageElement/ImageElement.types.ts
@@ -40,10 +40,20 @@ export interface ImageElementProps
      * Caption placeholder.
      */
     placeholder?: string;
+
+    /**
+     * Whether caption is read-only.
+     */
+    readOnly?: boolean;
   };
 
   /**
    * Whether the image is draggable.
    */
   draggable?: boolean;
+
+  /**
+   * Ignore editable readOnly mode
+   */
+  ignoreReadOnly?: boolean;
 }


### PR DESCRIPTION
**Description**

See changesets. Also added tests to ImageElement. Image captions were not being properly handled by readOnly mode, so added logic to handle it by default, with logic to override

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

