### PR TITLE
Allow passing options to isSelectionAtBlockEnd

### DIFF
--- a/.changeset/chilled-wolves-walk.md
+++ b/.changeset/chilled-wolves-walk.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-core": patch
+---
+
+Add `options` parameter to `isSelectionAtBlockEnd`

--- a/packages/core/src/queries/isSelectionAtBlockEnd.ts
+++ b/packages/core/src/queries/isSelectionAtBlockEnd.ts
@@ -1,3 +1,4 @@
+import { GetAboveNodeOptions } from '../slate/editor/getAboveNode';
 import { isEndPoint } from '../slate/editor/isEndPoint';
 import { TEditor, Value } from '../slate/editor/TEditor';
 import { getBlockAbove } from './getBlockAbove';
@@ -6,9 +7,10 @@ import { getBlockAbove } from './getBlockAbove';
  * Is the selection focus at the end of its parent block.
  */
 export const isSelectionAtBlockEnd = <V extends Value>(
-  editor: TEditor<V>
+  editor: TEditor<V>,
+  options?: GetAboveNodeOptions<V>
 ): boolean => {
-  const path = getBlockAbove(editor)?.[1];
+  const path = getBlockAbove(editor, options)?.[1];
 
   return !!path && isEndPoint(editor, editor.selection?.focus, path);
 };


### PR DESCRIPTION
Makes isSelectionAtBlockStart's and isSelectionAtBlockEnd's behavior consistent.

**Description**

See changesets.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

