### PR TITLE
Add "Relative" Option to Exit Break Plugin #2128

### DIFF
--- a/.changeset/dull-crabs-train.md
+++ b/.changeset/dull-crabs-train.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-break": patch
+---
+
+adds a new option relative?: boolean to the exit break plugin that allows the exit point ("level" property) to be relative to the current level rather than absolute. It is optional and default false to not introduce any breaking change. Also adds a passing fix to a doc typo. This allows the exit break plugin to be useful in editors with nested blocks e.g. tables (fixes #2128)

--- a/examples/src/exit-break/exitBreakPlugin.ts
+++ b/examples/src/exit-break/exitBreakPlugin.ts
@@ -18,6 +18,7 @@ export const exitBreakPlugin: Partial<MyPlatePlugin<ExitBreakPlugin>> = {
           end: true,
           allow: KEYS_HEADING,
         },
+        relative: true,
       },
     ],
   },

--- a/packages/editor/break/src/exit-break/transforms/exitBreak.ts
+++ b/packages/editor/break/src/exit-break/transforms/exitBreak.ts
@@ -13,7 +13,8 @@ import { ExitBreakRule } from '../types';
 export const exitBreak = <V extends Value>(
   editor: PlateEditor<V>,
   {
-    level = 1,
+    level = 0,
+    relative = false,
     defaultType = getPluginType(editor, ELEMENT_DEFAULT),
     query = {},
     before,
@@ -27,7 +28,10 @@ export const exitBreak = <V extends Value>(
   if (queryEdge && !isEdge) return;
 
   const selectionPath = getPath(editor, editor.selection);
-  const slicedPath = selectionPath.slice(0, -level);
+
+  const slicedPath = relative
+    ? selectionPath.slice(0, -level)
+    : selectionPath.slice(0, level + 1);
 
   let insertPath;
   if (before) {

--- a/packages/editor/break/src/exit-break/transforms/exitBreak.ts
+++ b/packages/editor/break/src/exit-break/transforms/exitBreak.ts
@@ -13,7 +13,7 @@ import { ExitBreakRule } from '../types';
 export const exitBreak = <V extends Value>(
   editor: PlateEditor<V>,
   {
-    level = 0,
+    level = 1,
     defaultType = getPluginType(editor, ELEMENT_DEFAULT),
     query = {},
     before,
@@ -27,12 +27,13 @@ export const exitBreak = <V extends Value>(
   if (queryEdge && !isEdge) return;
 
   const selectionPath = getPath(editor, editor.selection);
+  const slicedPath = selectionPath.slice(0, -level);
 
   let insertPath;
   if (before) {
-    insertPath = selectionPath.slice(0, level + 1);
+    insertPath = slicedPath;
   } else {
-    insertPath = Path.next(selectionPath.slice(0, level + 1));
+    insertPath = Path.next(slicedPath);
   }
 
   insertElements(

--- a/packages/editor/break/src/exit-break/types.ts
+++ b/packages/editor/break/src/exit-break/types.ts
@@ -22,9 +22,14 @@ export interface ExitBreakRule {
   };
 
   /**
-   * Path level where to exit. Default is 1.
+   * Path level where to exit. Default is 0.
    */
   level?: number;
+
+  /**
+   * If true, exit relative to current level. Otherwise, exit at the given level. Default is false.
+   */
+  relative?: boolean;
 
   /**
    * Exit before the selected block if true.


### PR DESCRIPTION
**Description**

See changesets.

This PR adds a new option `relative?: boolean` to the exit break plugin that allows the exit point ("level" property) to be relative to the current level rather than absolute. It is optional and default false to not introduce any breaking change. Also adds a passing fix to a doc typo.

This allows the exit break plugin to be useful in editors with nested blocks e.g. tables (fixes #2128 `:^)`).

**Before (and remains default behaviour):**

https://user-images.githubusercontent.com/33153339/212947593-ed714699-fefd-4225-ab5b-54ab582bd730.mov

**After (and with `relative: true`):**

https://user-images.githubusercontent.com/33153339/212947663-e1c41312-fd3e-474a-a6f2-b84fe8d89bd1.mov
