### PR TITLE
Fix import for Excalidraw component

### DIFF
--- a/.changeset/khaki-vans-sleep.md
+++ b/.changeset/khaki-vans-sleep.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-ui-excalidraw": patch
+---
+
+Fix import for Excalidraw component

--- a/packages/ui/nodes/excalidraw/src/components/ExcalidrawElement/ExcalidrawElement.tsx
+++ b/packages/ui/nodes/excalidraw/src/components/ExcalidrawElement/ExcalidrawElement.tsx
@@ -24,7 +24,7 @@ export const ExcalidrawElement = <V extends Value>(
   const [Excalidraw, setExcalidraw] = useState<any>(null);
   useEffect(() => {
     import('@excalidraw/excalidraw').then((comp) =>
-      setExcalidraw(comp.default)
+      setExcalidraw(comp.Excalidraw)
     );
   });
 


### PR DESCRIPTION
**Updated the import from `@excalidraw/excalidraw` to support latest version**


**Issue**
Excalidraw board stopped rendering upgrading the package to latest stable version. PR: #1943

**Solution**
This PR will fix the import issue. Latest version has named export for Excailidraw component instead of default.

**Video demonstration**
https://app.usebubbles.com/5B6y9mR73oAHdLknpsBJS4/excalidraw-demo-after-fix