### PR TITLE
Fix height of editor examples to prevent scrolling of left sidebar

### DIFF
--- a/examples/apps/next/src/pages/_app.tsx
+++ b/examples/apps/next/src/pages/_app.tsx
@@ -16,7 +16,14 @@ export default function MyApp({ Component, pageProps }: any) {
     <div className="app">
       <Sidebar />
 
-      <div style={{ position: 'relative', width: '100%' }}>
+      <div
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100vh',
+          overflow: 'scroll',
+        }}
+      >
         <DndProvider backend={HTML5Backend}>
           <Component key={router.asPath} {...pageProps} />
         </DndProvider>


### PR DESCRIPTION
Added `height: 100vh` and `overflow: 'scroll'` to editor examples to stop the left sidebar from scrolling up when the height of the example exceeds the height of the screen.

#### Before

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/33153339/198990115-d37319f2-b40c-47bd-81bf-daa6fa8cf564.png">

#### After

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/33153339/198990169-9c292038-d31f-40d6-8f13-6d7da5b1d631.png">




