### PR TITLE
fix bug when editor text is empty

### DIFF
--- a/.changeset/proud-buckets-bathe.md
+++ b/.changeset/proud-buckets-bathe.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-emoji": patch
+---
+
+fix bug when editor text is empty

--- a/packages/nodes/emoji/src/utils/getFindTriggeringInput.ts
+++ b/packages/nodes/emoji/src/utils/getFindTriggeringInput.ts
@@ -38,6 +38,8 @@ export const getFindTriggeringInput = <V extends Value>(
   let repeat = emojiTriggeringController.getOptions().maxTextToSearch;
 
   do {
+    if (!endPoint.offset) break;
+
     emojiTriggeringController.setText(currentText);
     if (emojiTriggeringController.hasTriggeringMark) break;
 


### PR DESCRIPTION
If the editor is empty or the whole text is deleted then the editor throws error while it can find the text he is searching for.

Fixed with stopping the loop if the offset is 0