### PR TITLE
fix(ui-combobox): add portalElement prop which is passed to PortalBody

### DIFF
--- a/.changeset/kind-islands-appear.md
+++ b/.changeset/kind-islands-appear.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-ui-combobox": patch
+---
+
+`Combobox`: add `portalElement` prop which is passed to `PortalBody`

--- a/packages/ui/combobox/src/Combobox.tsx
+++ b/packages/ui/combobox/src/Combobox.tsx
@@ -36,7 +36,7 @@ const ComboboxContent = <TData extends Data = NoData>(
     | 'filter'
   >
 ) => {
-  const { component: Component, items, onRenderItem } = props;
+  const { component: Component, items, portalElement, onRenderItem } = props;
 
   const targetRange = useComboboxSelectors.targetRange();
   const filteredItems = useComboboxSelectors.filteredItems();
@@ -103,7 +103,7 @@ const ComboboxContent = <TData extends Data = NoData>(
   );
 
   return (
-    <PortalBody>
+    <PortalBody element={portalElement}>
       <ul
         {...menuProps}
         ref={popperRef}

--- a/packages/ui/combobox/src/Combobox.types.ts
+++ b/packages/ui/combobox/src/Combobox.types.ts
@@ -36,4 +36,6 @@ export interface ComboboxProps<TData = NoData>
    * @default text
    */
   onRenderItem?: RenderFunction<ComboboxItemProps<TData>>;
+
+  portalElement?: Element;
 }


### PR DESCRIPTION
**Description**

Combobox should pass portalElement to PortalBody, otherwise it is impossible to use it in some cases. For example in a scrolling modal.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->

<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

