### PR TITLE
Mention position

### DIFF
--- a/.changeset/large-hats-cross.md
+++ b/.changeset/large-hats-cross.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-ui-combobox': patch
+---
+
+Allow ComboBox and Mentions to stay on screen / flip when at bottom of viewport

--- a/packages/ui/combobox/src/Combobox.tsx
+++ b/packages/ui/combobox/src/Combobox.tsx
@@ -12,8 +12,10 @@ import {
 } from '@udecode/plate-combobox';
 import { useEditorState, useEventEditorSelectors } from '@udecode/plate-core';
 import {
+  flip,
   getRangeBoundingClientRect,
   offset,
+  shift,
   useVirtualFloating,
 } from '@udecode/plate-floating';
 import { PortalBody } from '@udecode/plate-styled-components';
@@ -78,7 +80,7 @@ const ComboboxContent = <TData extends Data = NoData>(
   const { style, floating } = useVirtualFloating({
     placement: 'bottom-start',
     getBoundingClientRect,
-    middleware: [offset(4)],
+    middleware: [offset(4), shift(), flip()],
     ...floatingOptions,
   });
 
@@ -86,9 +88,11 @@ const ComboboxContent = <TData extends Data = NoData>(
     ? combobox.getMenuProps({}, { suppressRefError: true })
     : { ref: null };
 
-  const { root, item: styleItem, highlightedItem } = getComboboxStyles(
-    props as any
-  );
+  const {
+    root,
+    item: styleItem,
+    highlightedItem,
+  } = getComboboxStyles(props as any);
 
   return (
     <PortalBody element={portalElement}>


### PR DESCRIPTION
**Description**

ComboBox and Mention were scrolling off-screen when near the bottom of the viewport. Now they should flip above the element in the editor if necessary.