### PR TITLE
Fix runtime error when deserialized html contains svg element

### DIFF
--- a/.changeset/sharp-scissors-obey.md
+++ b/.changeset/sharp-scissors-obey.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-core": patch
+---
+
+Fix runtime error when deserialized html contains svg element

--- a/packages/core/src/plugins/html-deserializer/utils/pluginDeserializeHtml.ts
+++ b/packages/core/src/plugins/html-deserializer/utils/pluginDeserializeHtml.ts
@@ -63,7 +63,7 @@ export const pluginDeserializeHtml = <V extends Value>(
         }
 
         // Ignore if the rule className is not in el class list.
-        if (validClassName && !el.className.includes(validClassName))
+        if (validClassName && !el.classList.contains(validClassName))
           return false;
 
         if (validStyle) {


### PR DESCRIPTION
**Description**

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

I experience runtime error when deserializing HTML that contains svg element. This is because the deserializeHtml plugin check `!el.className.includes(validClassName)`. When `el` is svg the className value is not a string, so calling `includes` causes error.

In versions < v8, the check was using `!el.classList.contains(validClassName)`. And this works for all elements

https://github.com/udecode/plate/blob/632f7057fd8c05e8a92fc6fea3445d1641f082fe/packages/common/src/utils/getNodeDeserializer.ts#L35-L36

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

