### PR TITLE
Add ability to escape a text autoformat rule by pressing backspace

### DIFF
--- a/.changeset/stale-swans-buy.md
+++ b/.changeset/stale-swans-buy.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-autoformat': minor
+---
+
+Add ability to escape text autoformat rule with backspace

--- a/examples/src/autoformat/autoformatPlugin.ts
+++ b/examples/src/autoformat/autoformatPlugin.ts
@@ -7,5 +7,6 @@ export const autoformatPlugin: Partial<
 > = {
   options: {
     rules: autoformatRules as any,
+    enableUndoOnDelete: true,
   },
 };

--- a/packages/editor/autoformat/src/__tests__/withAutoformat/trigger.spec.tsx
+++ b/packages/editor/autoformat/src/__tests__/withAutoformat/trigger.spec.tsx
@@ -1,11 +1,16 @@
 /** @jsx jsx */
 
-import { createPlateEditor } from '@udecode/plate-core';
+import { createPlateEditor, getPlugin } from '@udecode/plate-core';
 import { jsx } from '@udecode/plate-test-utils';
 import { MARK_BOLD } from '../../../../../nodes/basic-marks/src/createBoldPlugin';
 import { MARK_ITALIC } from '../../../../../nodes/basic-marks/src/createItalicPlugin';
 import { MARK_UNDERLINE } from '../../../../../nodes/basic-marks/src/createUnderlinePlugin';
-import { createAutoformatPlugin } from '../../createAutoformatPlugin';
+import {
+  createAutoformatPlugin,
+  KEY_AUTOFORMAT,
+} from '../../createAutoformatPlugin';
+import onKeyDownAutoformat from '../../onKeyDownAutoformat';
+import { AutoformatPlugin } from '../../types';
 
 jsx;
 
@@ -52,5 +57,109 @@ describe('when trigger is defined', () => {
     editor.insertText('_');
 
     expect(input.children).toEqual(output.children);
+  });
+});
+
+describe('when undo is enabled', () => {
+  it('should undo text format upon delete', () => {
+    const undoInput = (
+      <editor>
+        <hp>
+          1/
+          <cursor />
+        </hp>
+      </editor>
+    ) as any;
+
+    const undoOutput = (
+      <editor>
+        <hp>
+          1/4
+          <cursor />
+        </hp>
+      </editor>
+    ) as any;
+
+    const editor = createPlateEditor({
+      editor: undoInput,
+      plugins: [
+        createAutoformatPlugin({
+          options: {
+            enableUndoOnDelete: true,
+            rules: [
+              {
+                mode: 'text',
+                match: '1/4',
+                format: '¼',
+              },
+            ],
+          },
+        }),
+      ],
+    });
+
+    editor.insertText('4'); // <-- this should triger the conversion
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'backspace',
+    }) as any;
+
+    onKeyDownAutoformat(
+      editor,
+      getPlugin<AutoformatPlugin>(editor, KEY_AUTOFORMAT)
+    )(event as any);
+
+    expect(undoInput.children).toEqual(undoOutput.children);
+  });
+});
+
+describe('when undo is disabled', () => {
+  it('should delete the autoformat text character itself', () => {
+    const undoInput = (
+      <editor>
+        <hp>
+          1/
+          <cursor />
+        </hp>
+      </editor>
+    ) as any;
+
+    const undoOutput = (
+      <editor>
+        <hp>
+          ¼<cursor />
+        </hp>
+      </editor>
+    ) as any;
+
+    const editor = createPlateEditor({
+      editor: undoInput,
+      plugins: [
+        createAutoformatPlugin({
+          options: {
+            rules: [
+              {
+                mode: 'text',
+                match: '1/4',
+                format: '¼',
+              },
+            ],
+          },
+        }),
+      ],
+    });
+
+    editor.insertText('4'); // <-- this should triger the conversion
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'backspace',
+    }) as any;
+
+    onKeyDownAutoformat(
+      editor,
+      getPlugin<AutoformatPlugin>(editor, KEY_AUTOFORMAT)
+    )(event as any);
+
+    expect(undoInput.children).toEqual(undoOutput.children);
   });
 });

--- a/packages/editor/autoformat/src/createAutoformatPlugin.ts
+++ b/packages/editor/autoformat/src/createAutoformatPlugin.ts
@@ -1,4 +1,5 @@
 import { createPluginFactory } from '@udecode/plate-core';
+import onKeyDownAutoformat from './onKeyDownAutoformat';
 import { AutoformatPlugin } from './types';
 import { withAutoformat } from './withAutoformat';
 
