### PR TITLE
Markdown image deserialization

### DIFF
--- a/packages/serializers/md/src/deserializer/utils/deserializeMd.ts
+++ b/packages/serializers/md/src/deserializer/utils/deserializeMd.ts
@@ -16,6 +16,7 @@ import {
   ELEMENT_H6,
 } from '@udecode/plate-heading';
 import { ELEMENT_HR } from '@udecode/plate-horizontal-rule';
+import { ELEMENT_IMAGE } from '@udecode/plate-image';
 import { ELEMENT_LINK } from '@udecode/plate-link';
 import { ELEMENT_LI, ELEMENT_OL, ELEMENT_UL } from '@udecode/plate-list';
 import { ELEMENT_PARAGRAPH } from '@udecode/plate-paragraph';
@@ -46,6 +47,7 @@ export const deserializeMd = <V extends Value>(
         // underline: getPluginType(editor, MARK_UNDERLINE),
         // subscript: getPluginType(editor, MARK_SUBSCRIPT),
         // superscript: getPluginType(editor, MARK_SUPERSCRIPT),
+        image: getPluginType(editor, ELEMENT_IMAGE),
         code_block: getPluginType(editor, ELEMENT_CODE_BLOCK),
         thematic_break: getPluginType(editor, ELEMENT_HR),
         ul_list: getPluginType(editor, ELEMENT_UL),


### PR DESCRIPTION
Added element type of image to markdown deserialization. Because markdown mdast expects "image" for the type, images aren't decoded right. Now uses ELEMENT_IMAGE as the type.