### PR TITLE
Fix OpenLinkButton href

### DIFF
--- a/packages/nodes/link/src/components/FloatingLink/OpenLinkButton.tsx
+++ b/packages/nodes/link/src/components/FloatingLink/OpenLinkButton.tsx
@@ -7,6 +7,7 @@ import {
   getPluginType,
   HTMLPropsAs,
   useEditorRef,
+  usePlateSelection,
 } from '@udecode/plate-core';
 import { ELEMENT_LINK } from '../../createLinkPlugin';
 import { TLinkElement } from '../../types';
@@ -15,13 +16,15 @@ export const useOpenLinkButton = (
   props: HTMLPropsAs<'a'>
 ): HTMLPropsAs<'a'> => {
   const editor = useEditorRef();
+  const selection = usePlateSelection();
 
   const entry = useMemo(
     () =>
       findNode<TLinkElement>(editor, {
         match: { type: getPluginType(editor, ELEMENT_LINK) },
       }),
-    [editor]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [editor, selection]
   );
 
   if (!entry) {


### PR DESCRIPTION
**Description**

Fixes https://github.com/udecode/plate/issues/1967

Basically link node was memoized without dep on selection, and when you change selection it stays the same.

It's my first PR here, I am not sure about changesets, do I need to add one?

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

