### PR TITLE
list deleteBackward should check for custom li type instead of default

### DIFF
--- a/.changeset/moody-apricots-laugh.md
+++ b/.changeset/moody-apricots-laugh.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-list': patch
+---
+
+Fix list deleteBackward with custom type

--- a/packages/nodes/list/src/deleteBackwardList.ts
+++ b/packages/nodes/list/src/deleteBackwardList.ts
@@ -34,7 +34,7 @@ export const deleteBackwardList = <V extends Value>(
 
     if (
       isSelectionAtBlockStart(editor, {
-        match: (node) => node.type === ELEMENT_LI,
+        match: (node) => node.type === getPluginType(editor, ELEMENT_LI),
       })
     ) {
       withoutNormalizing(editor, () => {


### PR DESCRIPTION
**Description**

List delete backward behavior is a bit erratic when using a custom ast/tag name as the condition check is against the default type rather than looking up the type.