### PR TITLE
Fixed Windows build problems

### DIFF
--- a/patches/is-hotkey+0.2.0.patch
+++ b/patches/is-hotkey+0.2.0.patch
@@ -5,17 +5,17 @@ index 7f2a126..3cf32b1 100644
 @@ -8,7 +8,8 @@ Object.defineProperty(exports, "__esModule", {
   * Constants.
   */
-
+ 
 -var IS_MAC = typeof window != 'undefined' && /Mac|iPod|iPhone|iPad/.test(window.navigator.platform);
 +// We make this a function so it can be tested in describe block mocks with Jest.
 +var IS_MAC = () => typeof window != 'undefined' && /Mac|iPod|iPhone|iPad/.test(window.navigator.platform);
-
+ 
  var MODIFIERS = {
    alt: 'altKey',
 @@ -17,7 +18,8 @@ var MODIFIERS = {
    shift: 'shiftKey'
  };
-
+ 
 -var ALIASES = {
 +// We make this a function so it can be tested in describe block mocks with Jest.
 +var ALIASES = () => ({
@@ -37,15 +37,15 @@ index 7f2a126..3cf32b1 100644
    windows: 'meta'
 -};
 +});
-
+ 
  var CODES = {
    backspace: 8,
 @@ -227,7 +229,7 @@ function toKeyCode(name) {
-
+ 
  function toKeyName(name) {
    name = name.toLowerCase();
 -  name = ALIASES[name] || name;
 +  name = ALIASES()[name] || name;
    return name;
  }
-
+ 

--- a/scripts/plop/plop-sandpack.js
+++ b/scripts/plop/plop-sandpack.js
@@ -29,8 +29,8 @@ module.exports = (_plop) => {
 
   const generateDirFiles = () => {
     let dirName = prevDir.slice(0, -1);
-    if (dirName.indexOf('/') > -1) {
-      dirName = dirName.substring(dirName.lastIndexOf('/') + 1);
+    if (dirName.indexOf(path.sep) > -1) {
+      dirName = dirName.substring(dirName.lastIndexOf(path.sep) + 1);
     }
 
     let fileContent = '';
@@ -70,9 +70,9 @@ export const ${camelCase(`${dirName}Files`)} = {
   };
 
   for (const templatePath of walkSync(inputPath)) {
-    const relativeFilePath = templatePath.split('examples/src/')[1];
+    const relativeFilePath = templatePath.split(`examples${path.sep}src${path.sep}`)[1];
 
-    const slashIndex = relativeFilePath.lastIndexOf('/');
+    const slashIndex = relativeFilePath.lastIndexOf(path.sep);
 
     const dir = relativeFilePath.substring(0, slashIndex + 1);
 


### PR DESCRIPTION
1. Fixed invalid patch file. Added missing spaces before LF in patch file.
2. Fixed hardcoded slash in scripts/plop/plop-sandpack.js

For more information about the patch-format see:
https://www.oreilly.com/library/view/git-pocket-guide/9781449327507/ch11.html

Description
On Windows run:

git clone https://github.com/udecode/plate.git
cd plate
yarn install

You get:

root-workspace-0b6124@workspace:. couldn't be built successfully (exit code 1, logs can be found here: AppData\Local\Temp\xfs-200e4c83\build.log)

build.log

This file contains the result of Yarn building a package (root-workspace-0b6124@workspace:.)
Script name: postinstall

patch-package 6.4.7
Applying patches...

ERROR Failed to apply patch for package is-hotkey
This happened because the patch file patches\is-hotkey+0.2.0.patch could not be parsed.

### plop-sandpack.js
The script is using indexOf('/') to find parts of a string. This does not work on Windows. Now using path.sep
