### PR TITLE
Fix preview Markdown example

### DIFF
--- a/examples/src/preview-markdown/PreviewLeaf.tsx
+++ b/examples/src/preview-markdown/PreviewLeaf.tsx
@@ -8,7 +8,7 @@ export const PreviewLeaf: RenderLeaf = (props) => {
   const { root } = getPreviewLeafStyles(leaf as any);
 
   return (
-    <span {...attributes} css={root.css} className={root.className}>
+    <span {...attributes} style={root.css[0] as object} className={root.className}>
       {children}
     </span>
   );


### PR DESCRIPTION
Styles were not applied properly in PreviewLeaf.tsx, now its fixed. Probably there are others way to fix it (via styled components, etc), but this one looks good to me :)

Closes #1813 