### PR TITLE
Some types of nested lists are not unwrapped completely

### DIFF
--- a/.changeset/giant-toes-shave.md
+++ b/.changeset/giant-toes-shave.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-list': patch
+---
+
+Some types of nested lists are not unwrapped completely

--- a/packages/nodes/list/src/transforms/unwrapList.spec.tsx
+++ b/packages/nodes/list/src/transforms/unwrapList.spec.tsx
@@ -1,0 +1,180 @@
+/** @jsx jsx */
+
+import { PlateEditor } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { createPlateUIEditor } from '../../../../ui/plate/src/utils/createPlateUIEditor';
+import { createListPlugin } from '../createListPlugin';
+import { unwrapList } from './unwrapList';
+
+jsx;
+
+describe('li list unwrapping', () => {
+  it('should unwrap a nested list ul > single li', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>
+              <anchor />1
+            </hlic>
+            <hul>
+              <hli>
+                <hlic>11</hlic>
+                <hlic>
+                  12
+                  <focus />
+                </hlic>
+              </hli>
+            </hul>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const output = ((
+      <editor>
+        <hp>1</hp>
+        <hp>11</hp>
+        <hp>12</hp>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const editor = createPlateUIEditor({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    unwrapList(editor);
+
+    expect(input.children).toEqual(output.children);
+  });
+
+  it('should unwrap a nested list ul > single li, collapsed selection', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>
+              <cursor />1
+            </hlic>
+          </hli>
+          <hli>
+            <hlic>2</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const output = ((
+      <editor>
+        <hp>1</hp>
+        <hul>
+          <hli>
+            <hlic>
+              <cursor />2
+            </hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const editor = createPlateUIEditor({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    unwrapList(editor);
+
+    expect(input.children).toEqual(output.children);
+  });
+
+  it('should unwrap a nested list ul > multiple li', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>
+              <anchor />1
+            </hlic>
+            <hul>
+              <hli>
+                <hlic>11</hlic>
+              </hli>
+            </hul>
+          </hli>
+          <hli>
+            <hlic>
+              2
+              <focus />
+            </hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const output = ((
+      <editor>
+        <hp>1</hp>
+        <hp>11</hp>
+        <hp>2</hp>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const editor = createPlateUIEditor({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    unwrapList(editor);
+
+    expect(input.children).toEqual(output.children);
+  });
+
+  it('should unwrap a nested list ul > multiple li, collapsed selection', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>
+              <cursor />1
+            </hlic>
+            <hul>
+              <hli>
+                <hlic>11</hlic>
+              </hli>
+            </hul>
+          </hli>
+          <hli>
+            <hlic>2</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const output = ((
+      <editor>
+        <hp>1</hp>
+        <hul>
+          <hli>
+            <hlic>
+              <cursor />
+              11
+            </hlic>
+          </hli>
+          <hli>
+            <hlic>2</hlic>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const editor = createPlateUIEditor({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    unwrapList(editor);
+
+    expect(input.children).toEqual(output.children);
+  });
+});

--- a/packages/nodes/list/src/transforms/unwrapList.ts
+++ b/packages/nodes/list/src/transforms/unwrapList.ts
@@ -1,7 +1,9 @@
 import {
   ELEMENT_DEFAULT,
   getAboveNode,
+  getCommonNode,
   getPluginType,
+  isElement,
   PlateEditor,
   setElements,
   unwrapNodes,
@@ -16,6 +18,29 @@ export const unwrapList = <V extends Value>(
   editor: PlateEditor<V>,
   { at }: { at?: Path } = {}
 ) => {
+  const anyAncestorIsListType = () => {
+    if (getAboveNode(editor, { match: { type: getListTypes(editor), at } })) {
+      return true;
+    }
+
+    // The selection's common node might be a list type
+    if (!at && editor.selection) {
+      const commonNode = getCommonNode(
+        editor,
+        editor.selection.anchor.path,
+        editor.selection.focus.path
+      );
+      if (
+        isElement(commonNode[0]) &&
+        getListTypes(editor).includes(commonNode[0].type)
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+
   withoutNormalizing(editor, () => {
     do {
       setElements(editor, {
@@ -38,8 +63,6 @@ export const unwrapList = <V extends Value>(
         },
         split: true,
       });
-    } while (
-      getAboveNode(editor, { match: { type: getListTypes(editor), at } })
-    );
+    } while (anyAncestorIsListType());
   });
 };


### PR DESCRIPTION
**Description**

See changesets.

If a nested list selection has several `li` elements at the top level, `getAboveNode` returns the parent of the common ancestor which is not a list type and the script does not recurse the proper number of times.

Add an additional check to continue recursing for as long as the selection's common node is a list type.
 
<!-- **Example** -->

Previously Plate failed to unwrap this list:

```
      <editor>
        <hul>
          <hli>
            <hlic>
              <anchor />1
            </hlic>
            <hul>
              <hli>
                <hlic>11</hlic>
              </hli>
            </hul>
          </hli>
          <hli>
            <hlic>
              2
              <focus />
            </hlic>
          </hli>
        </hul>
      </editor>
```

<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

Video of broken behavior:

https://user-images.githubusercontent.com/2341305/176779526-e8ed1abe-5f8c-412c-a9e0-2f5216c16b01.mov


Video of new behavior:

https://user-images.githubusercontent.com/2341305/176779562-fd336bee-0efd-438f-933f-33765a9dd43f.mov


