### PR TITLE
Updated creation of mention after selection

### DIFF
--- a/packages/nodes/mention/src/getMentionOnSelectItem.ts
+++ b/packages/nodes/mention/src/getMentionOnSelectItem.ts
@@ -7,7 +7,6 @@ import {
   TComboboxItem,
 } from '@udecode/plate-combobox';
 import {
-  deleteText,
   getBlockAbove,
   getPlugin,
   insertNodes,
@@ -47,7 +46,7 @@ export const getMentionOnSelectItem = <TData extends Data = NoData>({
   } = getPlugin<MentionPlugin>(editor as any, key);
 
   const pathAbove = getBlockAbove(editor)?.[1];
-  const isBlockEnd =
+  const isBlockEnd = () =>
     editor.selection &&
     pathAbove &&
     isEndPoint(editor, editor.selection.anchor, pathAbove);
@@ -59,11 +58,6 @@ export const getMentionOnSelectItem = <TData extends Data = NoData>({
     const props = createMentionNode!(item, {
       search: comboboxSelectors.text() ?? '',
     });
-
-    // insert a space to fix the bug
-    if (isBlockEnd) {
-      insertText(editor, ' ');
-    }
 
     select(editor, targetRange);
 
@@ -80,12 +74,12 @@ export const getMentionOnSelectItem = <TData extends Data = NoData>({
     } as TMentionElement);
 
     // move the selection after the element
-    moveSelection(editor);
+    moveSelection(editor, { unit: 'offset' });
 
-    // delete the inserted space
-    if (isBlockEnd && !insertSpaceAfterMention) {
-      deleteText(editor);
+    if (isBlockEnd() && insertSpaceAfterMention) {
+      insertText(editor, ' ');
     }
   });
+
   return comboboxActions.reset();
 };


### PR DESCRIPTION
**Description**

After selecting and item in dropdown the cursor is positioned behind the mention tag so the writer can write further without interruption. 

The prop `insertSpaceAfterMention` also does what it should do: it adds additional space after mention tag.

This Issue i think also talks about the same problem.
https://github.com/udecode/plate/issues/1533


Video with new behavior!
https://www.loom.com/share/ad5ea5759bc84bc1a5334560534b1a78
