### PR TITLE
Allow the link plugin to optionally specify a custom href for link text

### DIFF
--- a/.changeset/tough-pears-tickle.md
+++ b/.changeset/tough-pears-tickle.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-link': patch
+---
+
+Allow the link plugin to optionally specify a custom href for link text

--- a/packages/nodes/link/src/__tests__/withLink/insertText/space-after-url-across-blocks-custom-href.spec.tsx
+++ b/packages/nodes/link/src/__tests__/withLink/insertText/space-after-url-across-blocks-custom-href.spec.tsx
@@ -1,0 +1,61 @@
+/** @jsx jsx */
+
+import { createPlateEditor } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { createLinkPlugin } from '../../../createLinkPlugin';
+
+jsx;
+
+const input = (
+  <editor>
+    <hp>
+      link:{' '}
+      <element type="a" url="http://google.com">
+        google.com
+      </element>
+    </hp>
+    <hp>
+      test
+      <cursor />
+    </hp>
+  </editor>
+) as any;
+
+const text = ' ';
+
+const output = (
+  <editor>
+    <hp>
+      link:{' '}
+      <element type="a" url="http://google.com">
+        google.com
+      </element>
+    </hp>
+    <hp>
+      {'test '}
+      {/* keep above as string in quotes to force trailing space */}
+      <cursor />
+    </hp>
+  </editor>
+) as any;
+
+describe('when inserting a space with a link element in a preceeding block and using a custom href', () => {
+  it('should run default insertText', () => {
+    const editor = createPlateEditor({
+      editor: input,
+      plugins: [
+        createLinkPlugin({
+          options: {
+            getUrlHref: (url) => {
+              return 'http://google.com';
+            },
+          },
+        }),
+      ],
+    });
+
+    editor.insertText(text);
+
+    expect(input.children).toEqual(output.children);
+  });
+});

--- a/packages/nodes/link/src/__tests__/withLink/insertText/space-after-url-custom-href.spec.tsx
+++ b/packages/nodes/link/src/__tests__/withLink/insertText/space-after-url-custom-href.spec.tsx
@@ -9,13 +9,7 @@ jsx;
 const input = (
   <editor>
     <hp>
-      link:{' '}
-      <element type="a" url="http://google.com">
-        google.com
-      </element>
-    </hp>
-    <hp>
-      test
+      link: google.com
       <cursor />
     </hp>
   </editor>
@@ -29,23 +23,19 @@ const output = (
       link:{' '}
       <element type="a" url="http://google.com">
         google.com
-      </element>
-    </hp>
-    <hp>
-      {'test '}
-      {/* keep above as string in quotes to force trailing space */}
-      <cursor />
+      </element>{' '}
     </hp>
   </editor>
 ) as any;
 
-describe('when inserting a space with a link element in a preceeding block and using a custom href', () => {
-  it('should run default insertText', () => {
+describe('when inserting a space with a link element and using a custom href', () => {
+  it('should wrap the url in a link', () => {
     const editor = createPlateEditor({
       editor: input,
       plugins: [
         createLinkPlugin({
           options: {
+            isUrl: (url) => url === 'google.com',
             getUrlHref: (url) => {
               return 'http://google.com';
             },

--- a/packages/nodes/link/src/types.ts
+++ b/packages/nodes/link/src/types.ts
@@ -20,6 +20,12 @@ export interface LinkPlugin extends HotkeyPlugin {
   isUrl?: (text: string) => boolean;
 
   /**
+   * Callback to optionally get the href for a url
+   * @returns href: an optional link to be used that is different from the text content (example https://google.com for google.com)
+   */
+  getUrlHref?: (url: string) => string | undefined;
+
+  /**
    * On keyboard shortcut or toolbar mousedown, get the link url by calling this promise. The
    * default behavior is to use the browser's native `prompt`.
    */

--- a/packages/nodes/link/src/withLink.ts
+++ b/packages/nodes/link/src/withLink.ts
@@ -74,7 +74,7 @@ export const withLink = <
   editor: E,
   {
     type,
-    options: { isUrl, rangeBeforeOptions },
+    options: { isUrl, getUrlHref, rangeBeforeOptions },
   }: WithPlatePlugin<LinkPlugin, V, E>
 ) => {
   const { insertData, insertText } = editor;
@@ -96,9 +96,13 @@ export const withLink = <
 
       if (beforeWordRange) {
         const beforeWordText = getEditorString(editor, beforeWordRange);
+        const beforeWordHref = getUrlHref?.(beforeWordText);
 
         if (isUrl!(beforeWordText)) {
-          upsertLink(editor, { url: beforeWordText, at: beforeWordRange });
+          upsertLink(editor, {
+            url: beforeWordHref || beforeWordText,
+            at: beforeWordRange,
+          });
           moveSelection(editor, { unit: 'offset' });
         }
       }
@@ -109,10 +113,11 @@ export const withLink = <
 
   editor.insertData = (data: DataTransfer) => {
     const text = data.getData('text/plain');
+    const textHref = getUrlHref?.(text);
 
     if (text) {
       if (isUrl!(text)) {
-        return upsertLinkAtSelection(editor, { url: text });
+        return upsertLinkAtSelection(editor, { url: textHref || text });
       }
 
       if (someNode(editor, { match: { type } })) {


### PR DESCRIPTION
**Description**

Currently the link plugin only supports links that map directly to the link text content, this change allows clients to optionally specify an href for given text; for example:

```
[google.com](https://google.com)
[ed@gmail.com](mailto://ed@gmail.com)
```
