### PR TITLE
improve link plugin to wrap on insert-break

### DIFF
--- a/.changeset/dirty-feet-lay.md
+++ b/.changeset/dirty-feet-lay.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-link': minor
+---
+
+Wrap valid link in anchor element when inserting a break

--- a/packages/nodes/link/src/withLink.spec.tsx
+++ b/packages/nodes/link/src/withLink.spec.tsx
@@ -312,6 +312,39 @@ describe('withLink', () => {
         });
       });
 
+      describe('when creating new block', () => {
+        const input = (
+          <editor>
+            <hp>
+              http://google.com
+              <cursor />
+            </hp>
+          </editor>
+        ) as any;
+
+        const text = ' ';
+
+        const output = (
+          <editor>
+            <hp>
+              <htext />
+              <ha url="http://google.com">http://google.com</ha>
+              <htext />
+            </hp>
+            <hp>
+              <cursor />
+            </hp>
+          </editor>
+        ) as any;
+
+        it('should wrap the url with a link ha', () => {
+          const editor = createEditor(input);
+
+          editor.insertBreak();
+
+          expect(input.children).toEqual(output.children);
+        });
+      });
       // https://github.com/udecode/editor-protocol/issues/42
       describe('when after url at start of block', () => {
         const input = (


### PR DESCRIPTION
Previously, when you type a valid URL and hit 'enter,' it created a new block but did not wrap the inserted link into an anchor element. 

This PR fixes this behavior by overriding insertBreak and refactoring. Also added a test.


![CleanShot 2022-09-20 at 17 58 05](https://user-images.githubusercontent.com/5635880/191391004-8dc23fb0-479b-4bfd-93c9-7347c7d5adfd.gif)


**Description**

See changesets.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

