### PR TITLE
Respect editor read-only state in block selection hooks

### DIFF
--- a/.changeset/thin-ties-confess.md
+++ b/.changeset/thin-ties-confess.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-selection": patch
+---
+
+Respect editor read-only state in block selection hooks

--- a/packages/selection/src/useHooksBlockSelection.ts
+++ b/packages/selection/src/useHooksBlockSelection.ts
@@ -3,6 +3,7 @@ import {
   findNode,
   focusEditor,
   getEndPoint,
+  isEditorReadOnly,
   PlateEditor,
   removeNodes,
   Value,
@@ -36,6 +37,8 @@ export const useHooksBlockSelection = <
     if (el) {
       document.body.removeChild(el);
     }
+
+    const isReadonly = isEditorReadOnly(editor);
 
     if (isSelecting) {
       const input = document.createElement('input');
@@ -85,7 +88,7 @@ export const useHooksBlockSelection = <
           }
         }
 
-        if (isHotkey(['backspace', 'delete'])(e)) {
+        if (isHotkey(['backspace', 'delete'])(e) && !isReadonly) {
           removeNodes(editor, {
             at: [],
             match: (n) => blockSelectionSelectors.selectedIds().has(n.id),
@@ -109,16 +112,20 @@ export const useHooksBlockSelection = <
         if (blockSelectionSelectors.isSelectingSome()) {
           copySelectedBlocks(editor);
 
-          removeNodes(editor, {
-            at: [],
-            match: (n) => blockSelectionSelectors.selectedIds().has(n.id),
-          });
+          if (!isReadonly) {
+            removeNodes(editor, {
+              at: [],
+              match: (n) => blockSelectionSelectors.selectedIds().has(n.id),
+            });
+          }
         }
       };
       input.onpaste = (e) => {
         e.preventDefault();
 
-        pasteSelectedBlocks(editor, e);
+        if (!isReadonly) {
+          pasteSelectedBlocks(editor, e);
+        }
       };
       document.body.appendChild(input);
       input.focus();


### PR DESCRIPTION
Fixes #2089 `:^)`