### PR TITLE
Trim \n from start and end of text nodes when deserializing HTML

### DIFF
--- a/.changeset/chatty-sloths-check.md
+++ b/.changeset/chatty-sloths-check.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-core': minor
+---
+
+Trim \n characters from start and end of text nodes when deserializing HTML

--- a/packages/core/src/plugins/html-deserializer/utils/htmlTextNodeToString.spec.ts
+++ b/packages/core/src/plugins/html-deserializer/utils/htmlTextNodeToString.spec.ts
@@ -19,10 +19,19 @@ describe('htmlTextNodeToString', () => {
     });
   });
 
-  describe('when text node with \n', () => {
+  describe('when text node with no characters except \n', () => {
     it('should be null', () => {
-      const input = document.createTextNode('\n');
+      const input = document.createTextNode('\n\n\n\n\n');
       const output = null;
+
+      expect(htmlTextNodeToString(input)).toEqual(output);
+    });
+  });
+
+  describe('when text node with text and \n characters', () => {
+    it('should strip \n characters from start and end', () => {
+      const input = document.createTextNode('\n\n\ntest\n\ntest\n\n');
+      const output = 'test\n\ntest';
 
       expect(htmlTextNodeToString(input)).toEqual(output);
     });

--- a/packages/core/src/plugins/html-deserializer/utils/htmlTextNodeToString.ts
+++ b/packages/core/src/plugins/html-deserializer/utils/htmlTextNodeToString.ts
@@ -3,14 +3,9 @@
  */
 import { isHtmlText } from './isHtmlText';
 
-// export const htmlTextNewLineToNull = (node: HTMLElement | ChildNode) => {
-//   if (isHtmlText(node)) {
-//     return node.nodeValue === '\n' && null : node.textContent;
-//   }
-// };
-
 export const htmlTextNodeToString = (node: HTMLElement | ChildNode) => {
   if (isHtmlText(node)) {
-    return node.nodeValue === '\n' ? null : node.textContent;
+    const trimmedText = node.textContent?.replace(/^\n+|\n+$/g, '') ?? '';
+    return trimmedText.length > 0 ? trimmedText : null;
   }
 };

--- a/packages/serializers/docx/src/deserializer/__tests__/legal-in.spec.tsx
+++ b/packages/serializers/docx/src/deserializer/__tests__/legal-in.spec.tsx
@@ -54,7 +54,7 @@ describe(getDocxTestName(name), () => {
         </hp>
         <hp indent={7}>
           <htext underline>{'\t'}</htext>
-          {'\n'}Name
+          Name
         </hp>
         <hp indent={7}>Date of signature: </hp>
         <hp indent={7}>

--- a/packages/serializers/docx/src/deserializer/__tests__/legal.spec.tsx
+++ b/packages/serializers/docx/src/deserializer/__tests__/legal.spec.tsx
@@ -54,7 +54,7 @@ describe(getDocxTestName(name), () => {
         </hp>
         <hp indent={7}>
           <htext underline>{'\t'}</htext>
-          {'\n'}Name
+          Name
         </hp>
         <hp indent={7}>Date of signature: </hp>
         <hp indent={7}>


### PR DESCRIPTION
**Description**

Fixes #2152 

This PR changes the behaviour of the HTML deserializer plugin to strip `\n` chararcters from the start and end of text nodes, leaving internal newlines in place. If the text node contains no characters other than newlines, it will be excluded. (Previously, text nodes were only excluded if they contained exactly one newline and nothing else.)

`'test'` -> `'test'`
`'\ntest\n'` -> `'test'`
`'\ntest\ntest\n'` -> `'test\ntest'`
`''` -> `null`
`'\n'` -> `null`
`'\n\n'` -> `null`

**To do**

- [x] Fix failing tests
    `yarn run jest packages/serializers/docx/src/deserializer/__tests__/legal*.spec.tsx`

I'm not sure what to do about the failing DOCX serializer tests. If we want to keep the original behaviour in this context, we could add an option to `htmlTextNodeToString` and other relevant functions that controls how newlines are handled?