### PR TITLE
Add query option to mention plugin

### DIFF
--- a/.changeset/popular-beds-doubt.md
+++ b/.changeset/popular-beds-doubt.md
@@ -1,6 +1,5 @@
 ---
 "@udecode/plate-mention": patch
-"examples": patch
 ---
 
-Add query option to mention plugin
+Add `query` option to mention plugin

--- a/.changeset/popular-beds-doubt.md
+++ b/.changeset/popular-beds-doubt.md
@@ -1,0 +1,6 @@
+---
+"@udecode/plate-mention": patch
+"examples": patch
+---
+
+Add query option to mention plugin

--- a/examples/src/MentionApp.tsx
+++ b/examples/src/MentionApp.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import {
   createComboboxPlugin,
   createMentionPlugin,
+  getBlockAbove,
+  isStartPoint,
   MentionCombobox,
   MentionElement,
   Plate,
@@ -29,7 +31,17 @@ const plugins = createMyPlugins(
     createMentionPlugin({
       key: '/',
       component: MentionElement,
-      options: { trigger: '/' },
+      options: {
+        trigger: '/',
+        query: (editor) => {
+          const blockPath = getBlockAbove(editor)?.[1];
+          return (
+            !!editor.selection &&
+            !!blockPath &&
+            isStartPoint(editor, editor.selection.anchor, blockPath)
+          );
+        },
+      },
     }),
   ],
   {

--- a/packages/nodes/mention/src/types.ts
+++ b/packages/nodes/mention/src/types.ts
@@ -1,5 +1,5 @@
 import { Data, NoData } from '@udecode/plate-combobox';
-import { TElement } from '@udecode/plate-core';
+import { PlateEditor, TElement, Value } from '@udecode/plate-core';
 import { CreateMentionNode } from './getMentionOnSelectItem';
 
 export interface TMentionElement extends TElement {
@@ -16,4 +16,7 @@ export interface MentionPlugin<TData extends Data = NoData> {
   insertSpaceAfterMention?: boolean;
   trigger?: string;
   inputCreation?: { key: string; value: string };
+  query?: <V extends Value = Value, E extends PlateEditor<V> = PlateEditor<V>>(
+    editor: E
+  ) => boolean;
 }

--- a/packages/nodes/mention/src/withMention.ts
+++ b/packages/nodes/mention/src/withMention.ts
@@ -31,7 +31,7 @@ export const withMention = <
 >(
   editor: E,
   {
-    options: { id, trigger, inputCreation },
+    options: { id, trigger, query, inputCreation },
   }: WithPlatePlugin<MentionPlugin, V, E>
 ) => {
   const { type } = getPlugin<{}, V>(editor, ELEMENT_MENTION_INPUT);
@@ -101,6 +101,7 @@ export const withMention = <
     if (
       !editor.selection ||
       text !== trigger ||
+      (query && !query<V, E>(editor)) ||
       isSelectionInMentionInput(editor)
     ) {
       return _insertText(text);


### PR DESCRIPTION
**Description**

Fixes https://github.com/udecode/plate/discussions/2056 + useful towards slash menu. Have added an example to the Mentions example (the slash-triggered plugin only works at the start of the line) `:^)`
