### PR TITLE
Fix doc typo

### DIFF
--- a/docs/docs/plugins/autoformat.mdx
+++ b/docs/docs/plugins/autoformat.mdx
@@ -79,7 +79,7 @@ This package provides the following rules:
 |                                | `autoformatEquality` rules                                   |
 |                                | `autoformatOperation` rules                                  |
 |                                | `autoformatFraction` rules                                   |
-|                                | `autoformatSubscriptSymbols` rules                         |
+|                                | `autoformatSubscriptNumbers` rules                         |
 |                                | `autoformatSubscriptSymbols` rules                           |
 |                                | `autoformatSuperscriptNumbers` rules                         |
 |                                | `autoformatSuperscriptSymbols` rules                           |


### PR DESCRIPTION
**Description**
I noticed a small typo when referencing the docs, figured I'd make a PR to correct it :)
