### PR TITLE
Fix list plugin adjusting selection range on Tab or ShiftTab keypress

### DIFF
--- a/.changeset/cyan-chairs-kiss.md
+++ b/.changeset/cyan-chairs-kiss.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-list': patch
+---
+
+Fix Tab and Shift+Tab adjust selection ranges with the list plugin.

--- a/packages/nodes/list/src/onKeyDownList.ts
+++ b/packages/nodes/list/src/onKeyDownList.ts
@@ -43,7 +43,6 @@ export const onKeyDownList = <
 
       // This is a workaround for a Slate bug
       // See: https://github.com/ianstormtaylor/slate/pull/5039
-      anchor.offset = 0;
       const unHungRange = unhangRange(editor, { anchor, focus });
       if (unHungRange) {
         workRange = unHungRange;

--- a/packages/nodes/list/src/onkeyDownList.spec.tsx
+++ b/packages/nodes/list/src/onkeyDownList.spec.tsx
@@ -1,6 +1,11 @@
 /** @jsx jsx */
 
-import { getPlugin, HotkeyPlugin, Hotkeys } from '@udecode/plate-core';
+import {
+  getPlugin,
+  HotkeyPlugin,
+  Hotkeys,
+  PlateEditor,
+} from '@udecode/plate-core';
 import { createListPlugin } from '@udecode/plate-list';
 import { jsx } from '@udecode/plate-test-utils';
 import { createPlateUIEditor } from '@udecode/plate-ui/src/utils/createPlateUIEditor';
@@ -391,6 +396,46 @@ it('should unhang before indentation', () => {
 
   onKeyDownList(editor, getPlugin<HotkeyPlugin>(editor, 'list'))(event as any);
   expect(editor.children).toEqual(output.children);
+});
+
+it('should NOT not adjust selection length when unhanging ranges', () => {
+  const input = (
+    <editor>
+      <hp>
+        Some Text <anchor />
+        More Text
+        <focus />
+      </hp>
+    </editor>
+  ) as any;
+  const editor: PlateEditor<any> = createPlateUIEditor({
+    editor: input,
+    plugins: [createListPlugin()],
+  });
+
+  const selectionBefore = editor.selection;
+
+  onKeyDownList(
+    editor,
+    getPlugin<HotkeyPlugin>(editor, 'list')
+  )(
+    new KeyboardEvent('keydown', {
+      key: 'Tab',
+    }) as any // Using a native keyboard event but this wants a React.KeyboardEvent.
+  );
+  expect(editor.selection).toEqual(selectionBefore);
+
+  // Do the same with shift tab.
+  onKeyDownList(
+    editor,
+    getPlugin<HotkeyPlugin>(editor, 'list')
+  )(
+    new KeyboardEvent('keydown', {
+      key: 'Tab',
+      shiftKey: true,
+    }) as any // Using a native keyboard event but this wants a React.KeyboardEvent.
+  );
+  expect(editor.selection).toEqual(selectionBefore);
 });
 
 it('should convert top-level list item into body upon unindent if enableResetOnShiftTab is true', () => {


### PR DESCRIPTION
Fixes https://github.com/udecode/plate/issues/1985

I tracked this down as a regression coming from https://github.com/udecode/plate/pull/1642

The existing tests should all still be passing and I did some additional manual testing and the behaviour still seems to match the expection from that other PR. TBH I'm not really sure what this little line's purpose was.

**Description**

See changesets.
 
**Before**

![2022-11-11 16 36 10](https://user-images.githubusercontent.com/1770056/201436295-66c90421-c72c-4696-94c1-54dc370ce1de.gif)

**After**

![2022-11-11 16 56 33](https://user-images.githubusercontent.com/1770056/201436359-58d9d9c8-add6-45df-9121-da48bcbb00de.gif)

