### PR TITLE
docs: Use correct package plate-serializer-html

### DIFF
--- a/docs/docs/plugins/serializing-html.mdx
+++ b/docs/docs/plugins/serializing-html.mdx
@@ -8,7 +8,7 @@ title: HTML
 ```bash npm2yarn
 npm install @udecode/plate
 # or
-npm install @udecode/plate-serialize-html
+npm install @udecode/plate-serializer-html
 ```
 
 ### Usage


### PR DESCRIPTION
The package name is misspelled as `plate-serialize-html`, mind the missing `r`.

**Description**

I tried to install the html serializer, but I could not get it installed with yarn or npm. I then looked up the package name from the `headless` package, where it is a dependency.

```
$: yarn add @udecode/plate-serialize-html
yarn add v1.22.18
[1/5] Validating package.json...
[2/5] Resolving packages...
error An unexpected error occurred: "https://registry.yarnpkg.com/@udecode%2fplate-serialize-html: Not found".
```