### PR TITLE
Fix the unindent problem; add a test

### DIFF
--- a/.changeset/cyan-snails-grow.md
+++ b/.changeset/cyan-snails-grow.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-list': minor
+---
+
+Allow escape unindent of the first element of a list

--- a/packages/nodes/list/src/onKeyDownList.ts
+++ b/packages/nodes/list/src/onKeyDownList.ts
@@ -1,6 +1,5 @@
 import {
   getAboveNode,
-  HotkeyPlugin,
   Hotkeys,
   isCollapsed,
   KeyboardHandlerReturnType,
@@ -40,7 +39,7 @@ export const onKeyDownList = <
         ? { anchor: selection.focus, focus: selection.anchor }
         : { anchor: selection.anchor, focus: selection.focus };
 
-      // This is a workaround for a Slate bug 
+      // This is a workaround for a Slate bug
       // See: https://github.com/ianstormtaylor/slate/pull/5039
       anchor.offset = 0;
       const unHungRange = unhangRange(editor, { anchor, focus });

--- a/packages/nodes/list/src/onkeyDownList.spec.tsx
+++ b/packages/nodes/list/src/onkeyDownList.spec.tsx
@@ -444,6 +444,104 @@ it('should convert top-level list item into body upon unindent if enableResetOnS
   expect(editor.children).toEqual(output.children);
 });
 
+it('should convert top-level (first) list item into body upon unindent if enableResetOnShiftTab is true', () => {
+  const input = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>
+            <cursor />
+            E1
+          </hlic>
+        </hli>
+        <hli>
+          <hlic>E2</hlic>
+        </hli>
+        <hli>
+          <hlic>E3</hlic>
+        </hli>
+      </hul>
+    </editor>
+  ) as any;
+
+  const output = (
+    <editor>
+      <hp>
+        <htext>E1</htext>
+      </hp>
+      <hul>
+        <hli>
+          <hlic>E2</hlic>
+        </hli>
+        <hli>
+          <hlic>E3</hlic>
+        </hli>
+      </hul>
+    </editor>
+  ) as any;
+
+  const event = new KeyboardEvent('keydown', {
+    key: 'Tab',
+    shiftKey: true,
+  }) as any;
+  const editor = createPlateUIEditor({
+    editor: input,
+    plugins: [createListPlugin({ options: { enableResetOnShiftTab: true } })],
+  });
+
+  onKeyDownList(editor, getPlugin<HotkeyPlugin>(editor, 'list'))(event as any);
+  expect(editor.children).toEqual(output.children);
+});
+
+it('should convert top-level (last) list item into body upon unindent if enableResetOnShiftTab is true', () => {
+  const input = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>E1</hlic>
+        </hli>
+        <hli>
+          <hlic>E2</hlic>
+        </hli>
+        <hli>
+          <hlic>
+            <cursor />
+            E3
+          </hlic>
+        </hli>
+      </hul>
+    </editor>
+  ) as any;
+
+  const output = (
+    <editor>
+      <hul>
+        <hli>
+          <hlic>E1</hlic>
+        </hli>
+        <hli>
+          <hlic>E2</hlic>
+        </hli>
+      </hul>
+      <hp>
+        <htext>E3</htext>
+      </hp>
+    </editor>
+  ) as any;
+
+  const event = new KeyboardEvent('keydown', {
+    key: 'Tab',
+    shiftKey: true,
+  }) as any;
+  const editor = createPlateUIEditor({
+    editor: input,
+    plugins: [createListPlugin({ options: { enableResetOnShiftTab: true } })],
+  });
+
+  onKeyDownList(editor, getPlugin<HotkeyPlugin>(editor, 'list'))(event as any);
+  expect(editor.children).toEqual(output.children);
+});
+
 it('should NOT convert top-level list item into body upon unindent if enableResetOnShiftTab is false', () => {
   const input = (
     <editor>

--- a/packages/nodes/list/src/transforms/removeFirstListItem.ts
+++ b/packages/nodes/list/src/transforms/removeFirstListItem.ts
@@ -1,9 +1,4 @@
-import {
-  isFirstChild,
-  PlateEditor,
-  TElementEntry,
-  Value,
-} from '@udecode/plate-core';
+import { PlateEditor, TElementEntry, Value } from '@udecode/plate-core';
 import { isListNested } from '../queries/isListNested';
 import { moveListItemUp } from './moveListItemUp';
 
@@ -21,9 +16,8 @@ export const removeFirstListItem = <V extends Value>(
   }
 ) => {
   const [, listPath] = list;
-  const [, listItemPath] = listItem;
 
-  if (!isListNested(editor, listPath) && !isFirstChild(listItemPath)) {
+  if (!isListNested(editor, listPath)) {
     moveListItemUp(editor, { list, listItem });
 
     return true;


### PR DESCRIPTION
**Description**

In Previous PR (https://github.com/udecode/plate/pull/1663), I forgot to add a case for top level list item which specifically was disallowed from being pulled up.

In this PR I added the failing test case and fixed the implementation. 
![CleanShot 2022-07-07 at 16 12 39](https://user-images.githubusercontent.com/5635880/177886654-12036774-b08d-4ec9-a14c-5d4480d3389d.gif)

See changesets.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

