### PR TITLE
allow unindent of top level list item

### DIFF
--- a/.changeset/real-pigs-punch.md
+++ b/.changeset/real-pigs-punch.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-list': minor
+---
+
+Allow un-indenting top level list items

--- a/packages/nodes/list/src/onKeyDownList.ts
+++ b/packages/nodes/list/src/onKeyDownList.ts
@@ -14,13 +14,17 @@ import isHotkey from 'is-hotkey';
 import { castArray } from 'lodash';
 import { Range } from 'slate';
 import { moveListItems, toggleList } from './transforms';
+import { ListPlugin } from './types';
 
 export const onKeyDownList = <
   V extends Value = Value,
   E extends PlateEditor<V> = PlateEditor<V>
 >(
   editor: E,
-  { type, options: { hotkey } }: WithPlatePlugin<HotkeyPlugin, V, E>
+  {
+    type,
+    options: { hotkey, enableResetOnShiftTab },
+  }: WithPlatePlugin<ListPlugin, V, E>
 ): KeyboardHandlerReturnType => (e) => {
   const isTab = Hotkeys.isTab(editor, e);
   const isUntab = Hotkeys.isUntab(editor, e);
@@ -53,7 +57,11 @@ export const onKeyDownList = <
 
     if (workRange && listSelected) {
       e.preventDefault();
-      moveListItems(editor, { at: workRange, increase: isTab });
+      moveListItems(editor, {
+        at: workRange,
+        increase: isTab,
+        enableResetOnShiftTab,
+      });
       return true;
     }
   }

--- a/packages/nodes/list/src/onkeyDownList.spec.tsx
+++ b/packages/nodes/list/src/onkeyDownList.spec.tsx
@@ -393,7 +393,7 @@ it('should unhang before indentation', () => {
   expect(editor.children).toEqual(output.children);
 });
 
