### PR TITLE
Fix issue in huge editor example

### DIFF
--- a/docs/docs/examples/huge-document.mdx
+++ b/docs/docs/examples/huge-document.mdx
@@ -32,7 +32,7 @@ title: Huge Document
   const WithoutPlate = () => {
     const [value, setValue] = useState(initialValue);
     const renderElement = useCallback((p) => <Element {...p} />, []);
-    const editor = useMemo(() => withReact(createTEditor(), []);
+    const editor = useMemo(() => withReact(createTEditor(), []));
 
     return (
       <Slate


### PR DESCRIPTION
**Description**

This PR fixes a syntax error in the huge editor example, which causes the example not to be rendered. See:

https://plate.udecode.io/docs/examples/huge-document

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->
<img width="1134" alt="image" src="https://user-images.githubusercontent.com/11364625/172699752-c54f79a7-1cdd-41ba-bc9a-0639ccf9ec1c.png">



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

