### PR TITLE
fix(link): stop the link floating element from snapping to the wrong location

### DIFF
--- a/.changeset/funny-hotels-wash.md
+++ b/.changeset/funny-hotels-wash.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-link': patch
+---
+
+Fix FloatingLinkUrlInput snapping to the previous location on use

--- a/.changeset/funny-hotels-wash.md
+++ b/.changeset/funny-hotels-wash.md
@@ -2,4 +2,4 @@
 '@udecode/plate-link': patch
 ---
 
-Fix FloatingLinkUrlInput snapping to the previous location on use
+Fix FloatingLinkUrlInput snapping to the previous location on show and to the bottom of the editor upon clicking outside of the element

--- a/packages/nodes/link/src/components/FloatingLink/FloatingLinkUrlInput.tsx
+++ b/packages/nodes/link/src/components/FloatingLink/FloatingLinkUrlInput.tsx
@@ -1,4 +1,4 @@
-import { ChangeEventHandler, useCallback, useRef } from 'react';
+import { ChangeEventHandler, useCallback, useEffect, useRef } from 'react';
 import {
   AsProps,
   createComponentAs,
@@ -10,12 +10,22 @@ import {
 import {
   floatingLinkActions,
   floatingLinkSelectors,
+  useFloatingLinkSelectors,
 } from './floatingLinkStore';
 
 export const useFloatingLinkUrlInput = (
   props: HTMLPropsAs<'input'>
 ): HTMLPropsAs<'input'> => {
+  const updated = useFloatingLinkSelectors().updated();
   const ref = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (ref.current && updated) {
+      setTimeout(() => {
+        ref.current?.focus();
+      }, 0);
+    }
+  }, [updated]);
 
   const onChange: ChangeEventHandler<HTMLInputElement> = useCallback((e) => {
     floatingLinkActions.url(e.target.value);

--- a/packages/nodes/link/src/components/FloatingLink/FloatingLinkUrlInput.tsx
+++ b/packages/nodes/link/src/components/FloatingLink/FloatingLinkUrlInput.tsx
@@ -1,4 +1,4 @@
-import { ChangeEventHandler, useCallback, useEffect, useRef } from 'react';
+import { ChangeEventHandler, useCallback, useRef } from 'react';
 import {
   AsProps,
   createComponentAs,
@@ -10,20 +10,12 @@ import {
 import {
   floatingLinkActions,
   floatingLinkSelectors,
-  useFloatingLinkSelectors,
 } from './floatingLinkStore';
 
 export const useFloatingLinkUrlInput = (
   props: HTMLPropsAs<'input'>
 ): HTMLPropsAs<'input'> => {
-  const updated = useFloatingLinkSelectors().updated();
   const ref = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (ref.current && updated) {
-      ref.current.focus();
-    }
-  }, [updated]);
 
   const onChange: ChangeEventHandler<HTMLInputElement> = useCallback((e) => {
     floatingLinkActions.url(e.target.value);

--- a/packages/nodes/link/src/components/FloatingLink/useFloatingLinkInsert.ts
+++ b/packages/nodes/link/src/components/FloatingLink/useFloatingLinkInsert.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import {
+  focusEditor,
   getPluginOptions,
   HTMLPropsAs,
   useComposedRef,
@@ -50,6 +51,7 @@ export const useFloatingLinkInsert = ({
   const ref = useOnClickOutside(() => {
     if (floatingLinkSelectors.mode() === 'insert') {
       floatingLinkActions.hide();
+      focusEditor(editor, editor.selection!);
     }
   });
 

--- a/packages/ui/nodes/list/src/TodoListElement/TodoListElement.tsx
+++ b/packages/ui/nodes/list/src/TodoListElement/TodoListElement.tsx
@@ -43,7 +43,7 @@ export const TodoListElement = <V extends Value>(
           type="checkbox"
           checked={!!checked}
           onChange={(e) => {
-            if (readOnly) return
+            if (readOnly) return;
             const path = findNodePath(editor, element);
             if (!path) return;
 


### PR DESCRIPTION
Fixes https://github.com/udecode/plate/issues/1700

### Fixes:

- (Temporary) usage of `setTimeout` to allow the location of the floating element to be finalized before focusing.
- Re-focus on the selected node when clicking on outside of the floating element.

---

### Original Issue:

When using `FloatingLinkUrlInput`, the `updated` event is fired before the the final location of the floating element has been determined.

The `updated` event triggers a call to `.focus()` on the `input` contained within the floating element resulting in the following:

- On first instantiation, `x` and `y` are both `null` resulting in styles of `top: 0, left: 0`, so when the the `updated` event is fired and the user is sent to the top of the page. 

- On follow-on instantiations, `x` and `y` are both still their previous values, so when the the `updated` event is fired and the user is sent to the previous location. 

---

### Additional Updates:

- Includes a small fix for a lint warning discovered while running `g:prerelease`.