-it('should convert top-level list item into body upon unindent', () => {
+it('should convert top-level list item into body upon unindent if enableResetOnShiftTab is true', () => {
   const input = (
     <editor>
       <hul>
@@ -424,6 +424,58 @@ it('should convert top-level list item into body upon unindent', () => {
         <htext>E2</htext>
       </hp>
       <hul>
+        <hli>
+          <hlic>E3</hlic>
+        </hli>
+      </hul>
+    </editor>
+  ) as any;
+
+  const event = new KeyboardEvent('keydown', {
+    key: 'Tab',
+    shiftKey: true,
+  }) as any;
+  const editor = createPlateUIEditor({
+    editor: input,
+    plugins: [createListPlugin({ options: { enableResetOnShiftTab: true } })],
+  });
+
+  onKeyDownList(editor, getPlugin<HotkeyPlugin>(editor, 'list'))(event as any);
+  expect(editor.children).toEqual(output.children);
+});
+
+it('should NOT convert top-level list item into body upon unindent if enableResetOnShiftTab is false', () => {
+  const input = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>E1</hlic>
+        </hli>
+        <hli>
+          <hlic>
+            <cursor />
+            E2
+          </hlic>
+        </hli>
+        <hli>
+          <hlic>E3</hlic>
+        </hli>
+      </hul>
+    </editor>
+  ) as any;
+
+  const output = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>E1</hlic>
+        </hli>
+        <hli>
+          <hlic>
+            <cursor />
+            E2
+          </hlic>
+        </hli>
         <hli>
           <hlic>E3</hlic>
         </hli>

--- a/packages/nodes/list/src/onkeyDownList.spec.tsx
+++ b/packages/nodes/list/src/onkeyDownList.spec.tsx
@@ -392,3 +392,54 @@ it('should unhang before indentation', () => {
   onKeyDownList(editor, getPlugin<HotkeyPlugin>(editor, 'list'))(event as any);
   expect(editor.children).toEqual(output.children);
 });
+
+it('should convert top-level list item into body upon unindent', () => {
+  const input = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>E1</hlic>
+        </hli>
+        <hli>
+          <hlic>
+            <cursor />
+            E2
+          </hlic>
+        </hli>
+        <hli>
+          <hlic>E3</hlic>
+        </hli>
+      </hul>
+    </editor>
+  ) as any;
+
+  const output = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>E1</hlic>
+        </hli>
+      </hul>
+      <hp>
+        <htext>E2</htext>
+      </hp>
+      <hul>
+        <hli>
+          <hlic>E3</hlic>
+        </hli>
+      </hul>
+    </editor>
+  ) as any;
+
+  const event = new KeyboardEvent('keydown', {
+    key: 'Tab',
+    shiftKey: true,
+  }) as any;
+  const editor = createPlateUIEditor({
+    editor: input,
+    plugins: [createListPlugin()],
+  });
+
+  onKeyDownList(editor, getPlugin<HotkeyPlugin>(editor, 'list'))(event as any);
+  expect(editor.children).toEqual(output.children);
+});

--- a/packages/nodes/list/src/transforms/moveListItems.ts
+++ b/packages/nodes/list/src/transforms/moveListItems.ts
@@ -18,6 +18,7 @@ import { removeFirstListItem } from './removeFirstListItem';
 export type MoveListItemsOptions = {
   increase?: boolean;
   at?: GetNodeEntriesOptions['at'];
+  enableResetOnShiftTab?: boolean;
 };
 
 export const moveListItems = <V extends Value>(
@@ -25,6 +26,7 @@ export const moveListItems = <V extends Value>(
   {
     increase = true,
     at = editor.selection ?? undefined,
+    enableResetOnShiftTab,
   }: MoveListItemsOptions = {}
 ) => {
   const _nodes = getNodeEntries(editor, {
@@ -84,7 +86,7 @@ export const moveListItems = <V extends Value>(
           list: parentList as any,
           listItem: listItem as any,
         });
-      } else {
+      } else if (enableResetOnShiftTab) {
         // unindenting a top level list item, effectively breaking apart the list.
         removeFirstListItem(editor, {
           list: parentList as any,

--- a/packages/nodes/list/src/transforms/moveListItems.ts
+++ b/packages/nodes/list/src/transforms/moveListItems.ts
@@ -13,6 +13,7 @@ import { ELEMENT_LIC } from '../createListPlugin';
 import { isListNested } from '../queries/isListNested';
 import { moveListItemDown } from './moveListItemDown';
 import { moveListItemUp } from './moveListItemUp';
+import { removeFirstListItem } from './removeFirstListItem';
 
 export type MoveListItemsOptions = {
   increase?: boolean;
@@ -68,18 +69,29 @@ export const moveListItems = <V extends Value>(
 
       const listItem = getParentNode(editor, licPath);
       if (!listItem) return;
-      const listEntry = getParentNode(editor, listItem[1]);
+      const parentList = getParentNode(editor, listItem[1]);
+
+      // this shouldn't happen
+      if (!parentList) return;
 
       if (increase) {
         moveListItemDown(editor, {
-          list: listEntry as any,
+          list: parentList as any,
           listItem: listItem as any,
         });
-      } else if (listEntry && isListNested(editor, listEntry[1])) {
+      } else if (isListNested(editor, parentList[1])) {
+        // un-indent a sub-list item
         moveListItemUp(editor, {
-          list: listEntry as any,
+          list: parentList as any,
           listItem: listItem as any,
         });
+      } else {
+        // unindenting a top level list item, effectively breaking apart the list.
+        const moved = removeFirstListItem(editor, {
+          list: parentList as any,
+          listItem: listItem as any,
+        });
+        if (moved) return true;
       }
     });
   });

--- a/packages/nodes/list/src/transforms/moveListItems.ts
+++ b/packages/nodes/list/src/transforms/moveListItems.ts
@@ -69,9 +69,8 @@ export const moveListItems = <V extends Value>(
 
       const listItem = getParentNode(editor, licPath);
       if (!listItem) return;
-      const parentList = getParentNode(editor, listItem[1]);
 
-      // this shouldn't happen
+      const parentList = getParentNode(editor, listItem[1]);
       if (!parentList) return;
 
       if (increase) {
@@ -87,11 +86,10 @@ export const moveListItems = <V extends Value>(
         });
       } else {
         // unindenting a top level list item, effectively breaking apart the list.
-        const moved = removeFirstListItem(editor, {
+        removeFirstListItem(editor, {
           list: parentList as any,
           listItem: listItem as any,
         });
-        if (moved) return true;
       }
     });
   });

--- a/packages/nodes/list/src/types.ts
+++ b/packages/nodes/list/src/types.ts
@@ -5,4 +5,5 @@ export interface ListPlugin extends HotkeyPlugin {
    * Valid children types for list items, in addition to p and ul types.
    */
   validLiChildrenTypes?: string[];
+  enableResetOnShiftTab?: boolean;
 }


### PR DESCRIPTION
**Description**

See changesets.

Given a list:
```
1. E1
2. <cursor>E2
3. E3
```

When user presses `Shift+Tab` to un-indent, it should break apart the list. Currently, Plate does not allow unindenting beyond level 1. The correct output after unindent should be:

```
1. E1
<cursor>E2
1. E3
```


<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

