### PR TITLE
Fix link hotkey prevent default

### DIFF
--- a/.changeset/cool-grapes-jam.md
+++ b/.changeset/cool-grapes-jam.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-link": patch
+---
+
+Fix link hotkey prevent default

--- a/packages/nodes/link/src/components/FloatingLink/useFloatingLinkEdit.ts
+++ b/packages/nodes/link/src/components/FloatingLink/useFloatingLinkEdit.ts
@@ -87,10 +87,11 @@ export const useFloatingLinkEdit = ({
   useHotkeys(
     triggerFloatingLinkHotkeys!,
     (e) => {
-      e.preventDefault();
-
-      if (floatingLinkSelectors.mode() === 'edit') {
-        triggerFloatingLinkEdit(editor);
+      if (
+        floatingLinkSelectors.mode() === 'edit' &&
+        triggerFloatingLinkEdit(editor)
+      ) {
+        e.preventDefault();
       }
     },
     {

--- a/packages/nodes/link/src/components/FloatingLink/useFloatingLinkInsert.ts
+++ b/packages/nodes/link/src/components/FloatingLink/useFloatingLinkInsert.ts
@@ -38,11 +38,9 @@ export const useFloatingLinkInsert = ({
   useHotkeys(
     triggerFloatingLinkHotkeys!,
     (e) => {
-      e.preventDefault();
-
-      triggerFloatingLinkInsert(editor, {
-        focused,
-      });
+      if (triggerFloatingLinkInsert(editor, { focused })) {
+        e.preventDefault();
+      }
     },
     {
       enableOnContentEditable: true,

--- a/packages/nodes/link/src/utils/triggerFloatingLinkEdit.ts
+++ b/packages/nodes/link/src/utils/triggerFloatingLinkEdit.ts
@@ -32,4 +32,6 @@ export const triggerFloatingLinkEdit = <V extends Value>(
   floatingLinkActions.text(text);
 
   floatingLinkActions.isEditing(true);
+
+  return true;
 };

--- a/packages/nodes/link/src/utils/triggerFloatingLinkInsert.ts
+++ b/packages/nodes/link/src/utils/triggerFloatingLinkInsert.ts
@@ -42,4 +42,6 @@ export const triggerFloatingLinkInsert = <V extends Value>(
 
   floatingLinkActions.text(getEditorString(editor, editor.selection));
   floatingLinkActions.show('insert', editor.id);
+
+  return true;
 };


### PR DESCRIPTION
**Description**

It seems that link hotkey always prevents default too, it should only do it when it really handled the action
 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

