### PR TITLE
Make withNodeId add Ids to nested blocks

### DIFF
--- a/.changeset/good-pumpkins-fold.md
+++ b/.changeset/good-pumpkins-fold.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-node-id': patch
+---
+
+make withNodeId set ids on nested nodes that are inserted

--- a/.changeset/long-spoons-roll.md
+++ b/.changeset/long-spoons-roll.md
@@ -1,5 +1,0 @@
----
-'@udecode/plate-core': patch
----
-
-Make withNodeId add ids to nested nodes that are inserted

--- a/.changeset/long-spoons-roll.md
+++ b/.changeset/long-spoons-roll.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-core': patch
+---
+
+Make withNodeId add ids to nested nodes that are inserted

--- a/packages/editor/node-id/src/createNodeIdPlugin.spec.tsx
+++ b/packages/editor/node-id/src/createNodeIdPlugin.spec.tsx
@@ -5,12 +5,12 @@ import {
   insertNodes,
   mergeNodes,
   PlateEditor,
-  splitNodes,
+  splitNodes
 } from '@udecode/plate-core';
 import { jsx } from '@udecode/plate-test-utils';
 import {
   ELEMENT_LI,
-  ELEMENT_UL,
+  ELEMENT_UL
 } from '../../../nodes/list/src/createListPlugin';
 import { ELEMENT_PARAGRAPH } from '../../../nodes/paragraph/src/createParagraphPlugin';
 import { createNodeIdPlugin } from './createNodeIdPlugin';
@@ -50,6 +50,7 @@ describe('when inserting nodes', () => {
             options: {
               idCreator: getIdFactory(),
               allow: [ELEMENT_PARAGRAPH],
+              reuseId: true
             },
           }),
         ],
@@ -70,7 +71,7 @@ describe('when inserting nodes', () => {
 
       expect(input.children).toEqual(output.children);
     });
