### PR TITLE
Get node performance list normalization

### DIFF
--- a/.changeset/curvy-clocks-knock.md
+++ b/.changeset/curvy-clocks-knock.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-core': patch
+---
+
+improve performance of list normalizations

--- a/packages/core/src/slate/node/getNode.ts
+++ b/packages/core/src/slate/node/getNode.ts
@@ -1,4 +1,5 @@
-import { Path, Text } from 'slate';
+import { Path } from 'slate';
+import { isText } from '../text';
 import { NodeOf, TNode } from './TNode';
 
 /**
@@ -13,13 +14,10 @@ export const getNode = <N extends NodeOf<R>, R extends TNode = TNode>(
   path: Path
 ) => {
   try {
-    if (!path.length) {
-      return null;
-    }
     for (let i = 0; i < path.length; i++) {
-      const p = path[i]
+      const p = path[i];
 
-      if (Text.isText(root) || !root.children[p]) {
+      if (isText(root) || !root.children[p]) {
         return null;
       }
 

--- a/packages/core/src/slate/node/getNode.ts
+++ b/packages/core/src/slate/node/getNode.ts
@@ -22,6 +22,6 @@ export const getNode = <N extends NodeOf<R>, R extends TNode = TNode>(
     root = root.children[p] as R;
   }
 
-  return root;
+  return root as N;
 };
 

--- a/packages/core/src/slate/node/getNode.ts
+++ b/packages/core/src/slate/node/getNode.ts
@@ -12,16 +12,22 @@ export const getNode = <N extends NodeOf<R>, R extends TNode = TNode>(
   root: R,
   path: Path
 ) => {
-  for (let i = 0; i < path.length; i++) {
-    const p = path[i]
-
-    if (Text.isText(root) || !root.children[p]) {
+  try {
+    if (!path.length) {
       return null;
     }
+    for (let i = 0; i < path.length; i++) {
+      const p = path[i]
 
-    root = root.children[p] as R;
+      if (Text.isText(root) || !root.children[p]) {
+        return null;
+      }
+
+      root = root.children[p] as R;
+    }
+
+    return root as N;
+  } catch (e) {
+    return null;
   }
-
-  return root as N;
 };
-

--- a/packages/core/src/slate/node/getNode.ts
+++ b/packages/core/src/slate/node/getNode.ts
@@ -1,18 +1,27 @@
-import { Node, Path } from 'slate';
+import { Path, Text } from 'slate';
 import { NodeOf, TNode } from './TNode';
 
 /**
  * Get the descendant node referred to by a specific path.
  * If the path is an empty array, it refers to the root node itself.
  * If the node is not found, return null.
+ * Based on Slate get and has, performance optimization without overhead of
+ * stringify on throwing
  */
 export const getNode = <N extends NodeOf<R>, R extends TNode = TNode>(
   root: R,
   path: Path
 ) => {
-  try {
-    return Node.get(root, path) as N;
-  } catch (err) {
-    return null;
+  for (let i = 0; i < path.length; i++) {
+    const p = path[i]
+
+    if (Text.isText(root) || !root.children[p]) {
+      return null;
+    }
+
+    root = root.children[p] as R;
   }
+
+  return root;
 };
+


### PR DESCRIPTION
**Description**

See changesets.

Improve performance of list normalizations by calling our own getNode that does not throw and stringify the message which was significantly slowing down performance, especially given that we would just return null.