### PR TITLE
improve performance of list normalizations

### DIFF
--- a/.changeset/light-snakes-camp.md
+++ b/.changeset/light-snakes-camp.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-core': patch
+---
+
+Improve performance of list normalization node lookup

--- a/packages/core/src/common/queries/getNode.ts
+++ b/packages/core/src/common/queries/getNode.ts
@@ -1,15 +1,23 @@
-import { Node, Path } from 'slate';
+import { Node, Path, Text } from 'slate';
 import { TEditor } from '../../types/slate/TEditor';
 
 /**
  * Get the descendant node referred to by a specific path.
  * If the path is an empty array, it refers to the root node itself.
  * If the node is not found, return null.
+ * Based on Slate get and has, performance optimization without overhead of
+ * stringify on throwing
  */
 export const getNode = <T extends Node>(editor: TEditor, path: Path) => {
-  try {
-    return Node.get(editor, path) as T;
-  } catch (err) {
-    return null;
+  for (let i = 0; i < path.length; i++) {
+    const p = path[i]
+
+    if (Text.isText(editor) || !editor.children[p]) {
+      return null;
+    }
+
+    editor = editor.children[p];
   }
+
+  return editor as T;
 };


### PR DESCRIPTION
**Description**

See changesets.

List normalizations were slower than necessary due to a buried try/catch with stringify when simply checking for the existence of a node.