-  });
+  })
 
   describe('when exclude is p, inserting li and p', () => {
     it('should add an id to li but not p', () => {

--- a/packages/editor/node-id/src/withNodeId.ts
+++ b/packages/editor/node-id/src/withNodeId.ts
@@ -1,14 +1,13 @@
 import {
-  defaultsDeepToNodes,
-  isAncestor,
-  PlateEditor,
+  applyDeepToNodes,
+  defaultsDeepToNodes,PlateEditor,
   queryNode,
   someNode,
   TDescendant,
   TNode,
   TNodeEntry,
   Value,
-  WithPlatePlugin,
+  WithPlatePlugin
 } from '@udecode/plate-core';
 import cloneDeep from 'lodash/cloneDeep';
 import { NodeIdPlugin } from './createNodeIdPlugin';
@@ -43,20 +42,13 @@ export const withNodeId = <
     );
   };
 
-  const deleteDuplicateIds = <N extends TDescendant>(node: N) => {
-    // the id in the new node is already being used in the editor, we need to replace it with a new id
+  const removeIdFromNodeIfDuplicate = <N extends TDescendant>(node: N) => {
     if (
       !reuseId ||
       someNode(editor, { match: { [idKey]: node[idKey] }, at: [] })
     ) {
       delete node[idKey];
     }
-
-    if (!isAncestor(node)) return;
-
-    node.children.forEach((child) => {
-      deleteDuplicateIds(child);
-    });
   };
 
   const query = {
@@ -70,7 +62,13 @@ export const withNodeId = <
       // clone to be able to write (read-only)
       const node = cloneDeep(operation.node);
 
-      deleteDuplicateIds(node);
+      // Delete ids from node that are already being used
+      applyDeepToNodes({ 
+        node, 
+        query, 
+        source: {}, 
+        apply: removeIdFromNodeIfDuplicate 
+      })
 
       defaultsDeepToNodes({
         node,

--- a/packages/editor/node-id/src/withNodeId.ts
+++ b/packages/editor/node-id/src/withNodeId.ts
@@ -1,13 +1,13 @@
 import {
   defaultsDeepToNodes,
+  isAncestor,
   PlateEditor,
   queryNode,
   someNode,
+  TDescendant,
   TNode,
   TNodeEntry,
-  TDescendant,
   Value,
-  isAncestor,
   WithPlatePlugin,
 } from '@udecode/plate-core';
 import cloneDeep from 'lodash/cloneDeep';
@@ -42,7 +42,7 @@ export const withNodeId = <
       filter!(nodeEntry) && (!filterText || nodeEntry[0]?.type !== undefined)
     );
   };
-  
+
   const deleteDuplicateIds = <N extends TDescendant>(node: N) => {
     // the id in the new node is already being used in the editor, we need to replace it with a new id
     if (
@@ -52,13 +52,12 @@ export const withNodeId = <
       delete node[idKey];
     }
 
-    if (!isAncestor(node))
-        return
+    if (!isAncestor(node)) return;
 
     node.children.forEach((child) => {
-        deleteDuplicateIds(child)
+      deleteDuplicateIds(child);
     });
-  }
+  };
 
   const query = {
     filter: filterNode,
@@ -71,7 +70,7 @@ export const withNodeId = <
       // clone to be able to write (read-only)
       const node = cloneDeep(operation.node);
 
-      deleteDuplicateIds(node)
+      deleteDuplicateIds(node);
 
       defaultsDeepToNodes({
         node,

--- a/packages/editor/node-id/src/withNodeId.ts
+++ b/packages/editor/node-id/src/withNodeId.ts
@@ -5,7 +5,9 @@ import {
   someNode,
   TNode,
   TNodeEntry,
+  TDescendant,
   Value,
+  isAncestor,
   WithPlatePlugin,
 } from '@udecode/plate-core';
 import cloneDeep from 'lodash/cloneDeep';
@@ -40,6 +42,23 @@ export const withNodeId = <
       filter!(nodeEntry) && (!filterText || nodeEntry[0]?.type !== undefined)
     );
   };
+  
+  const deleteDuplicateIds = <N extends TDescendant>(node: N) => {
+    // the id in the new node is already being used in the editor, we need to replace it with a new id
+    if (
+      !reuseId ||
+      someNode(editor, { match: { [idKey]: node[idKey] }, at: [] })
+    ) {
+      delete node[idKey];
+    }
+
+    if (!isAncestor(node))
+        return
+
+    node.children.forEach((child) => {
+        removeDuplicateId(child)
+    });
+  }
 
   const query = {
     filter: filterNode,
@@ -52,13 +71,7 @@ export const withNodeId = <
       // clone to be able to write (read-only)
       const node = cloneDeep(operation.node);
 
-      // the id in the new node is already being used in the editor, we need to replace it with a new id
-      if (
-        !reuseId ||
-        someNode(editor, { match: { [idKey]: node[idKey] }, at: [] })
-      ) {
-        delete node[idKey];
-      }
+      removeDuplicateIds(node)
 
       defaultsDeepToNodes({
         node,

--- a/packages/editor/node-id/src/withNodeId.ts
+++ b/packages/editor/node-id/src/withNodeId.ts
@@ -56,7 +56,7 @@ export const withNodeId = <
         return
 
     node.children.forEach((child) => {
-        removeDuplicateId(child)
+        deleteDuplicateIds(child)
     });
   }
 
@@ -71,7 +71,7 @@ export const withNodeId = <
       // clone to be able to write (read-only)
       const node = cloneDeep(operation.node);
 
-      removeDuplicateIds(node)
+      deleteDuplicateIds(node)
 
       defaultsDeepToNodes({
         node,


### PR DESCRIPTION
**Description**
The current way that `withNodeId` is implemented doesn't guarantee ID uniqueness when inserting nested nodes. 

For instance, say we apply the following insert node operation:

```
{
    "type": "insert_node",
    "path": [
        0,
        1
    ],
    "node": {
        "type": "li",
        "children": [
            {
                "type": "lic",
                "children": [
                    {
                        "text": "",
                        "id": "2"
                    }
                ],
                "id": "1"
            }
        ],
        "id": "0"
    },
}
```

The current implementation of `withNodeId` will only check if the node with **id 0** is duplicated and regenerate it if so. It will not check if the nodes with **id 1** and **id 2** are being used elsewhere, meaning it's possible to have multiple nodes with those ids.


