### PR TITLE
HTML Serializer: Ensures options are passed down

### DIFF
--- a/.changeset/mighty-ducks-taste.md
+++ b/.changeset/mighty-ducks-taste.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-serializer-html": patch
+---
+
+- fix `serializeHtml`: `convertNewLinesToHtmlBr` option was not used

--- a/packages/serializers/html/src/serializeHtml.ts
+++ b/packages/serializers/html/src/serializeHtml.ts
@@ -87,6 +87,7 @@ export const serializeHtml = <V extends Value>(
             nodes: node.children as EDescendant<V>[],
             preserveClassNames,
             stripWhitespace,
+            convertNewLinesToHtmlBr,
           }),
           attributes: { 'data-slate-node': 'element', ref: null },
           editor,


### PR DESCRIPTION
**Description**

This fixes an oversight in my latest PR ([#1633](https://github.com/udecode/plate/pull/1633#issuecomment-1175947681)) where the `convertNewLinesToHtmlBr` option was not passed down to the recursive call of `serializeHtml`.

Thanks to @igorsheg-wix for pointing this out!