### PR TITLE
Fix floating link insert popup closing other editors popups

### DIFF
--- a/.changeset/few-elephants-roll.md
+++ b/.changeset/few-elephants-roll.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-link": patch
+---
+
+Fixes #1771

--- a/packages/nodes/link/src/components/FloatingLink/useFloatingLinkInsert.ts
+++ b/packages/nodes/link/src/components/FloatingLink/useFloatingLinkInsert.ts
@@ -50,12 +50,17 @@ export const useFloatingLinkInsert = ({
     [focused]
   );
 
-  const ref = useOnClickOutside(() => {
-    if (floatingLinkSelectors.mode() === 'insert') {
-      floatingLinkActions.hide();
-      focusEditor(editor, editor.selection!);
+  const ref = useOnClickOutside(
+    () => {
+      if (floatingLinkSelectors.mode() === 'insert') {
+        floatingLinkActions.hide();
+        focusEditor(editor, editor.selection!);
+      }
+    },
+    {
+      disabled: !open,
     }
-  });
+  );
 
   const { update, style, floating } = useVirtualFloatingLink({
     editorId: editor.id,


### PR DESCRIPTION
**Description**

It seems that I missed one case when `useFloatingLinkInsert` closes other editors popups because of always enabled `useOnClickOutside`

Fixes https://github.com/udecode/plate/issues/1771#issuecomment-1305433623

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

