### PR TITLE
Continue unwrapping a list until no list items remain in the range

### DIFF
--- a/.changeset/pretty-pots-attend.md
+++ b/.changeset/pretty-pots-attend.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-list': patch
+---
+
+Continue unwrapping a list until no list items remain in the range

--- a/packages/nodes/list/src/transforms/unwrapList.spec.tsx
+++ b/packages/nodes/list/src/transforms/unwrapList.spec.tsx
@@ -49,6 +49,73 @@ describe('li list unwrapping', () => {
     expect(input.children).toEqual(output.children);
   });
 
+  it('should unwrap only the selected part of a nested list ul > single li', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>
+              <anchor />1
+            </hlic>
+            <hul>
+              <hli>
+                <hlic>11</hlic>
+                <hlic>
+                  12
+                  <focus />
+                </hlic>
+              </hli>
+            </hul>
+          </hli>
+        </hul>
+        <hul>
+          <hli>
+            <hlic>1</hlic>
+            <hul>
+              <hli>
+                <hlic>11</hlic>
+                <hlic>12</hlic>
+              </hli>
+            </hul>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const output = ((
+      <editor>
+        <hp>1</hp>
+        <hp>11</hp>
+        <hp>12</hp>
+        <hul>
+          <hli>
+            <hlic>
+              <anchor />1
+            </hlic>
+            <hul>
+              <hli>
+                <hlic>11</hlic>
+                <hlic>
+                  12
+                  <focus />
+                </hlic>
+              </hli>
+            </hul>
+          </hli>
+        </hul>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const editor = createPlateUIEditor({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    unwrapList(editor);
+
+    expect(input.children).toEqual(output.children);
+  });
+
   it('should unwrap a nested list ul > single li, collapsed selection', () => {
     const input = ((
       <editor>

--- a/packages/nodes/list/src/transforms/unwrapList.spec.tsx
+++ b/packages/nodes/list/src/transforms/unwrapList.spec.tsx
@@ -130,6 +130,50 @@ describe('li list unwrapping', () => {
     expect(input.children).toEqual(output.children);
   });
 
+  it('should unwrap a nested list ul > multiple li with a p', () => {
+    const input = ((
+      <editor>
+        <hul>
+          <hli>
+            <hlic>
+              <anchor />1
+            </hlic>
+            <hul>
+              <hli>
+                <hlic>11</hlic>
+              </hli>
+            </hul>
+          </hli>
+          <hli>
+            <hlic>2</hlic>
+          </hli>
+        </hul>
+        <hp>
+          body
+          <focus />
+        </hp>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const output = ((
+      <editor>
+        <hp>1</hp>
+        <hp>11</hp>
+        <hp>2</hp>
+        <hp>body</hp>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const editor = createPlateUIEditor({
+      editor: input,
+      plugins: [createListPlugin()],
+    });
+
+    unwrapList(editor);
+
+    expect(input.children).toEqual(output.children);
+  });
+
   it('should unwrap a nested list ul > multiple li, collapsed selection', () => {
     const input = ((
       <editor>

--- a/packages/nodes/list/src/transforms/unwrapList.ts
+++ b/packages/nodes/list/src/transforms/unwrapList.ts
@@ -2,6 +2,7 @@ import {
   ELEMENT_DEFAULT,
   getAboveNode,
   getCommonNode,
+  getNodeEntries,
   getPluginType,
   isElement,
   PlateEditor,
@@ -12,33 +13,24 @@ import {
 } from '@udecode/plate-core';
 import { Path } from 'slate';
 import { ELEMENT_LI, ELEMENT_OL, ELEMENT_UL } from '../createListPlugin';
-import { getListTypes } from '../queries';
 
 export const unwrapList = <V extends Value>(
   editor: PlateEditor<V>,
   { at }: { at?: Path } = {}
 ) => {
-  const ancestorListTypeCheck = () => {
-    if (getAboveNode(editor, { match: { type: getListTypes(editor), at } })) {
-      return true;
-    }
-
-    // The selection's common node might be a list type
-    if (!at && editor.selection) {
-      const commonNode = getCommonNode(
-        editor,
-        editor.selection.anchor.path,
-        editor.selection.focus.path
-      );
-      if (
-        isElement(commonNode[0]) &&
-        getListTypes(editor).includes(commonNode[0].type)
-      ) {
-        return true;
+  const foundAnyListNodes = () => {
+    const listNodes = getNodeEntries(editor, {
+      at,
+      match: {
+        type: [
+          getPluginType(editor, ELEMENT_LI),
+          getPluginType(editor, ELEMENT_UL),
+          getPluginType(editor, ELEMENT_OL),
+        ],
       }
-    }
+    });
 
-    return false;
+    return Array.from(listNodes).length;
   };
 
   withoutNormalizing(editor, () => {
@@ -63,6 +55,6 @@ export const unwrapList = <V extends Value>(
         },
         split: true,
       });
-    } while (ancestorListTypeCheck());
+    } while (foundAnyListNodes());
   });
 };


### PR DESCRIPTION
**Description**

See changesets.

I discovered an additional broken case for list unwrapping and came up with a simpler rule:
we should continue to iterate until there are no more list elements remaining in the selection 

