### PR TITLE
Fix crash on deletion of block selection

### DIFF
--- a/packages/selection/src/useHooksBlockSelection.ts
+++ b/packages/selection/src/useHooksBlockSelection.ts
@@ -93,8 +93,6 @@ export const useHooksBlockSelection = <
             at: [],
             match: (n) => blockSelectionSelectors.selectedIds().has(n.id),
           });
-
-          blockSelectionActions.resetSelectedIds();
         }
       };
 


### PR DESCRIPTION
**Description**

Fixes #2116 `:^)`

This PR removes a redundant call to `resetSelectedIds` that causes the editor to crash. It is redundant because `blockSelectionActions.unselect()` is already called by `onChangeBlockSelection`.

There are now no calls to `resetSelectedIds` in the codebase, and it has essentially the same effect as `unselect`, so it might be redundant now 🤷🏻 
