### PR TITLE
fix: serializing sandbox examples

### DIFF
--- a/docs/docs/plugins/SerializingCsvSandpack.tsx
+++ b/docs/docs/plugins/SerializingCsvSandpack.tsx
@@ -13,6 +13,7 @@ import { commonFiles } from '../sandpack/files/common/code-commonFiles';
 import { serializingCsvFiles } from '../sandpack/files/serializing-csv/code-serializingCsvFiles';
 import { softBreakPluginFile } from '../sandpack/files/soft-break/code-softBreakPlugin';
 import { typescriptFiles } from '../sandpack/files/typescript/code-typescriptFiles';
+import { linkFiles } from '../sandpack/files/link/code-linkFiles';
 
 export const SerializingCsvSandpack = () => (
   <CommonSandpack
@@ -32,6 +33,7 @@ export const SerializingCsvSandpack = () => (
       ...softBreakPluginFile,
       ...commonFiles,
       ...typescriptFiles,
+      ...linkFiles,
     }}
   />
 );

--- a/docs/docs/plugins/SerializingHtmlSandpack.tsx
+++ b/docs/docs/plugins/SerializingHtmlSandpack.tsx
@@ -13,6 +13,7 @@ import { commonFiles } from '../sandpack/files/common/code-commonFiles';
 import { serializingHtmlFiles } from '../sandpack/files/serializing-html/code-serializingHtmlFiles';
 import { softBreakPluginFile } from '../sandpack/files/soft-break/code-softBreakPlugin';
 import { typescriptFiles } from '../sandpack/files/typescript/code-typescriptFiles';
+import { linkFiles } from '../sandpack/files/link/code-linkFiles';
 
 export const SerializingHtmlSandpack = () => (
   <CommonSandpack
@@ -33,6 +34,7 @@ export const SerializingHtmlSandpack = () => (
       ...softBreakPluginFile,
       ...commonFiles,
       ...typescriptFiles,
+      ...linkFiles,
     }}
   />
 );

--- a/docs/docs/plugins/SerializingMdSandpack.tsx
+++ b/docs/docs/plugins/SerializingMdSandpack.tsx
@@ -8,6 +8,7 @@ import { serializingMdAppCode } from '../sandpack/files/code-SerializingMdApp';
 import { commonFiles } from '../sandpack/files/common/code-commonFiles';
 import { serializingMdFiles } from '../sandpack/files/serializing-md/code-serializingMdFiles';
 import { typescriptFiles } from '../sandpack/files/typescript/code-typescriptFiles';
+import { linkFiles } from '../sandpack/files/link/code-linkFiles';
 
 export const SerializingMdSandpack = () => (
   <CommonSandpack
@@ -25,6 +26,7 @@ export const SerializingMdSandpack = () => (
       ...basicMarksPluginsFile,
       ...commonFiles,
       ...typescriptFiles,
+      ...linkFiles,
     }}
   />
 );

--- a/docs/docs/sandpack/files/code-SerializingHtmlApp.tsx
+++ b/docs/docs/sandpack/files/code-SerializingHtmlApp.tsx
@@ -46,7 +46,7 @@ const plugins = createMyPlugins(
 const Serialized = () => {
   const editor = useEditorState();
   const html = serializeHtml(editor, {
-    nodes: basicNodesValue,
+    nodes: editor.children,
   });
 
   return <HighlightHTML code={html} />;

--- a/examples/src/SerializingHtmlApp.tsx
+++ b/examples/src/SerializingHtmlApp.tsx
@@ -46,7 +46,7 @@ const plugins = createMyPlugins(
 const Serialized = () => {
   const editor = useEditorState();
   const html = serializeHtml(editor, {
-    nodes: basicNodesValue,
+    nodes: editor.children,
   });
 
   return <HighlightHTML code={html} />;


### PR DESCRIPTION
**Description**

The example about serializing on the official website does not work properly because linkFiles is not imported. It works fine after adding it.

In the example of serializing html, the serialized object is changed from baseNode to editor.children, which can be seen more intuitively.