### PR TITLE
Autoformatter will incorrectly match on text that contains one additional character of text

### DIFF
--- a/.changeset/dry-mails-dress.md
+++ b/.changeset/dry-mails-dress.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-autoformat': patch
+---
+
+Autoformatter will incorrectly match on text that contains one additional character of text

--- a/packages/core/src/queries/getPointBeforeLocation.ts
+++ b/packages/core/src/queries/getPointBeforeLocation.ts
@@ -128,7 +128,7 @@ export const getPointBeforeLocation = <V extends Value>(
       count += 1;
 
       if (!options.skipInvalid) {
-        if (!matchString || count > matchString.length) return;
+        if (!matchString || count >= matchString.length) return;
       }
     }
   });

--- a/packages/editor/autoformat/src/__tests__/withAutoformat/text.spec.tsx
+++ b/packages/editor/autoformat/src/__tests__/withAutoformat/text.spec.tsx
@@ -39,6 +39,68 @@ describe('when --space', () => {
 
     expect(input.children).toEqual(output.children);
   });
+
+  it('should not insert — with multiple in between chars', () => {
+    const input = (
+      <editor>
+        <hp>
+          -OO
+          <cursor />
+          hello
+        </hp>
+      </editor>
+    ) as any;
+
+    const output = (
+      <editor>
+        <hp>
+          -OO-
+          <cursor />
+          hello
+        </hp>
+      </editor>
+    ) as any;
+
+    const editor = withAutoformat(
+      withReact(input),
+      mockPlugin(autoformatPlugin as any)
+    );
+
+    editor.insertText('-');
+
+    expect(input.children).toEqual(output.children);
+  });
+
+  it('should not insert — with 1 in between char', () => {
+    const input = (
+      <editor>
+        <hp>
+          -O
+          <cursor />
+          hello
+        </hp>
+      </editor>
+    ) as any;
+
+    const output = (
+      <editor>
+        <hp>
+          -O-
+          <cursor />
+          hello
+        </hp>
+      </editor>
+    ) as any;
+
+    const editor = withAutoformat(
+      withReact(input),
+      mockPlugin(autoformatPlugin as any)
+    );
+
+    editor.insertText('-');
+
+    expect(input.children).toEqual(output.children);
+  });
 });
 
 describe('when (tm)', () => {


### PR DESCRIPTION
**Description**

See changesets.

The auto formatter was incorrectly matching the text that contained extra characters:

```
`-X-` became `—`
`-X>` became `→`
```