### PR TITLE
Add ability to indent/un-indent multiple list items

### DIFF
--- a/.changeset/lemon-queens-pretend.md
+++ b/.changeset/lemon-queens-pretend.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-list': minor
+---
+
+Improved list item indentation when selection spans across different elements

--- a/packages/nodes/list/src/onKeyDownList.ts
+++ b/packages/nodes/list/src/onKeyDownList.ts
@@ -2,13 +2,17 @@ import {
   getAboveNode,
   HotkeyPlugin,
   Hotkeys,
+  isCollapsed,
   KeyboardHandlerReturnType,
   PlateEditor,
+  select,
+  unhangRange,
   Value,
   WithPlatePlugin,
 } from '@udecode/plate-core';
 import isHotkey from 'is-hotkey';
 import { castArray } from 'lodash';
+import { Range } from 'slate';
 import { moveListItems, toggleList } from './transforms';
 
 export const onKeyDownList = <
@@ -20,15 +24,37 @@ export const onKeyDownList = <
 ): KeyboardHandlerReturnType => (e) => {
   const isTab = Hotkeys.isTab(editor, e);
   const isUntab = Hotkeys.isUntab(editor, e);
+
+  let workRange = editor.selection;
+
   if (editor.selection && (isTab || isUntab)) {
+    const { selection } = editor;
+
+    // Unhang the expanded selection
+    if (!isCollapsed(editor.selection)) {
+      const { anchor, focus } = Range.isBackward(selection)
+        ? { anchor: selection.focus, focus: selection.anchor }
+        : { anchor: selection.anchor, focus: selection.focus };
+
+      // This is a workaround for a Slate bug 
+      // See: https://github.com/ianstormtaylor/slate/pull/5039
+      anchor.offset = 0;
+      const unHungRange = unhangRange(editor, { anchor, focus });
+      if (unHungRange) {
+        workRange = unHungRange;
+        select(editor, unHungRange);
+      }
+    }
+
+    // check if we're in a list context.
     const listSelected = getAboveNode(editor, {
       at: editor.selection,
     });
 
-    if (listSelected) {
+    if (workRange && listSelected) {
       e.preventDefault();
-      moveListItems(editor, { increase: isTab });
-      return;
+      moveListItems(editor, { at: workRange, increase: isTab });
+      return true;
     }
   }
 

--- a/packages/nodes/list/src/onKeyDownList.ts
+++ b/packages/nodes/list/src/onKeyDownList.ts
@@ -23,7 +23,6 @@ export const onKeyDownList = <
   if (editor.selection && (isTab || isUntab)) {
     const listSelected = getAboveNode(editor, {
       at: editor.selection,
-      match: { type },
     });
 
     if (listSelected) {

--- a/packages/nodes/list/src/onkeyDownList.spec.tsx
+++ b/packages/nodes/list/src/onkeyDownList.spec.tsx
@@ -8,18 +8,26 @@ import * as isHotkey from 'is-hotkey';
 import { onKeyDownList } from './onKeyDownList';
 
 jsx;
+/*
+input:
+1. E1
+2. |E2
 
-it('should indent single list item', () => {
+output:
+1. E1
+  1. |E2
+*/
+it('should indent single list item (start of item)', () => {
   const input = (
     <editor>
       <hul>
         <hli>
-          <hlic>some text</hlic>
+          <hlic>E1</hlic>
         </hli>
         <hli>
           <hlic>
             <cursor />
-            some text
+            E2
           </hlic>
         </hli>
       </hul>
@@ -30,12 +38,12 @@ it('should indent single list item', () => {
     <editor>
       <hul>
         <hli>
-          <hlic>some text</hlic>
+          <hlic>E1</hlic>
           <hul>
             <hli>
               <hlic>
                 <cursor />
-                some text
+                E2
               </hlic>
             </hli>
           </hul>
@@ -54,22 +62,26 @@ it('should indent single list item', () => {
   expect(editor.children).toEqual(output.children);
 });
 
-it('should indent multiple list items', () => {
+/*
+input:
+1. E1
+2. E2|
+
+output:
+1. E1
+  1. E2|
+*/
+it('should indent single list item (end of item)', () => {
   const input = (
     <editor>
       <hul>
         <hli>
-          <hlic>first element</hlic>
+          <hlic>E1</hlic>
         </hli>
         <hli>
           <hlic>
-            <focus />
-            second element
-          </hlic>
-        </hli>
-        <hli>
-          <hlic>
-            third element <anchor />
+            E2
+            <cursor />
           </hlic>
         </hli>
       </hul>
@@ -80,17 +92,12 @@ it('should indent multiple list items', () => {
     <editor>
       <hul>
         <hli>
-          <hlic>first element</hlic>
+          <hlic>E1</hlic>
           <hul>
             <hli>
               <hlic>
-                <focus />
-                second element
-              </hlic>
-            </hli>
-            <hli>
-              <hlic>
-                third element <anchor />
+                E2
+                <cursor />
               </hlic>
             </hli>
           </hul>
@@ -109,22 +116,101 @@ it('should indent multiple list items', () => {
   expect(editor.children).toEqual(output.children);
 });
 
-it('should un-indent multiple list items', () => {
+/*
+input:
+1. E1
+2. |E2
+3. E3|
+
+output:
+1. E1
+  1. |E2
+  2. E3|
+*/
+it('should indent multiple list items (start/end)', () => {
   const input = (
     <editor>
       <hul>
         <hli>
-          <hlic>first element</hlic>
+          <hlic>E1</hlic>
+        </hli>
+        <hli>
+          <hlic>
+            <focus />
+            E2
+          </hlic>
+        </hli>
+        <hli>
+          <hlic>
+            E3
+            <anchor />
+          </hlic>
+        </hli>
+      </hul>
+    </editor>
+  ) as any;
+
+  const output = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>E1</hlic>
           <hul>
             <hli>
               <hlic>
                 <focus />
-                second element
+                E2
               </hlic>
             </hli>
             <hli>
               <hlic>
-                third element <anchor />
+                E3<anchor />
+              </hlic>
+            </hli>
+          </hul>
+        </hli>
+      </hul>
+    </editor>
+  ) as any;
+
+  const event = new KeyboardEvent('keydown', { key: 'Tab' }) as any;
+  const editor = createPlateUIEditor({
+    editor: input,
+    plugins: [createListPlugin()],
+  });
+
+  onKeyDownList(editor, getPlugin<HotkeyPlugin>(editor, 'ul'))(event as any);
+  expect(editor.children).toEqual(output.children);
+});
+
+/*
+input:
+1. E1
+  1. |E2
+  2. E3|
+
+output:
+1. E1
+2. |E2
+3. E3|
+*/
+it('should un-indent multiple list items (start/end)', () => {
+  const input = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>E1</hlic>
+          <hul>
+            <hli>
+              <hlic>
+                <focus />
+                E2
+              </hlic>
+            </hli>
+            <hli>
+              <hlic>
+                E3
+                <anchor />
               </hlic>
             </hli>
           </hul>
@@ -137,17 +223,18 @@ it('should un-indent multiple list items', () => {
     <editor>
       <hul>
         <hli>
-          <hlic>first element</hlic>
+          <hlic>E1</hlic>
         </hli>
         <hli>
           <hlic>
             <focus />
-            second element
+            E2
           </hlic>
         </hli>
         <hli>
           <hlic>
-            third element <anchor />
+            E3
+            <anchor />
           </hlic>
         </hli>
       </hul>
@@ -163,6 +250,77 @@ it('should un-indent multiple list items', () => {
     plugins: [createListPlugin()],
   });
 
-  onKeyDownList(editor, getPlugin<HotkeyPlugin>(editor, 'ul'))(event as any);
+  onKeyDownList(editor, getPlugin<HotkeyPlugin>(editor, 'list'))(event as any);
+  expect(editor.children).toEqual(output.children);
+});
+
+/*
+input:
+1. E1
+  1. |E2
+  2. E3
+|
+
+output:
+1. E1
+2. |E2
+3. E3
+|
+*/
+it('should un-indent multiple list items (start/out)', () => {
+  const input = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>E1</hlic>
+          <hul>
+            <hli>
+              <hlic>
+                <focus />
+                E2
+              </hlic>
+            </hli>
+            <hli>
+              <hlic>E3</hlic>
+            </hli>
+            <anchor />
+          </hul>
+        </hli>
+      </hul>
+    </editor>
+  ) as any;
+
+  const output = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>E1</hlic>
+        </hli>
+        <hli>
+          <hlic>
+            <focus />
+            E2
+          </hlic>
+        </hli>
+        <hli>
+          <hlic>
+            E3
+            <anchor />
+          </hlic>
+        </hli>
+      </hul>
+    </editor>
+  ) as any;
+
+  const event = new KeyboardEvent('keydown', {
+    shiftKey: true,
+    key: 'Tab',
+  }) as any;
+  const editor = createPlateUIEditor({
+    editor: input,
+    plugins: [createListPlugin()],
+  });
+
+  onKeyDownList(editor, getPlugin<HotkeyPlugin>(editor, 'list'))(event as any);
   expect(editor.children).toEqual(output.children);
 });

--- a/packages/nodes/list/src/onkeyDownList.spec.tsx
+++ b/packages/nodes/list/src/onkeyDownList.spec.tsx
@@ -1,0 +1,168 @@
+/** @jsx jsx */
+
+import { getPlugin, HotkeyPlugin, Hotkeys } from '@udecode/plate-core';
+import { createListPlugin } from '@udecode/plate-list';
+import { jsx } from '@udecode/plate-test-utils';
+import { createPlateUIEditor } from '@udecode/plate-ui/src/utils/createPlateUIEditor';
+import * as isHotkey from 'is-hotkey';
+import { onKeyDownList } from './onKeyDownList';
+
+jsx;
+
+it('should indent single list item', () => {
+  const input = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>some text</hlic>
+        </hli>
+        <hli>
+          <hlic>
+            <cursor />
+            some text
+          </hlic>
+        </hli>
+      </hul>
+    </editor>
+  ) as any;
+
+  const output = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>some text</hlic>
+          <hul>
+            <hli>
+              <hlic>
+                <cursor />
+                some text
+              </hlic>
+            </hli>
+          </hul>
+        </hli>
+      </hul>
+    </editor>
+  ) as any;
+
+  const event = new KeyboardEvent('keydown', { key: 'Tab' }) as any;
+  const editor = createPlateUIEditor({
+    editor: input,
+    plugins: [createListPlugin()],
+  });
+
+  onKeyDownList(editor, getPlugin<HotkeyPlugin>(editor, 'ul'))(event as any);
+  expect(editor.children).toEqual(output.children);
+});
+
+it('should indent multiple list items', () => {
+  const input = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>first element</hlic>
+        </hli>
+        <hli>
+          <hlic>
+            <focus />
+            second element
+          </hlic>
+        </hli>
+        <hli>
+          <hlic>
+            third element <anchor />
+          </hlic>
+        </hli>
+      </hul>
+    </editor>
+  ) as any;
+
+  const output = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>first element</hlic>
+          <hul>
+            <hli>
+              <hlic>
+                <focus />
+                second element
+              </hlic>
+            </hli>
+            <hli>
+              <hlic>
+                third element <anchor />
+              </hlic>
+            </hli>
+          </hul>
+        </hli>
+      </hul>
+    </editor>
+  ) as any;
+
+  const event = new KeyboardEvent('keydown', { key: 'Tab' }) as any;
+  const editor = createPlateUIEditor({
+    editor: input,
+    plugins: [createListPlugin()],
+  });
+
+  onKeyDownList(editor, getPlugin<HotkeyPlugin>(editor, 'ul'))(event as any);
+  expect(editor.children).toEqual(output.children);
+});
+
+it('should un-indent multiple list items', () => {
+  const input = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>first element</hlic>
+          <hul>
+            <hli>
+              <hlic>
+                <focus />
+                second element
+              </hlic>
+            </hli>
+            <hli>
+              <hlic>
+                third element <anchor />
+              </hlic>
+            </hli>
+          </hul>
+        </hli>
+      </hul>
+    </editor>
+  ) as any;
+
+  const output = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>first element</hlic>
+        </hli>
+        <hli>
+          <hlic>
+            <focus />
+            second element
+          </hlic>
+        </hli>
+        <hli>
+          <hlic>
+            third element <anchor />
+          </hlic>
+        </hli>
+      </hul>
+    </editor>
+  ) as any;
+
+  const event = new KeyboardEvent('keydown', {
+    shiftKey: true,
+    key: 'Tab',
+  }) as any;
+  const editor = createPlateUIEditor({
+    editor: input,
+    plugins: [createListPlugin()],
+  });
+
+  onKeyDownList(editor, getPlugin<HotkeyPlugin>(editor, 'ul'))(event as any);
+  expect(editor.children).toEqual(output.children);
+});

--- a/packages/nodes/list/src/onkeyDownList.spec.tsx
+++ b/packages/nodes/list/src/onkeyDownList.spec.tsx
@@ -164,7 +164,8 @@ it('should indent multiple list items (start/end)', () => {
             </hli>
             <hli>
               <hlic>
-                E3<anchor />
+                E3
+                <anchor />
               </hlic>
             </hli>
           </hul>
@@ -281,9 +282,11 @@ it('should un-indent multiple list items (start/out)', () => {
               </hlic>
             </hli>
             <hli>
-              <hlic>E3</hlic>
+              <hlic>
+                E3
+                <anchor />
+              </hlic>
             </hli>
-            <anchor />
           </hul>
         </hli>
       </hul>
@@ -314,6 +317,71 @@ it('should un-indent multiple list items (start/out)', () => {
 
   const event = new KeyboardEvent('keydown', {
     shiftKey: true,
+    key: 'Tab',
+  }) as any;
+  const editor = createPlateUIEditor({
+    editor: input,
+    plugins: [createListPlugin()],
+  });
+
+  onKeyDownList(editor, getPlugin<HotkeyPlugin>(editor, 'list'))(event as any);
+  expect(editor.children).toEqual(output.children);
+});
+
+it('should unhang before indentation', () => {
+  const input = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>E1</hlic>
+        </hli>
+        <hli>
+          <hlic>
+            <focus />
+            E2
+          </hlic>
+        </hli>
+        <hli>
+          <hlic>E3</hlic>
+        </hli>
+      </hul>
+      <hp>
+        <htext>
+          <anchor />
+          paragraph
+        </htext>
+      </hp>
+    </editor>
+  ) as any;
+
+  const output = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>E1</hlic>
+          <hul>
+            <hli>
+              <hlic>
+                <focus />
+                E2
+              </hlic>
+            </hli>
+            <hli>
+              <hlic>E3</hlic>
+            </hli>
+          </hul>
+        </hli>
+      </hul>
+      <hp>
+        <htext>
+          <anchor />
+          paragraph
+        </htext>
+      </hp>
+    </editor>
+  ) as any;
+
+  const event = new KeyboardEvent('keydown', {
     key: 'Tab',
   }) as any;
   const editor = createPlateUIEditor({


### PR DESCRIPTION
**Description**

This fixes a whole class of list indentation bugs that are introduced due to "hanging" nodes. 

There is still a bug in Slate's hang code for which @davisg123 created [this PR](https://github.com/ianstormtaylor/slate/pull/5039).

See changesets.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->
Before:

https://user-images.githubusercontent.com/5635880/176800545-fb866e13-ec71-4151-82cd-c238ac6dfaa1.mp4




After:

https://user-images.githubusercontent.com/5635880/176800439-32570d2e-e88f-493c-b912-2138ed32fab5.mp4




