### PR TITLE
Fix floating link open state for multiple editors

### DIFF
--- a/.changeset/rotten-planes-collect.md
+++ b/.changeset/rotten-planes-collect.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-link": patch
+---
+
+- Fixes #1771

--- a/packages/nodes/link/src/components/FloatingLink/floatingLinkStore.ts
+++ b/packages/nodes/link/src/components/FloatingLink/floatingLinkStore.ts
@@ -3,7 +3,7 @@ import { createStore } from '@udecode/plate-core';
 export type FloatingLinkMode = '' | 'insert' | 'edit';
 
 export const floatingLinkStore = createStore('floatingLink')({
-  open: false,
+  openEditorId: null as null | string,
   mouseDown: false,
   updated: false,
   url: '',
@@ -22,15 +22,18 @@ export const floatingLinkStore = createStore('floatingLink')({
     },
   }))
   .extendActions((set) => ({
-    show: (mode: FloatingLinkMode) => {
+    show: (mode: FloatingLinkMode, editorId: string) => {
       set.mode(mode);
       set.isEditing(false);
-      set.open(true);
+      set.openEditorId(editorId);
     },
     hide: () => {
-      set.open(false);
+      set.openEditorId(null);
       set.reset();
     },
+  }))
+  .extendSelectors((state) => ({
+    isOpen: (editorId: string) => state.openEditorId === editorId,
   }));
 
 export const floatingLinkActions = floatingLinkStore.set;

--- a/packages/nodes/link/src/components/FloatingLink/useFloatingLinkEdit.ts
+++ b/packages/nodes/link/src/components/FloatingLink/useFloatingLinkEdit.ts
@@ -35,7 +35,7 @@ export const useFloatingLinkEdit = ({
   const editor = useEditorRef();
   const keyEditor = usePlateSelectors().keyEditor();
   const mode = useFloatingLinkSelectors().mode();
-  const open = useFloatingLinkSelectors().open();
+  const open = useFloatingLinkSelectors().isOpen(editor.id);
 
   const { triggerFloatingLinkHotkeys } = getPluginOptions<LinkPlugin>(
     editor,
@@ -61,6 +61,7 @@ export const useFloatingLinkEdit = ({
   const isOpen = open && mode === 'edit';
 
   const { update, style, floating } = useVirtualFloatingLink({
+    editorId: editor.id,
     open: isOpen,
     getBoundingClientRect,
     ...floatingOptions,
@@ -73,7 +74,7 @@ export const useFloatingLinkEdit = ({
         match: { type: getPluginType(editor, ELEMENT_LINK) },
       })
     ) {
-      floatingLinkActions.show('edit');
+      floatingLinkActions.show('edit', editor.id);
       update();
       return;
     }

--- a/packages/nodes/link/src/components/FloatingLink/useFloatingLinkEnter.ts
+++ b/packages/nodes/link/src/components/FloatingLink/useFloatingLinkEnter.ts
@@ -1,8 +1,11 @@
 import { useEditorRef, useHotkeys } from '@udecode/plate-core';
 import { submitFloatingLink } from '../../transforms/submitFloatingLink';
+import { useFloatingLinkSelectors } from './floatingLinkStore';
 
 export const useFloatingLinkEnter = () => {
   const editor = useEditorRef();
+
+  const open = useFloatingLinkSelectors().isOpen(editor.id);
 
   useHotkeys(
     '*',
@@ -14,6 +17,7 @@ export const useFloatingLinkEnter = () => {
       }
     },
     {
+      enabled: open,
       enableOnTags: ['INPUT'],
     },
     []

--- a/packages/nodes/link/src/components/FloatingLink/useFloatingLinkEscape.ts
+++ b/packages/nodes/link/src/components/FloatingLink/useFloatingLinkEscape.ts
@@ -2,10 +2,13 @@ import { focusEditor, useEditorRef, useHotkeys } from '@udecode/plate-core';
 import {
   floatingLinkActions,
   floatingLinkSelectors,
+  useFloatingLinkSelectors,
 } from './floatingLinkStore';
 
 export const useFloatingLinkEscape = () => {
   const editor = useEditorRef();
+
+  const open = useFloatingLinkSelectors().isOpen(editor.id);
 
   useHotkeys(
     'escape',
@@ -13,7 +16,7 @@ export const useFloatingLinkEscape = () => {
       if (floatingLinkSelectors.mode() !== 'edit') return;
 
       if (floatingLinkSelectors.isEditing()) {
-        floatingLinkActions.show('edit');
+        floatingLinkActions.show('edit', editor.id);
         focusEditor(editor, editor.selection!);
         return;
       }
@@ -21,6 +24,7 @@ export const useFloatingLinkEscape = () => {
       floatingLinkActions.hide();
     },
     {
+      enabled: open,
       enableOnTags: ['INPUT'],
       enableOnContentEditable: true,
     },

--- a/packages/nodes/link/src/components/FloatingLink/useFloatingLinkInsert.ts
+++ b/packages/nodes/link/src/components/FloatingLink/useFloatingLinkInsert.ts
@@ -28,7 +28,7 @@ export const useFloatingLinkInsert = ({
   const editor = useEditorRef();
   const focused = useFocused();
   const mode = useFloatingLinkSelectors().mode();
-  const open = useFloatingLinkSelectors().open();
+  const open = useFloatingLinkSelectors().isOpen(editor.id);
 
   const { triggerFloatingLinkHotkeys } = getPluginOptions<LinkPlugin>(
     editor,
@@ -58,6 +58,7 @@ export const useFloatingLinkInsert = ({
   });
 
   const { update, style, floating } = useVirtualFloatingLink({
+    editorId: editor.id,
     open: open && mode === 'insert',
     getBoundingClientRect: getSelectionBoundingClientRect,
     whileElementsMounted: () => {},

--- a/packages/nodes/link/src/components/FloatingLink/useVirtualFloatingLink.ts
+++ b/packages/nodes/link/src/components/FloatingLink/useVirtualFloatingLink.ts
@@ -6,12 +6,14 @@ import {
 } from '@udecode/plate-floating';
 import { floatingLinkActions } from './floatingLinkStore';
 
-export const useVirtualFloatingLink = (
-  floatingOptions?: UseVirtualFloatingOptions
-) => {
+export const useVirtualFloatingLink = ({
+  editorId,
+  ...floatingOptions
+}: { editorId: string } & UseVirtualFloatingOptions) => {
   return useVirtualFloating({
     placement: 'bottom-start',
-    onOpenChange: floatingLinkActions.open,
+    onOpenChange: (open) =>
+      floatingLinkActions.openEditorId(open ? editorId : null),
     middleware: [
       offset(12),
       flip({

--- a/packages/nodes/link/src/utils/triggerFloatingLinkInsert.ts
+++ b/packages/nodes/link/src/utils/triggerFloatingLinkInsert.ts
@@ -41,5 +41,5 @@ export const triggerFloatingLinkInsert = <V extends Value>(
   if (hasLink) return;
 
   floatingLinkActions.text(getEditorString(editor, editor.selection));
-  floatingLinkActions.show('insert');
+  floatingLinkActions.show('insert', editor.id);
 };


### PR DESCRIPTION
**Description**

Fixed floating link toolbar when used with multiple editors.

Fixes https://github.com/udecode/plate/issues/1771


<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

