### PR TITLE
Fix prev selection plugin event persistence on React 16.x

### DIFF
--- a/.changeset/smart-moles-act.md
+++ b/.changeset/smart-moles-act.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-core': patch
+---
+
+Fix `PrevSelectionPlugin` event persistence on React 16.x

--- a/packages/core/src/plugins/createPrevSelectionPlugin.ts
+++ b/packages/core/src/plugins/createPrevSelectionPlugin.ts
@@ -7,6 +7,8 @@ export const createPrevSelectionPlugin = createPluginFactory({
   key: KEY_PREV_SELECTION,
   handlers: {
     onKeyDown: (editor) => (e) => {
+      // React 16.x needs this event to be persistented due to it's event pooling implementation.
+      // https://reactjs.org/docs/legacy-event-pooling.html
       editor.currentKeyboardEvent = e;
     },
   },

--- a/packages/core/src/plugins/createPrevSelectionPlugin.ts
+++ b/packages/core/src/plugins/createPrevSelectionPlugin.ts
@@ -9,6 +9,7 @@ export const createPrevSelectionPlugin = createPluginFactory({
     onKeyDown: (editor) => (e) => {
       // React 16.x needs this event to be persistented due to it's event pooling implementation.
       // https://reactjs.org/docs/legacy-event-pooling.html
+      e.persist();
       editor.currentKeyboardEvent = e;
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5490,7 +5490,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-headless@npm:18.0.0, @udecode/plate-headless@workspace:packages/headless":
+"@udecode/plate-headless@npm:18.1.0, @udecode/plate-headless@workspace:packages/headless":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-headless@workspace:packages/headless"
   dependencies:
@@ -5514,7 +5514,7 @@ __metadata:
     "@udecode/plate-indent-list": "npm:17.0.3"
     "@udecode/plate-kbd": "npm:17.0.3"
     "@udecode/plate-line-height": "npm:17.0.3"
-    "@udecode/plate-link": "npm:17.0.3"
+    "@udecode/plate-link": "npm:18.1.0"
     "@udecode/plate-list": "npm:17.0.3"
     "@udecode/plate-media": "npm:17.0.3"
     "@udecode/plate-mention": "npm:17.0.3"
@@ -5527,7 +5527,7 @@ __metadata:
     "@udecode/plate-serializer-csv": "npm:17.0.3"
     "@udecode/plate-serializer-docx": "npm:17.0.3"
     "@udecode/plate-serializer-html": "npm:17.0.3"
-    "@udecode/plate-serializer-md": "npm:17.0.3"
+    "@udecode/plate-serializer-md": "npm:18.1.0"
     "@udecode/plate-table": "npm:17.0.3"
     "@udecode/plate-trailing-block": "npm:17.0.3"
   peerDependencies:
@@ -5653,7 +5653,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-link@npm:17.0.3, @udecode/plate-link@workspace:packages/nodes/link":
+"@udecode/plate-link@npm:18.1.0, @udecode/plate-link@workspace:packages/nodes/link":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-link@workspace:packages/nodes/link"
   dependencies:
@@ -5871,7 +5871,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-serializer-md@npm:17.0.3, @udecode/plate-serializer-md@workspace:packages/serializers/md":
+"@udecode/plate-serializer-md@npm:18.1.0, @udecode/plate-serializer-md@workspace:packages/serializers/md":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-serializer-md@workspace:packages/serializers/md"
   dependencies:
@@ -5879,7 +5879,7 @@ __metadata:
     "@udecode/plate-code-block": "npm:17.0.3"
     "@udecode/plate-core": "npm:17.0.3"
     "@udecode/plate-heading": "npm:17.0.3"
-    "@udecode/plate-link": "npm:17.0.3"
+    "@udecode/plate-link": "npm:18.1.0"
     "@udecode/plate-list": "npm:17.0.3"
     "@udecode/plate-paragraph": "npm:17.0.3"
     remark-parse: "npm:^9.0.0"
@@ -6174,12 +6174,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-ui-link@npm:17.0.3, @udecode/plate-ui-link@workspace:packages/ui/nodes/link":
+"@udecode/plate-ui-link@npm:18.1.0, @udecode/plate-ui-link@workspace:packages/ui/nodes/link":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-ui-link@workspace:packages/ui/nodes/link"
   dependencies:
     "@udecode/plate-core": "npm:17.0.3"
-    "@udecode/plate-link": "npm:17.0.3"
+    "@udecode/plate-link": "npm:18.1.0"
     "@udecode/plate-styled-components": "npm:17.0.3"
     "@udecode/plate-ui-button": "npm:17.0.3"
     "@udecode/plate-ui-toolbar": "npm:17.0.3"
@@ -6211,16 +6211,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-ui-media@npm:17.0.3, @udecode/plate-ui-media@workspace:packages/ui/nodes/media":
+"@udecode/plate-ui-media@npm:18.1.0, @udecode/plate-ui-media@workspace:packages/ui/nodes/media":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-ui-media@workspace:packages/ui/nodes/media"
   dependencies:
     "@udecode/plate-core": "npm:17.0.3"
     "@udecode/plate-floating": "npm:17.0.3"
-    "@udecode/plate-link": "npm:17.0.3"
+    "@udecode/plate-link": "npm:18.1.0"
     "@udecode/plate-media": "npm:17.0.3"
     "@udecode/plate-styled-components": "npm:17.0.3"
-    "@udecode/plate-ui-link": "npm:17.0.3"
+    "@udecode/plate-ui-link": "npm:18.1.0"
     "@udecode/plate-ui-toolbar": "npm:17.0.3"
     js-video-url-parser: "npm:0.5.1"
   peerDependencies:
@@ -6336,11 +6336,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-ui@npm:18.0.0, @udecode/plate-ui@workspace:packages/ui/plate":
+"@udecode/plate-ui@npm:18.1.0, @udecode/plate-ui@workspace:packages/ui/plate":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-ui@workspace:packages/ui/plate"
   dependencies:
-    "@udecode/plate-headless": "npm:18.0.0"
+    "@udecode/plate-headless": "npm:18.1.0"
     "@udecode/plate-styled-components": "npm:17.0.3"
     "@udecode/plate-ui-alignment": "npm:17.0.3"
     "@udecode/plate-ui-block-quote": "npm:17.0.3"
@@ -6352,9 +6352,9 @@ __metadata:
     "@udecode/plate-ui-find-replace": "npm:17.0.3"
     "@udecode/plate-ui-font": "npm:17.0.3"
     "@udecode/plate-ui-line-height": "npm:17.0.3"
-    "@udecode/plate-ui-link": "npm:17.0.3"
+    "@udecode/plate-ui-link": "npm:18.1.0"
     "@udecode/plate-ui-list": "npm:17.0.3"
-    "@udecode/plate-ui-media": "npm:17.0.3"
+    "@udecode/plate-ui-media": "npm:18.1.0"
     "@udecode/plate-ui-mention": "npm:17.0.3"
     "@udecode/plate-ui-placeholder": "npm:17.0.3"
     "@udecode/plate-ui-table": "npm:17.0.3"
@@ -6376,8 +6376,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@udecode/plate@workspace:packages/plate"
   dependencies:
-    "@udecode/plate-headless": "npm:18.0.0"
-    "@udecode/plate-ui": "npm:18.0.0"
+    "@udecode/plate-headless": "npm:18.1.0"
+    "@udecode/plate-ui": "npm:18.1.0"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"


### PR DESCRIPTION
**Description**

React 16.x used an event pooling mechanism that would cause synthetic events to get "re-used" unless they are explicitly persisted. You can find this documented here. https://reactjs.org/docs/legacy-event-pooling.html

As a result the synthetic events stashed in the `prevSelectionPlugin` would have all of its values nulled out and was issuing a warning when the properties of the events were accessed.

Notably for me this manifested in the table plugin's keyboard shortcuts not working properly, although I'm imaging it causes other keyboard shortcuts relying on this previous event to be broken too.

Of course we're working to move to react 17, but one of the blockers is our old editor that we are replacing with Plate. Luckily at the moment the fix is pretty straightforward. Call `event.persist()`. In React 17 and React 18 this is a no-op.

https://reactjs.org/blog/2020/08/10/react-v17-rc.html#no-event-pooling

> Note that e.persist() is still available on the React event object, but now it doesn’t do anything.