### PR TITLE
Code block tests and fixes

### DIFF
--- a/.changeset/blue-seals-taste.md
+++ b/.changeset/blue-seals-taste.md
@@ -1,0 +1,6 @@
+---
+'examples': patch
+'@udecode/plate-code-block': patch
+---
+
+Various fixes relating to code block

--- a/.changeset/blue-seals-taste.md
+++ b/.changeset/blue-seals-taste.md
@@ -1,5 +1,4 @@
 ---
-'examples': patch
 '@udecode/plate-code-block': patch
 ---
 

--- a/docs/docs/sandpack/files/code-PlaygroundApp.tsx
+++ b/docs/docs/sandpack/files/code-PlaygroundApp.tsx
@@ -3,6 +3,7 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import {
   AutoformatPlugin,
+  CodeBlockElement,
   createAlignPlugin,
   createAutoformatPlugin,
   createBlockquotePlugin,
@@ -44,6 +45,7 @@ import {
   createTodoListPlugin,
   createTrailingBlockPlugin,
   createUnderlinePlugin,
+  ELEMENT_CODE_BLOCK,
   MentionCombobox,
   Plate,
   PlateFloatingComments,
@@ -87,6 +89,7 @@ import { playgroundValue } from './playgroundValue';
 import { ToolbarButtons } from './ToolbarButtons';
 
 let components = createPlateUI({
+  [ELEMENT_CODE_BLOCK]: CodeBlockElement,
   [ELEMENT_EXCALIDRAW]: ExcalidrawElement,
   // customize your components by plugin key
 });

--- a/examples/src/PlaygroundApp.tsx
+++ b/examples/src/PlaygroundApp.tsx
@@ -3,6 +3,7 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import {
   AutoformatPlugin,
+  CodeBlockElement,
   createAlignPlugin,
   createAutoformatPlugin,
   createBlockquotePlugin,
@@ -44,6 +45,7 @@ import {
   createTodoListPlugin,
   createTrailingBlockPlugin,
   createUnderlinePlugin,
+  ELEMENT_CODE_BLOCK,
   MentionCombobox,
   Plate,
   PlateFloatingComments,
@@ -87,6 +89,7 @@ import { playgroundValue } from './playgroundValue';
 import { ToolbarButtons } from './ToolbarButtons';
 
 let components = createPlateUI({
+  [ELEMENT_CODE_BLOCK]: CodeBlockElement,
   [ELEMENT_EXCALIDRAW]: ExcalidrawElement,
   // customize your components by plugin key
 });

--- a/packages/nodes/code-block/src/normalizers/normalizeCodeBlock.spec.tsx
+++ b/packages/nodes/code-block/src/normalizers/normalizeCodeBlock.spec.tsx
@@ -1,0 +1,42 @@
+/** @jsx jsx */
+
+import { createPlateUIEditor } from '@udecode/plate/src';
+import { getNode, PlateEditor } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { createCodeBlockPlugin } from '../createCodeBlockPlugin';
+
+jsx;
+
+describe('clean up code block', () => {
+  it('should turn children of code block to code lines', () => {
+    const input = ((
+      <editor>
+        <hcodeblock>
+          <hp>line 1</hp>
+          <hcodeline>line 2</hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const output = ((
+      <editor>
+        <hcodeblock>
+          <hcodeline>line 1</hcodeline>
+          <hcodeline>line 2</hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const editor = createPlateUIEditor({
+      editor: input,
+      plugins: [createCodeBlockPlugin()],
+    });
+
+    const path = [0];
+    const node = getNode(editor, path);
+
+    editor.normalizeNode([node!, path]);
+
+    expect(input.children).toEqual(output.children);
+  });
+});

--- a/packages/nodes/code-block/src/normalizers/normalizeCodeBlock.tsx
+++ b/packages/nodes/code-block/src/normalizers/normalizeCodeBlock.tsx
@@ -8,14 +8,15 @@ import {
   TNodeEntry,
   Value,
 } from '@udecode/plate-core';
-import { ELEMENT_CODE_BLOCK, ELEMENT_CODE_LINE } from '../constants';
+import { ELEMENT_CODE_BLOCK } from '../constants';
+import { getCodeLineType } from '../options';
 
 /**
  * Normalize code block node to force the pre>code>div.codeline structure.
  */
 export const normalizeCodeBlock = <V extends Value>(editor: PlateEditor<V>) => {
   const codeBlockType = getPluginType(editor, ELEMENT_CODE_BLOCK);
-  const codeLineType = getPluginType(editor, ELEMENT_CODE_LINE);
+  const codeLineType = getCodeLineType(editor);
 
   const { normalizeNode } = editor;
   return ([node, path]: TNodeEntry) => {

--- a/packages/nodes/code-block/src/transforms/indentCodeLine.spec.tsx
+++ b/packages/nodes/code-block/src/transforms/indentCodeLine.spec.tsx
@@ -1,0 +1,133 @@
+/** @jsx jsx */
+
+import { getNodeEntry, PlateEditor, TElementEntry } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { createPlateUIEditor } from '../../../../ui/plate/src/utils/createPlateUIEditor';
+import { createCodeBlockPlugin } from '../createCodeBlockPlugin';
+import { indentCodeLine } from './indentCodeLine';
+
+jsx;
+
+describe('indent code line', () => {
+  describe('when the selection is expanded', () => {
+    it('should indent', () => {
+      const input = ((
+        <editor>
+          <hcodeblock>
+            <hcodeline>
+              {'  '}before <anchor />
+              selection
+              <focus /> after
+            </hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any) as PlateEditor;
+
+      const output = ((
+        <editor>
+          <hcodeblock>
+            <hcodeline>
+              {'    '}before <anchor />
+              selection
+              <focus /> after
+            </hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any) as PlateEditor;
+
+      const editor = createPlateUIEditor({
+        editor: input,
+        plugins: [createCodeBlockPlugin()],
+      });
+
+      const codeBlock = getNodeEntry(editor, [0]) as TElementEntry;
+      const codeLine = getNodeEntry(editor, [0, 0]) as TElementEntry;
+
+      indentCodeLine(editor, { codeBlock, codeLine });
+
+      expect(input.children).toEqual(output.children);
+    });
+  });
+
+  describe('when the selection is collapsed', () => {
+    describe('when there are only whitespace characters left of the cursor', () => {
+      it('should indent', () => {
+        const input = ((
+          <editor>
+            <hcodeblock>
+              <hcodeline>
+                {'  '}
+                <cursor />
+                after
+              </hcodeline>
+            </hcodeblock>
+          </editor>
+        ) as any) as PlateEditor;
+
+        const output = ((
+          <editor>
+            <hcodeblock>
+              <hcodeline>
+                {'    '}
+                <cursor />
+                after
+              </hcodeline>
+            </hcodeblock>
+          </editor>
+        ) as any) as PlateEditor;
+
+        const editor = createPlateUIEditor({
+          editor: input,
+          plugins: [createCodeBlockPlugin()],
+        });
+
+        const codeBlock = getNodeEntry(editor, [0]) as TElementEntry;
+        const codeLine = getNodeEntry(editor, [0, 0]) as TElementEntry;
+
+        indentCodeLine(editor, { codeBlock, codeLine });
+
+        expect(input.children).toEqual(output.children);
+      });
+    });
+
+    describe('when there are non-whitespace characters left of the cursor', () => {
+      it('should insert 2 spaces at the cursor', () => {
+        const input = ((
+          <editor>
+            <hcodeblock>
+              <hcodeline>
+                {'  '}before
+                <cursor />
+                after
+              </hcodeline>
+            </hcodeblock>
+          </editor>
+        ) as any) as PlateEditor;
+
+        const output = ((
+          <editor>
+            <hcodeblock>
+              <hcodeline>
+                {'  '}before{'  '}
+                <cursor />
+                after
+              </hcodeline>
+            </hcodeblock>
+          </editor>
+        ) as any) as PlateEditor;
+
+        const editor = createPlateUIEditor({
+          editor: input,
+          plugins: [createCodeBlockPlugin()],
+        });
+
+        const codeBlock = getNodeEntry(editor, [0]) as TElementEntry;
+        const codeLine = getNodeEntry(editor, [0, 0]) as TElementEntry;
+
+        indentCodeLine(editor, { codeBlock, codeLine });
+
+        expect(input.children).toEqual(output.children);
+      });
+    });
+  });
+});

--- a/packages/nodes/code-block/src/transforms/indentCodeLine.ts
+++ b/packages/nodes/code-block/src/transforms/indentCodeLine.ts
@@ -12,30 +12,33 @@ import {
 export interface IndentCodeLineOptions {
   codeBlock: TElementEntry;
   codeLine: TElementEntry;
+  indentDepth?: number;
 }
 
 /**
  * Indent if:
- * - the selection is expanded
- * - the selected code line has no whitespace character
+ * - the selection is expanded OR
+ * - there are no non-whitespace characters left of the cursor
  * Indentation = 2 spaces.
  */
 export const indentCodeLine = <V extends Value>(
   editor: TEditor<V>,
-  { codeLine }: IndentCodeLineOptions
+  { codeLine, indentDepth = 2 }: IndentCodeLineOptions
 ) => {
   const [, codeLinePath] = codeLine;
   const codeLineStart = getStartPoint(editor, codeLinePath);
+  const indent = ' '.repeat(indentDepth);
+
   if (!isExpanded(editor.selection)) {
     const cursor = editor.selection?.anchor;
     const range = getRange(editor, codeLineStart, cursor);
     const text = getEditorString(editor, range);
 
     if (/\S/.test(text)) {
-      insertText(editor, '  ', { at: editor.selection! });
+      insertText(editor, indent, { at: editor.selection! });
       return;
     }
   }
 
-  insertText(editor, '  ', { at: codeLineStart });
+  insertText(editor, indent, { at: codeLineStart });
 };

--- a/packages/nodes/code-block/src/transforms/insertCodeBlock.spec.tsx
+++ b/packages/nodes/code-block/src/transforms/insertCodeBlock.spec.tsx
@@ -1,0 +1,112 @@
+/** @jsx jsx */
+
+import { PlateEditor } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { createPlateUIEditor } from '../../../../ui/plate/src/utils/createPlateUIEditor';
+import { createCodeBlockPlugin } from '../createCodeBlockPlugin';
+import { insertCodeBlock } from './insertCodeBlock';
+
+jsx;
+
+describe('insert code block', () => {
+  describe('when selection is at start of block', () => {
+    it('should turn line to code block', () => {
+      const input = ((
+        <editor>
+          <hp>line 1</hp>
+          <hp>
+            <cursor />
+            line 2
+          </hp>
+          <hp>line 3</hp>
+        </editor>
+      ) as any) as PlateEditor;
+
+      const output = ((
+        <editor>
+          <hp>line 1</hp>
+          <hcodeblock>
+            <hcodeline>
+              <cursor />
+              line 2
+            </hcodeline>
+          </hcodeblock>
+          <hp>line 3</hp>
+        </editor>
+      ) as any) as PlateEditor;
+
+      const editor = createPlateUIEditor({
+        editor: input,
+        plugins: [createCodeBlockPlugin()],
+      });
+
+      insertCodeBlock(editor);
+
+      expect(input.children).toEqual(output.children);
+    });
+  });
+
+  describe('when selection is not at start of block', () => {
+    it('should split line at selection and turn latter line to code block', () => {
+      const input = ((
+        <editor>
+          <hp>line 1</hp>
+          <hp>
+            before <cursor />
+            after
+          </hp>
+          <hp>line 3</hp>
+        </editor>
+      ) as any) as PlateEditor;
+
+      const output = ((
+        <editor>
+          <hp>line 1</hp>
+          <hp>before </hp>
+          <hcodeblock>
+            <hcodeline>
+              <cursor />
+              after
+            </hcodeline>
+          </hcodeblock>
+          <hp>line 3</hp>
+        </editor>
+      ) as any) as PlateEditor;
+
+      const editor = createPlateUIEditor({
+        editor: input,
+        plugins: [createCodeBlockPlugin()],
+      });
+
+      insertCodeBlock(editor);
+
+      expect(input.children).toEqual(output.children);
+    });
+  });
+
+  describe('when selection is expanded', () => {
+    it('should do nothing', () => {
+      const input = ((
+        <editor>
+          <hp>line 1</hp>
+          <hp>
+            before <anchor />
+            selection
+            <focus />
+            after
+          </hp>
+          <hp>line 3</hp>
+        </editor>
+      ) as any) as PlateEditor;
+
+      const editor = createPlateUIEditor({
+        editor: input,
+        plugins: [createCodeBlockPlugin()],
+      });
+
+      insertCodeBlock(editor);
+
+      expect(input.children).toEqual(input.children);
+    });
+  });
+});

--- a/packages/nodes/code-block/src/transforms/insertCodeLine.spec.tsx
+++ b/packages/nodes/code-block/src/transforms/insertCodeLine.spec.tsx
@@ -1,0 +1,46 @@
+/** @jsx jsx */
+
+import { PlateEditor } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { createPlateUIEditor } from '../../../../ui/plate/src/utils/createPlateUIEditor';
+import { createCodeBlockPlugin } from '../createCodeBlockPlugin';
+import { insertCodeLine } from './insertCodeLine';
+
+jsx;
+
+describe('insert code line', () => {
+  it('should insert code line below selected line', () => {
+    const input = ((
+      <editor>
+        <hcodeblock>
+          <hcodeline>
+            line 1<cursor />
+          </hcodeline>
+          <hcodeline>line 2</hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const output = ((
+      <editor>
+        <hcodeblock>
+          <hcodeline>line 1</hcodeline>
+          <hcodeline>
+            {'    '}
+            <cursor />
+          </hcodeline>
+          <hcodeline>line 2</hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const editor = createPlateUIEditor({
+      editor: input,
+      plugins: [createCodeBlockPlugin()],
+    });
+
+    insertCodeLine(editor, 4);
+
+    expect(input.children).toEqual(output.children);
+  });
+});

--- a/packages/nodes/code-block/src/transforms/insertEmptyCodeBlock.spec.tsx
+++ b/packages/nodes/code-block/src/transforms/insertEmptyCodeBlock.spec.tsx
@@ -1,0 +1,117 @@
+/** @jsx jsx */
+
+import { PlateEditor } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { createPlateUIEditor } from '../../../../ui/plate/src/utils/createPlateUIEditor';
+import { createCodeBlockPlugin } from '../createCodeBlockPlugin';
+import { insertEmptyCodeBlock } from './insertEmptyCodeBlock';
+
+jsx;
+
+describe('insert empty code block', () => {
+  it('should insert empty code block on selected empty line', () => {
+    const input = ((
+      <editor>
+        <hp>
+          <cursor />
+        </hp>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const output = ((
+      <editor>
+        <hcodeblock>
+          <hcodeline>
+            <cursor />
+          </hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const editor = createPlateUIEditor({
+      editor: input,
+      plugins: [createCodeBlockPlugin()],
+    });
+
+    insertEmptyCodeBlock(editor, {
+      insertNodesOptions: { select: true },
+    });
+
+    expect(input.children).toEqual(output.children);
+  });
+
+  it('should insert empty code block below selected non-empty line', () => {
+    const input = ((
+      <editor>
+        <hp>
+          test
+          <cursor />
+        </hp>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const output = ((
+      <editor>
+        <hp>test</hp>
+        <hcodeblock>
+          <hcodeline>
+            <cursor />
+          </hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const editor = createPlateUIEditor({
+      editor: input,
+      plugins: [createCodeBlockPlugin()],
+    });
+
+    insertEmptyCodeBlock(editor, {
+      insertNodesOptions: { select: true },
+    });
+
+    expect(input.children).toEqual(output.children);
+  });
+
+  it('should insert empty code block below expanded selection', () => {
+    const input = ((
+      <editor>
+        <hp>line 1</hp>
+        <hp>
+          line <anchor />2
+        </hp>
+        <hp>line 3</hp>
+        <hp>
+          line 4<focus />
+        </hp>
+        <hp>line 5</hp>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const output = ((
+      <editor>
+        <hp>line 1</hp>
+        <hp>line 2</hp>
+        <hp>line 3</hp>
+        <hp>line 4</hp>
+        <hcodeblock>
+          <hcodeline>
+            <cursor />
+          </hcodeline>
+        </hcodeblock>
+        <hp>line 5</hp>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const editor = createPlateUIEditor({
+      editor: input,
+      plugins: [createCodeBlockPlugin()],
+    });
+
+    insertEmptyCodeBlock(editor, {
+      insertNodesOptions: { select: true },
+    });
+
+    expect(input.children).toEqual(output.children);
+  });
+});

--- a/packages/nodes/code-block/src/transforms/insertEmptyCodeBlock.ts
+++ b/packages/nodes/code-block/src/transforms/insertEmptyCodeBlock.ts
@@ -1,6 +1,5 @@
 import {
   ELEMENT_DEFAULT,
-  getPath,
   getPluginType,
   insertElements,
   isBlockAboveEmpty,
@@ -8,7 +7,7 @@ import {
   PlateEditor,
   Value,
 } from '@udecode/plate-core';
-import { Path } from 'slate';
+import { Path, Range } from 'slate';
 import { CodeBlockInsertOptions } from '../types';
 import { insertCodeBlock } from './insertCodeBlock';
 
@@ -27,7 +26,7 @@ export const insertEmptyCodeBlock = <V extends Value>(
   if (!editor.selection) return;
 
   if (isExpanded(editor.selection) || !isBlockAboveEmpty(editor)) {
-    const selectionPath = getPath(editor, editor.selection);
+    const selectionPath = Range.end(editor.selection).path;
     const insertPath = Path.next(selectionPath.slice(0, level + 1));
     insertElements(
       editor,

--- a/packages/nodes/code-block/src/transforms/outdentCodeLine.spec.tsx
+++ b/packages/nodes/code-block/src/transforms/outdentCodeLine.spec.tsx
@@ -1,0 +1,67 @@
+/** @jsx jsx */
+
+import { getNodeEntry, PlateEditor, TElementEntry } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { createPlateUIEditor } from '../../../../ui/plate/src/utils/createPlateUIEditor';
+import { createCodeBlockPlugin } from '../createCodeBlockPlugin';
+import { outdentCodeLine } from './outdentCodeLine';
+
+jsx;
+
+describe('outdent code line', () => {
+  describe('when line is indented', () => {
+    it('should outdent line', () => {
+      const input = ((
+        <editor>
+          <hcodeblock>
+            <hcodeline>{'    '}test</hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any) as PlateEditor;
+
+      const output = ((
+        <editor>
+          <hcodeblock>
+            <hcodeline>{'  '}test</hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any) as PlateEditor;
+
+      const editor = createPlateUIEditor({
+        editor: input,
+        plugins: [createCodeBlockPlugin()],
+      });
+
+      const codeBlock = getNodeEntry(editor, [0]) as TElementEntry;
+      const codeLine = getNodeEntry(editor, [0, 0]) as TElementEntry;
+
+      outdentCodeLine(editor, { codeBlock, codeLine });
+
+      expect(input.children).toEqual(output.children);
+    });
+  });
+
+  describe('when line is not indented', () => {
+    it('should do nothing', () => {
+      const input = ((
+        <editor>
+          <hcodeblock>
+            <hcodeline>test</hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any) as PlateEditor;
+
+      const editor = createPlateUIEditor({
+        editor: input,
+        plugins: [createCodeBlockPlugin()],
+      });
+
+      const codeBlock = getNodeEntry(editor, [0]) as TElementEntry;
+      const codeLine = getNodeEntry(editor, [0, 0]) as TElementEntry;
+
+      outdentCodeLine(editor, { codeBlock, codeLine });
+
+      expect(input.children).toEqual(input.children);
+    });
+  });
+});

--- a/packages/nodes/code-block/src/transforms/toggleCodeBlock.spec.tsx
+++ b/packages/nodes/code-block/src/transforms/toggleCodeBlock.spec.tsx
@@ -1,0 +1,229 @@
+/** @jsx jsx */
+
+import { PlateEditor } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { createPlateUIEditor } from '../../../../ui/plate/src/utils/createPlateUIEditor';
+import { createCodeBlockPlugin } from '../createCodeBlockPlugin';
+import { toggleCodeBlock } from './toggleCodeBlock';
+
+jsx;
+
+describe('toggle on', () => {
+  it('should turn a p to a code block', () => {
+    const input = ((
+      <editor>
+        <hp>
+          line 1
+          <cursor />
+        </hp>
+        <hp>line 2</hp>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const output = ((
+      <editor>
+        <hcodeblock>
+          <hcodeline>
+            line 1
+            <cursor />
+          </hcodeline>
+        </hcodeblock>
+        <hp>line 2</hp>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const editor = createPlateUIEditor({
+      editor: input,
+      plugins: [createCodeBlockPlugin()],
+    });
+
+    toggleCodeBlock(editor);
+
+    expect(input.children).toEqual(output.children);
+  });
+
+  it('should turn a p with a selection to code block', () => {
+    const input = ((
+      <editor>
+        <hp>
+          Planetas <anchor />
+          mori in
+          <focus /> gandavum!
+        </hp>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const output = ((
+      <editor>
+        <hcodeblock>
+          <hcodeline>
+            Planetas <anchor />
+            mori in
+            <focus /> gandavum!
+          </hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const editor = createPlateUIEditor({
+      editor: input,
+      plugins: [createCodeBlockPlugin()],
+    });
+
+    toggleCodeBlock(editor);
+
+    expect(input.children).toEqual(output.children);
+  });
+
+  it('should turn multiple p to a code block', () => {
+    const input = ((
+      <editor>
+        <hp>
+          line <anchor />1
+        </hp>
+        <hp>line 2</hp>
+        <hp>
+          <focus />
+          line 3
+        </hp>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const output = ((
+      <editor>
+        <hcodeblock>
+          <hcodeline>
+            line <anchor />1
+          </hcodeline>
+          <hcodeline>line 2</hcodeline>
+          <hcodeline>
+            <focus />
+            line 3
+          </hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const editor = createPlateUIEditor({
+      editor: input,
+      plugins: [createCodeBlockPlugin()],
+    });
+
+    toggleCodeBlock(editor);
+
+    expect(input.children).toEqual(output.children);
+  });
+});
+
+describe('toggle off', () => {
+  it('should turn a code block to multiple p', () => {
+    const input = ((
+      <editor>
+        <hcodeblock>
+          <hcodeline>
+            line 1
+            <cursor />
+          </hcodeline>
+
+          <hcodeline>line 2</hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const output = ((
+      <editor>
+        <hp>
+          <htext>line 1</htext>
+          <cursor />
+        </hp>
+        <hp>line 2</hp>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const editor = createPlateUIEditor({
+      editor: input,
+      plugins: [createCodeBlockPlugin()],
+    });
+
+    toggleCodeBlock(editor);
+
+    expect(input.children).toEqual(output.children);
+  });
+
+  it('should turn multiple code blocks to multiple p', () => {
+    const input = ((
+      <editor>
+        <hcodeblock>
+          <hcodeline>line 1</hcodeline>
+          <hcodeline>
+            line 2
+            <anchor />
+          </hcodeline>
+          <hcodeline>line 3</hcodeline>
+        </hcodeblock>
+        <hcodeblock>
+          <hcodeline>
+            line 4
+            <focus />
+          </hcodeline>
+          <hcodeline>line 5</hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const output = ((
+      <editor>
+        <hp>line 1</hp>
+        <hp>
+          line 2
+          <anchor />
+        </hp>
+        <hp>line 3</hp>
+        <hp>
+          line 4
+          <focus />
+        </hp>
+        <hp>line 5</hp>
+      </editor>
+    ) as any) as PlateEditor;
+
+    const editor = createPlateUIEditor({
+      editor: input,
+      plugins: [createCodeBlockPlugin()],
+    });
+
+    toggleCodeBlock(editor);
+
+    expect(input.children).toEqual(output.children);
+  });
+
+  describe('when not inside code block', () => {
+    it('should do nothing', () => {
+      const input = ((
+        <editor>
+          <hp>
+            <htext>line 1</htext>
+            <cursor />
+          </hp>
+          <hcodeblock>
+            <hcodeline>
+              line 2
+              <cursor />
+            </hcodeline>
+
+            <hcodeline>line 3</hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any) as PlateEditor;
+
+      const editor = createPlateUIEditor({
+        editor: input,
+        plugins: [createCodeBlockPlugin()],
+      });
+
+      toggleCodeBlock(editor);
+
+      expect(input.children).toEqual(input.children);
+    });
+  });
+});

--- a/packages/nodes/code-block/src/transforms/toggleCodeBlock.ts
+++ b/packages/nodes/code-block/src/transforms/toggleCodeBlock.ts
@@ -1,11 +1,11 @@
 import {
-  getNodeEntries,
   getPluginType,
   PlateEditor,
   setElements,
   someNode,
   TElement,
   Value,
+  withoutNormalizing,
   wrapNodes,
 } from '@udecode/plate-core';
 import { ELEMENT_CODE_BLOCK } from '../constants';
@@ -16,38 +16,26 @@ export const toggleCodeBlock = <V extends Value>(editor: PlateEditor<V>) => {
   if (!editor.selection) return;
 
   const codeBlockType = getPluginType(editor, ELEMENT_CODE_BLOCK);
+  const codeLineType = getCodeLineType(editor);
 
   const isActive = someNode(editor, {
     match: { type: codeBlockType },
   });
 
-  unwrapCodeBlock(editor);
+  withoutNormalizing(editor, () => {
+    unwrapCodeBlock(editor);
 
-  setElements(editor, {
-    type: getCodeLineType(editor),
-  });
-
-  if (!isActive) {
-    const codeBlock = {
-      type: codeBlockType,
-      children: [],
-    };
-    wrapNodes<TElement>(editor, codeBlock);
-
-    const _nodes = getNodeEntries(editor, {
-      match: { type: getCodeLineType(editor) },
-    });
-    const nodes = Array.from(_nodes);
-
-    const codeLine = {
-      type: codeBlockType,
-      children: [],
-    };
-
-    for (const [, path] of nodes) {
-      setElements(editor, codeLine, {
-        at: path,
+    if (!isActive) {
+      setElements(editor, {
+        type: codeLineType,
       });
+
+      const codeBlock = {
+        type: codeBlockType,
+        children: [],
+      };
+
+      wrapNodes<TElement>(editor, codeBlock);
     }
-  }
+  });
 };

--- a/packages/nodes/code-block/src/transforms/unwrapCodeBlock.ts
+++ b/packages/nodes/code-block/src/transforms/unwrapCodeBlock.ts
@@ -1,18 +1,43 @@
 import {
+  ELEMENT_DEFAULT,
+  getChildren,
+  getNodeEntries,
   getPluginType,
   PlateEditor,
+  setElements,
   unwrapNodes,
   Value,
+  withoutNormalizing,
 } from '@udecode/plate-core';
+import { Location } from 'slate';
 import { ELEMENT_CODE_BLOCK } from '../constants';
-import { getCodeLineType } from '../options';
 
 export const unwrapCodeBlock = <V extends Value>(editor: PlateEditor<V>) => {
-  unwrapNodes(editor, {
-    match: { type: getCodeLineType(editor) },
-  });
-  unwrapNodes(editor, {
-    match: { type: getPluginType(editor, ELEMENT_CODE_BLOCK) },
-    split: true,
+  if (!editor.selection) return;
+
+  const codeBlockType = getPluginType(editor, ELEMENT_CODE_BLOCK);
+  const defaultType = getPluginType(editor, ELEMENT_DEFAULT);
+
+  withoutNormalizing(editor, () => {
+    const codeBlockEntries = getNodeEntries(editor, {
+      at: editor.selection as Location,
+      match: { type: codeBlockType },
+    });
+
+    const reversedCodeBlockEntries = Array.from(codeBlockEntries).reverse();
+
+    for (const codeBlockEntry of reversedCodeBlockEntries) {
+      const codeLineEntries = getChildren(codeBlockEntry);
+
+      for (const [, path] of codeLineEntries) {
+        setElements(editor, { type: defaultType }, { at: path });
+      }
+
+      unwrapNodes(editor, {
+        at: codeBlockEntry[1],
+        match: { type: codeBlockType },
+        split: true,
+      });
+    }
   });
 };

--- a/packages/nodes/code-block/src/withCodeBlock.spec.tsx
+++ b/packages/nodes/code-block/src/withCodeBlock.spec.tsx
@@ -1,0 +1,48 @@
+/** @jsx jsx */
+
+import { getNodeEntry, PlateEditor, TElementEntry } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { createPlateUIEditor } from '../../../ui/plate/src/utils/createPlateUIEditor';
+import { createCodeBlockPlugin } from './createCodeBlockPlugin';
+
+jsx;
+
+describe('insert break', () => {
+  describe('when cursor is inside code line', () => {
+    it('should insert a new code line with same indentation', () => {
+      const input = ((
+        <editor>
+          <hcodeblock>
+            <hcodeline>
+              {'    '}before
+              <cursor />
+              after
+            </hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any) as PlateEditor;
+
+      const output = ((
+        <editor>
+          <hcodeblock>
+            <hcodeline>{'    '}before</hcodeline>
+            <hcodeline>
+              {'    '}
+              <cursor />
+              after
+            </hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any) as PlateEditor;
+
+      const editor = createPlateUIEditor({
+        editor: input,
+        plugins: [createCodeBlockPlugin()],
+      });
+
+      editor.insertBreak();
+
+      expect(input.children).toEqual(output.children);
+    });
+  });
+});

--- a/packages/nodes/code-block/src/withCodeBlock.ts
+++ b/packages/nodes/code-block/src/withCodeBlock.ts
@@ -2,7 +2,7 @@ import { PlateEditor, Value } from '@udecode/plate-core';
 import { normalizeCodeBlock } from './normalizers/normalizeCodeBlock';
 import { insertFragmentCodeBlock } from './insertFragmentCodeBlock';
 import { getCodeLineEntry, getIndentDepth } from './queries';
-import { insertCodeLine } from './transforms';
+import { indentCodeLine } from './transforms';
 
 export const withCodeBlock = <
   V extends Value = Value,
@@ -23,7 +23,14 @@ export const withCodeBlock = <
       codeBlock,
       codeLine,
     });
-    insertCodeLine(editor, indentDepth);
+
+    insertBreak();
+
+    indentCodeLine(editor, {
+      codeBlock,
+      codeLine,
+      indentDepth,
+    });
 
     return true;
   };


### PR DESCRIPTION
**Description**

This PR adds tests for a few important functions relating to code blocks, plus fixes where necessary to ensure the correct behaviour. In most cases, I've assumed that the implemented behaviour is the desired behaviour, and I've documented this behaviour in the tests. If you see any tests that don't match intended behaviour, let me know.

See discussion #2160
Fixes #2161
Fixes #719

Check if fixes:
- ~~#2046~~
  - Cannot reproduce in latest examples
- ~~#2026~~
  - Not fixed

 **To do**

- [x] Figure out why code blocks aren't working on [Playground](https://plate-examples-794g1wy0f-udecode.vercel.app/) (but are working on [Basic Elements](https://plate-examples-794g1wy0f-udecode.vercel.app/basic-elements))
- [x] Fix incorrect behaviour in `insertBreakCodeBlock` (see failing spec)
- [x] Fix error in `insertEmptyCodeBlock` (see failing spec)
- [x] ~~Figure out why syntax highlighting isn't working (assuming it should be on Basic Elements)~~
      Edit: Decorations are working correctly but no CSS is set for them
- [x] Changesets
- [x] Rebase prior to merge