### PR TITLE
fix(table): onKeyDownTable tab key acts only when a selection is done

### DIFF
--- a/.changeset/odd-tigers-drive.md
+++ b/.changeset/odd-tigers-drive.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-table': patch
+---
+
+fix onKeyDownTable so it only acts with Tab key when selection is within a table, so default or others handlers can work outside

--- a/packages/nodes/table/src/onKeyDownTable.ts
+++ b/packages/nodes/table/src/onKeyDownTable.ts
@@ -59,8 +59,6 @@ export const onKeyDownTable = <
   }
 
   if (e.key === 'Tab') {
-    e.preventDefault();
-    e.stopPropagation();
     const res = getTableCellEntry(editor, {});
     if (!res) return;
     const { tableRow, tableCell } = res;
@@ -78,6 +76,8 @@ export const onKeyDownTable = <
       if (previousCell) {
         const [, previousCellPath] = previousCell;
         select(editor, previousCellPath);
+        e.preventDefault();
+        e.stopPropagation();
       }
     } else if (tab) {
       // move right with tab
@@ -90,6 +90,8 @@ export const onKeyDownTable = <
       if (nextCell) {
         const [, nextCellPath] = nextCell;
         select(editor, nextCellPath);
+        e.preventDefault();
+        e.stopPropagation();
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/udecode/plate/issues/1552