### PR TITLE
Fix loading tweets in multiple plate instances

### DIFF
--- a/.changeset/big-kids-admire.md
+++ b/.changeset/big-kids-admire.md
@@ -1,0 +1,6 @@
+---
+'examples-next': patch
+'@udecode/plate-media': patch
+---
+
+Fixed twitter embed loading when using multiple plate instances

--- a/.changeset/big-kids-admire.md
+++ b/.changeset/big-kids-admire.md
@@ -1,5 +1,4 @@
 ---
-'examples-next': patch
 '@udecode/plate-media': patch
 ---
 

--- a/examples/apps/next/src/config/sidebarItems.ts
+++ b/examples/apps/next/src/config/sidebarItems.ts
@@ -23,7 +23,7 @@ export const sidebarItems = [
   'line-height',
   'link',
   'list',
-  'media-embed',
+  'media',
   'mention',
   'multi-editors',
   'multiple-editors',

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -22,7 +22,8 @@
     "@udecode/plate-core": "16.0.0",
     "js-video-url-parser": "^0.5.1",
     "re-resizable": "^6.9.9",
-    "react-textarea-autosize": "^8.3.3"
+    "react-textarea-autosize": "^8.3.3",
+    "scriptjs": "2.5.9"
   },
   "peerDependencies": {
     "react": ">=16.8.0",
@@ -38,5 +39,8 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "@types/scriptjs": "0.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4496,6 +4496,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/scriptjs@npm:0.0.2":
+  version: 0.0.2
+  resolution: "@types/scriptjs@npm:0.0.2"
+  checksum: cc0aa5c882e0a58414be928a85165a15e151876fbc4eecc896139cca029a6c2e0ae9c9e7b53a6b464504a4e237e8d46cf6f809459cd9ecc9484ba82301bdbe53
+  languageName: node
+  linkType: hard
+
 "@types/semver@npm:^6.0.0":
   version: 6.2.3
   resolution: "@types/semver@npm:6.2.3"
@@ -5313,10 +5320,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@udecode/plate-media@workspace:packages/media"
   dependencies:
+    "@types/scriptjs": "npm:0.0.2"
     "@udecode/plate-core": "npm:16.0.0"
     js-video-url-parser: "npm:^0.5.1"
     re-resizable: "npm:^6.9.9"
     react-textarea-autosize: "npm:^8.3.3"
+    scriptjs: "npm:2.5.9"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -21588,6 +21597,13 @@ __metadata:
   version: 5.2.0
   resolution: "screenfull@npm:5.2.0"
   checksum: 31ea12db77b1a85bdeba385d0f6bd96e03f02b066ad6ceec12f3adec0d6924b74e48256e9a6e62005d80cf921362975586c52df805343b7ca5732ee61f8b3b5c
+  languageName: node
+  linkType: hard
+
+"scriptjs@npm:2.5.9":
+  version: 2.5.9
+  resolution: "scriptjs@npm:2.5.9"
+  checksum: 155b10ae4dc9b30baaf121b935ae6c8a2b818282ebe5e63b8c20f771d4caba41c1e28e3415b03b9d0b81f99ab7fef2b12eda8d25318bb24538d15e27fc0a178b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Description**

See changesets.

Uses scriptjs to handle waiting for window.twttr to become available before trying to call createTweet.

Fixes only 1 tweet loading when using multiple plate instances that includes tweets.

Also includes fix for broken link to Media in the example app.

Closes #1753 

