### PR TITLE
Fix mention keydown handler

### DIFF
--- a/.changeset/nice-dryers-invent.md
+++ b/.changeset/nice-dryers-invent.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-mention": patch
+---
+
+Fix mention espace keydown handler: it always prevents default on Escape but it should only happen when there is a mention input

--- a/packages/nodes/mention/src/handlers/mentionOnKeyDownHandler.ts
+++ b/packages/nodes/mention/src/handlers/mentionOnKeyDownHandler.ts
@@ -14,12 +14,13 @@ export const mentionOnKeyDownHandler: <V extends Value>(
   editor
 ) => (event) => {
   if (isHotkey('escape', event)) {
-    event.preventDefault();
     const currentMentionInput = findMentionInput(editor)!;
     if (currentMentionInput) {
+      event.preventDefault();
       removeMentionInput(editor, currentMentionInput[1]);
+      return true;
     }
-    return true;
+    return false;
   }
 
   return moveSelectionByOffset(editor, options)(event);


### PR DESCRIPTION
**Description**

I think mention keydown might be incorrect, it always prevents default on `Escape` but it seems that it should only happen when there is a mention input
 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

