### PR TITLE
Fix floating link escape handling

### DIFF
--- a/.changeset/loud-emus-return.md
+++ b/.changeset/loud-emus-return.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-link": patch
+---
+
+Fix floating link escape handling

--- a/packages/nodes/link/src/components/FloatingLink/useFloatingLinkEscape.ts
+++ b/packages/nodes/link/src/components/FloatingLink/useFloatingLinkEscape.ts
@@ -12,13 +12,22 @@ export const useFloatingLinkEscape = () => {
 
   useHotkeys(
     'escape',
-    () => {
-      if (floatingLinkSelectors.mode() !== 'edit') return;
+    (e) => {
+      if (!floatingLinkSelectors.mode()) return;
 
-      if (floatingLinkSelectors.isEditing()) {
+      e.preventDefault();
+
+      if (
+        floatingLinkSelectors.mode() === 'edit' &&
+        floatingLinkSelectors.isEditing()
+      ) {
         floatingLinkActions.show('edit', editor.id);
         focusEditor(editor, editor.selection!);
         return;
+      }
+
+      if (floatingLinkSelectors.mode() === 'insert') {
+        focusEditor(editor, editor.selection!);
       }
 
       floatingLinkActions.hide();


### PR DESCRIPTION
**Description**

Does it makes sense to do that? 😄 

This PR:
1) Adds `e.preventDefault();` when `Escape` is handled by the floating link popup.
2) Adds `insert` mode handling too, so now you can close insertion window with keyboard too.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