@@ -10,6 +11,9 @@ export const KEY_AUTOFORMAT = 'autoformat';
 export const createAutoformatPlugin = createPluginFactory<AutoformatPlugin>({
   key: KEY_AUTOFORMAT,
   withOverrides: withAutoformat,
+  handlers: {
+    onKeyDown: onKeyDownAutoformat,
+  },
   options: {
     rules: [],
   },

--- a/packages/editor/autoformat/src/onKeyDownAutoformat.ts
+++ b/packages/editor/autoformat/src/onKeyDownAutoformat.ts
@@ -1,0 +1,93 @@
+import { KeyboardEvent } from 'react';
+import {
+  deleteBackward,
+  getEditorString,
+  getPointBefore,
+  insertText,
+  KeyboardHandlerReturnType,
+  PlateEditor,
+  Value,
+  WithPlatePlugin,
+} from '@udecode/plate-core';
+import isHotkey from 'is-hotkey';
+import { Range } from 'slate';
+import { AutoformatPlugin, AutoformatRule, AutoformatTextRule } from './types';
+
+const onKeyDownAutoformat = <
+  V extends Value = Value,
+  E extends PlateEditor<V> = PlateEditor<V>
+>(
+  editor: PlateEditor<V>,
+  {
+    options: { rules, enableUndoOnDelete },
+  }: WithPlatePlugin<AutoformatPlugin, V, E>
+): KeyboardHandlerReturnType => (e: KeyboardEvent) => {
+  // Abort quicky if hotKey was not pressed.
+
+  if (!isHotkey('backspace', { byKey: true }, e)) return false;
+
+  if (!rules) return false;
+  if (!enableUndoOnDelete) return false;
+
+  // Abort if selection is not collapsed i.e. we're not deleting single character.
+  const { selection } = editor;
+  if (!selection || !Range.isCollapsed(selection)) return;
+
+  // Get start and end point of selection.
+  // For example: Text|
+  //                  ^ cursor at the moment of pressing the hotkey
+  // start, end will be equal to the location of the |
+  const [start, end] = Range.edges(selection);
+
+  // Get location before the cursor.
+  // before will be a point one character before | so:
+  // Text|
+  //    ^
+  const before = getPointBefore(editor, end, {
+    unit: 'character',
+    distance: 1,
+  });
+  if (!start) return false;
+  if (!before) return false;
+
+  // Abort if there doesn't exist a valid character to replace.
+  const charRange = { anchor: before, focus: start };
+  if (!charRange) return false;
+
+  // Text|
+  //    ^
+  // Between ^ and | is t
+  const char = getEditorString(editor, charRange);
+  if (!char) return false;
+
+  const matchers: AutoformatRule[] = [...rules].filter((rule) => {
+    const textRule = rule as AutoformatTextRule;
+    if (textRule) {
+      return textRule.mode === 'text' && textRule.format === char;
+    }
+    return false;
+  });
+
+  // abort if no matching substitution is found.
+  if (!matchers || matchers.length === 0) return false;
+
+  e.preventDefault();
+
+  // remove the shorthand character.
+  deleteBackward(editor, { unit: 'character' });
+
+  // put back the orignal characters. This could match to a single string or an array.
+  const rule = matchers[0] as AutoformatTextRule;
+
+  if (rule && typeof rule.match === 'string') {
+    insertText(editor, rule.match);
+  } else {
+    const matchArray = rule.match as string[];
+    if (matchArray && matchArray.length > 0) {
+      insertText(editor, matchArray[0]);
+    }
+  }
+  return true;
+};
+
+export default onKeyDownAutoformat;

--- a/packages/editor/autoformat/src/types.ts
+++ b/packages/editor/autoformat/src/types.ts
@@ -144,4 +144,5 @@ export interface AutoformatPlugin<
    * A list of triggering rules.
    */
   rules?: AutoformatRule<V, E>[];
+  enableUndoOnDelete?: boolean;
 }


### PR DESCRIPTION
**Description**

Fixes [This issue](https://github.com/udecode/plate/issues/1678)

Previously, a text autoformat rule was impossible to undo. Usually there is a way to escape it. E.g. it was impossible to type `http://www.google.com` in the plate sandbox.
![CleanShot 2022-07-07 at 17 31 24](https://user-images.githubusercontent.com/5635880/177898951-bd343d70-6b53-40aa-9cae-4a836eca04af.gif)


This change allows the following behavior:
![CleanShot 2022-07-07 at 18 32 08](https://user-images.githubusercontent.com/5635880/177898845-836d59f6-ab9c-4964-b1c2-6d2a60de40c1.gif)

I added tests as well. 

See changesets.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

[](url)