### PR TITLE
Remove unnecessary query in deserialize markdown

### DIFF
--- a/.changeset/happy-jobs-judge.md
+++ b/.changeset/happy-jobs-judge.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-serializer-md': patch
+---
+
+Fix markdown string to Node conversion process not working properly in markdown string pasting.

--- a/packages/serializers/md/src/deserializer/createDeserializeMdPlugin.ts
+++ b/packages/serializers/md/src/deserializer/createDeserializeMdPlugin.ts
@@ -9,19 +9,6 @@ export const createDeserializeMdPlugin = createPluginFactory({
     editor: {
       insertData: {
         format: 'text/plain',
-        query: ({ data, dataTransfer }) => {
-          const htmlData = dataTransfer.getData('text/html');
-          if (htmlData) return false;
-
-          const { files } = dataTransfer;
-          if (!files?.length) {
-            // if content is simply a URL pass through to not break LinkPlugin
-            if (isUrl(data)) {
-              return false;
-            }
-          }
-          return true;
-        },
         getFragment: ({ data }) => deserializeMd(editor, data),
       },
     },


### PR DESCRIPTION
**Description**

If you copy and paste a markdown string from a text editor, the process of converting it to a node may not work, for example, VSCode. Then occurs because dataTransfer.getData('text/html') can obtain a string.

The query process itself seems unnecessary in the markdown deserialization process.
 
**Example**
1. Go to https://plate.udecode.io/docs/serializing-md
2. Paste markdown strings from VSCode. 