### PR TITLE
plugin-table: Add `at` option for inserts

### DIFF
--- a/.changeset/cuddly-cups-cover.md
+++ b/.changeset/cuddly-cups-cover.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-table": patch
+---
+
+`insertTableColumn`, `insertTableRow`: new option `at`

--- a/packages/nodes/table/src/transforms/insertTableColumn.spec.tsx
+++ b/packages/nodes/table/src/transforms/insertTableColumn.spec.tsx
@@ -158,4 +158,81 @@ describe('insertTableColumn', () => {
       expect(editor.selection).toEqual(output.selection);
     });
   });
+
+  describe('when using at', () => {
+    it('should insert', () => {
+      const input = ((
+        <editor>
+          <htable>
+            <htr>
+              <htd>
+                <hp>11</hp>
+              </htd>
+              <htd>
+                <hp>12</hp>
+              </htd>
+            </htr>
+            <htr>
+              <htd>
+                <hp>
+                  21
+                  <cursor />
+                </hp>
+              </htd>
+              <htd>
+                <hp>22</hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any) as PlateEditor;
+
+      const output = ((
+        <editor>
+          <htable>
+            <htr>
+              <htd>
+                <hp>
+                  <htext />
+                </hp>
+              </htd>
+              <htd>
+                <hp>11</hp>
+              </htd>
+              <htd>
+                <hp>12</hp>
+              </htd>
+            </htr>
+            <htr>
+              <htd>
+                <hp>
+                  <cursor />
+                </hp>
+              </htd>
+              <htd>
+                <hp>21</hp>
+              </htd>
+              <htd>
+                <hp>22</hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any) as PlateEditor;
+
+      const editor = createPlateEditor({
+        editor: input,
+        plugins: [
+          createTablePlugin({
+            options: { newCellChildren: [{ text: '' }] },
+          }),
+        ],
+      });
+
+      insertTableColumn(editor, { at: [0, 0, 0] });
+
+      expect(editor.children).toEqual(output.children);
+      expect(editor.selection).toEqual(output.selection);
+    });
+  });
 });

