### PR TITLE
Pass search to createMentionNode as metadata

### DIFF
--- a/.changeset/grumpy-gorillas-change.md
+++ b/.changeset/grumpy-gorillas-change.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-mention': patch
+---
+
+Pass search to createMentionNode as metadata

--- a/packages/nodes/mention/src/getMentionOnSelectItem.ts
+++ b/packages/nodes/mention/src/getMentionOnSelectItem.ts
@@ -25,7 +25,14 @@ import { ELEMENT_MENTION, ELEMENT_MENTION_INPUT } from './createMentionPlugin';
 import { MentionPlugin, TMentionElement } from './types';
 
 export interface CreateMentionNode<TData extends Data> {
-  (item: TComboboxItem<TData>): TNodeProps<TMentionElement>;
+  (
+    item: TComboboxItem<TData>,
+    meta: CreateMentionNodeMeta
+  ): TNodeProps<TMentionElement>;
+}
+
+export interface CreateMentionNodeMeta {
+  search: string;
 }
 
 export const getMentionOnSelectItem = <TData extends Data = NoData>({
@@ -46,6 +53,13 @@ export const getMentionOnSelectItem = <TData extends Data = NoData>({
     isEndPoint(editor, editor.selection.anchor, pathAbove);
 
   withoutNormalizing(editor, () => {
+    // Selectors are sensitive to operations, it's better to create everything
+    // before the editor state is changed. For example, asking for text after
+    // removeNodes below will return null.
+    const props = createMentionNode!(item, {
+      search: comboboxSelectors.text() ?? '',
+    });
+
     // insert a space to fix the bug
     if (isBlockEnd) {
       insertText(editor, ' ');
@@ -58,8 +72,6 @@ export const getMentionOnSelectItem = <TData extends Data = NoData>({
         match: (node) => node.type === ELEMENT_MENTION_INPUT,
       })
     );
-
-    const props = createMentionNode!(item);
 
     insertNodes<TMentionElement>(editor, {
       type,


### PR DESCRIPTION
Makes it possible to create nodes based on search, for example creating
a task if a task with the query is not found.

**Description**

See changesets.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

