### PR TITLE
Toggling a nested list that includes paragraph content should toggle all nested list elements

### DIFF
--- a/.changeset/clean-stingrays-repair.md
+++ b/.changeset/clean-stingrays-repair.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-list': patch
+---
+
+Toggling a nested list that includes paragraph content should toggle all nested list elements

--- a/packages/nodes/list/src/transforms/toggleList.spec.tsx
+++ b/packages/nodes/list/src/transforms/toggleList.spec.tsx
@@ -379,4 +379,54 @@ describe('toggle over', () => {
 
     expect(input.children).toEqual(output.children);
   });
+
+  it('should fully toggle a nested list when the selection contains a p', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>
+              <anchor />1
+            </hlic>
+            <hul>
+              <hli>
+                <hlic>11</hlic>
+              </hli>
+            </hul>
+          </hli>
+        </hul>
+        <hp>
+          body
+          <focus />
+        </hp>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const output = ((
+      <editor>
+        <hol>
+          <hli>
+            <hlic>1</hlic>
+            <hol>
+              <hli>
+                <hlic>11</hlic>
+              </hli>
+            </hol>
+          </hli>
+          <hli>
+            <hlic>body</hlic>
+          </hli>
+        </hol>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const editor = createPlateUIEditor({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    toggleList(editor, { type: getPluginType(editor, ELEMENT_OL) });
+
+    expect(input.children).toEqual(output.children);
+  });
 });

--- a/packages/nodes/list/src/transforms/toggleList.ts
+++ b/packages/nodes/list/src/transforms/toggleList.ts
@@ -126,7 +126,16 @@ export const toggleList = <V extends Value>(
 
         nodes.forEach((n) => {
           if (getListTypes(editor).includes(n[0].type)) {
-            setElements(editor, { type }, { at: n[1] });
+            setElements(
+              editor,
+              { type },
+              {
+                at: n[1],
+                match: (_n) =>
+                  isElement(_n) && getListTypes(editor).includes(_n.type),
+                mode: 'all',
+              }
+            );
           } else {
             setElements(
               editor,


### PR DESCRIPTION

**Description**

See changesets.

If I toggle a nested list, all of the nested list elements are toggled

If my selection includes both a nested list and a paragraph, this is not the case. I would expect toggling the list to toggle all nested list elements.
 
<!-- **Example** -->

Before toggle:
```
• Item 1
    • Item 11
• Item 2
Body
```

Expected:
```
1. Item 1
    1. Item 11
2. Item 2
3. Body
```

Actual:
```
1. Item 1
    • Item 11
2. Item 2
3. Body
```