--- a/packages/nodes/table/src/transforms/insertTableColumn.ts
+++ b/packages/nodes/table/src/transforms/insertTableColumn.ts
@@ -21,6 +21,7 @@ export const insertTableColumn = <V extends Value>(
   {
     disableSelect,
     fromCell,
+    at,
     header,
   }: {
     header?: boolean;
@@ -29,6 +30,12 @@ export const insertTableColumn = <V extends Value>(
      * Path of the cell to insert the column from.
      */
     fromCell?: Path;
+
+    /**
+     * Exact path of the cell to insert the column at.
+     * Will overrule `fromCell`.
+     */
+    at?: Path;
 
     /**
      * Disable selection after insertion.
@@ -56,8 +63,16 @@ export const insertTableColumn = <V extends Value>(
 
   const [tableNode, tablePath] = tableEntry;
 
-  const nextCellPath = Path.next(cellPath);
-  const nextColIndex = cellPath[cellPath.length - 1] + 1;
+  let nextCellPath: Path;
+  let nextColIndex: number;
+
+  if (Path.isPath(at)) {
+    nextCellPath = at;
+    nextColIndex = at[at.length - 1];
+  } else {
+    nextCellPath = Path.next(cellPath);
+    nextColIndex = cellPath[cellPath.length - 1] + 1;
+  }
   const currentRowIndex = cellPath[cellPath.length - 2];
 
   const { newCellChildren } = getPluginOptions<TablePlugin, V>(
@@ -69,7 +84,11 @@ export const insertTableColumn = <V extends Value>(
     // for each row, insert a new cell
     tableNode.children.forEach((row, rowIndex) => {
       const insertCellPath = [...nextCellPath];
-      insertCellPath[cellPath.length - 2] = rowIndex;
+      if (Path.isPath(at)) {
+        insertCellPath[at.length - 2] = rowIndex;
+      } else {
+        insertCellPath[cellPath.length - 2] = rowIndex;
+      }
 
       const isHeaderRow =
         header === undefined

--- a/packages/nodes/table/src/transforms/insertTableRow.spec.tsx
+++ b/packages/nodes/table/src/transforms/insertTableRow.spec.tsx
@@ -86,4 +86,83 @@ describe('insertTableRow', () => {
       expect(editor.selection).toEqual(output.selection);
     });
   });
+
+  describe('when inserting a table row at specific path', () => {
+    it('should insert a tr with empty cells', () => {
+      const input = ((
+        <editor>
+          <htable>
+            <htr>
+              <htd>
+                <hp>11</hp>
+              </htd>
+              <htd>
+                <hp>12</hp>
+              </htd>
+            </htr>
+            <htr>
+              <htd>
+                <hp>
+                  21
+                  <cursor />
+                </hp>
+              </htd>
+              <htd>
+                <hp>22</hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any) as PlateEditor;
+
+      const output = ((
+        <editor>
+          <htable>
+            <htr>
+              <htd>
+                <hp>
+                  <cursor />
+                </hp>
+              </htd>
+              <htd>
+                <hp>
+                  <htext />
+                </hp>
+              </htd>
+            </htr>
+            <htr>
+              <htd>
+                <hp>11</hp>
+              </htd>
+              <htd>
+                <hp>12</hp>
+              </htd>
+            </htr>
+            <htr>
+              <htd>
+                <hp>21</hp>
+              </htd>
+              <htd>
+                <hp>22</hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any) as PlateEditor;
+
+      const editor = createPlateEditor({
+        editor: input,
+        plugins: [
+          createTablePlugin({
+            options: { newCellChildren: [{ text: '' }] },
+          }),
+        ],
+      });
+
+      insertTableRow(editor, { at: [0, 0] });
+
+      expect(editor.children).toEqual(output.children);
+      expect(editor.selection).toEqual(output.selection);
+    });
+  });
 });

--- a/packages/nodes/table/src/transforms/insertTableRow.ts
+++ b/packages/nodes/table/src/transforms/insertTableRow.ts
@@ -20,8 +20,18 @@ export const insertTableRow = <V extends Value>(
   {
     header,
     fromRow,
+    at,
     disableSelect,
-  }: { header?: boolean; fromRow?: Path; disableSelect?: boolean } = {}
+  }: {
+    header?: boolean;
+    fromRow?: Path;
+    /**
+     * Exact path of the row to insert the column at.
+     * Will overrule `fromRow`.
+     */
+    at?: Path;
+    disableSelect?: boolean;
+  } = {}
 ) => {
   const trEntry = fromRow
     ? findNode(editor, {
@@ -55,7 +65,7 @@ export const insertTableRow = <V extends Value>(
         newCellChildren,
       }),
       {
-        at: Path.next(trPath),
+        at: Path.isPath(at) ? at : Path.next(trPath),
       }
     );
   });
@@ -67,8 +77,11 @@ export const insertTableRow = <V extends Value>(
     if (!cellEntry) return;
 
     const [, nextCellPath] = cellEntry;
-
-    nextCellPath[nextCellPath.length - 2] += 1;
+    if (Path.isPath(at)) {
+      nextCellPath[nextCellPath.length - 2] = at[at.length - 2];
+    } else {
+      nextCellPath[nextCellPath.length - 2] += 1;
+    }
 
     select(editor, nextCellPath);
   }


### PR DESCRIPTION
**Description**

Solves #2004 
I went for the `at` option as requested by @zbeyens 
 
I created our own `TableToobarButton` component with the same props but with our existing style system. So the usage is the same. Here is an example from my test with our editor:
```tsx
[...]
  const type = getCellTypes(editor)
  const node = getBlockAbove(editor, { match: { type } })
  if (!node) return null
  const [, path] = node
[...]
  return (
    <TableToolbarButton
      title={t('insertTableColumnButton.tooltip')}
      transform={(editor, options) => insertTableColumn(editor, { ...options, at: path })}
      className={styles.tableButtonAdd}>
      <PlusIcon />
    </TableToolbarButton>
  )
```

This is my first try on this. I am not yet satisfied with the code as it is now, lot's of `if`s that probably can be done better. But I am running out of time today and like to have early feedback.

I followed the CONTRIBUTING.md. I got lint fixes in plate-node-id which I did not included because it does not belong to anything I changed.