### PR TITLE
Add `isCodeBlockEmpty` and `isSelectionAtCodeBlockStart`

### DIFF
--- a/.changeset/witty-moles-serve.md
+++ b/.changeset/witty-moles-serve.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-code-block': minor
+---
+
+Add isCodeBlockEmpty and isSelectionAtCodeBlockStart queries for use with the reset node plugin

--- a/docs/docs/sandpack/files/exit-break/code-exitBreakPlugin.ts
+++ b/docs/docs/sandpack/files/exit-break/code-exitBreakPlugin.ts
@@ -19,6 +19,7 @@ export const exitBreakPlugin: Partial<MyPlatePlugin<ExitBreakPlugin>> = {
           allow: KEYS_HEADING,
         },
         relative: true,
+        level: 1,
       },
     ],
   },

--- a/docs/docs/sandpack/files/reset-node/code-resetBlockTypePlugin.ts
+++ b/docs/docs/sandpack/files/reset-node/code-resetBlockTypePlugin.ts
@@ -1,16 +1,26 @@
 export const resetBlockTypePluginCode = `import {
   ELEMENT_BLOCKQUOTE,
+  ELEMENT_CODE_BLOCK,
   ELEMENT_PARAGRAPH,
   ELEMENT_TODO_LI,
   isBlockAboveEmpty,
+  isCodeBlockEmpty,
   isSelectionAtBlockStart,
+  isSelectionAtCodeBlockStart,
   ResetNodePlugin,
+  unwrapCodeBlock,
 } from '@udecode/plate';
 import { MyPlatePlugin } from '../typescript/plateTypes';
 
 const resetBlockTypesCommonRule = {
   types: [ELEMENT_BLOCKQUOTE, ELEMENT_TODO_LI],
   defaultType: ELEMENT_PARAGRAPH,
+};
+
+const resetBlockTypesCodeBlockRule = {
+  types: [ELEMENT_CODE_BLOCK],
+  defaultType: ELEMENT_PARAGRAPH,
+  onReset: unwrapCodeBlock,
 };
 
 export const resetBlockTypePlugin: Partial<MyPlatePlugin<ResetNodePlugin>> = {
@@ -25,6 +35,16 @@ export const resetBlockTypePlugin: Partial<MyPlatePlugin<ResetNodePlugin>> = {
         ...resetBlockTypesCommonRule,
         hotkey: 'Backspace',
         predicate: isSelectionAtBlockStart,
+      },
+      {
+        ...resetBlockTypesCodeBlockRule,
+        hotkey: 'Enter',
+        predicate: isCodeBlockEmpty,
+      },
+      {
+        ...resetBlockTypesCodeBlockRule,
+        hotkey: 'Backspace',
+        predicate: isSelectionAtCodeBlockStart,
       },
     ],
   },

--- a/examples/src/reset-node/resetBlockTypePlugin.ts
+++ b/examples/src/reset-node/resetBlockTypePlugin.ts
@@ -1,16 +1,26 @@
 import {
   ELEMENT_BLOCKQUOTE,
+  ELEMENT_CODE_BLOCK,
   ELEMENT_PARAGRAPH,
   ELEMENT_TODO_LI,
   isBlockAboveEmpty,
+  isCodeBlockEmpty,
   isSelectionAtBlockStart,
+  isSelectionAtCodeBlockStart,
   ResetNodePlugin,
+  unwrapCodeBlock,
 } from '@udecode/plate';
 import { MyPlatePlugin } from '../typescript/plateTypes';
 
 const resetBlockTypesCommonRule = {
   types: [ELEMENT_BLOCKQUOTE, ELEMENT_TODO_LI],
   defaultType: ELEMENT_PARAGRAPH,
+};
+
+const resetBlockTypesCodeBlockRule = {
+  types: [ELEMENT_CODE_BLOCK],
+  defaultType: ELEMENT_PARAGRAPH,
+  onReset: unwrapCodeBlock,
 };
 
 export const resetBlockTypePlugin: Partial<MyPlatePlugin<ResetNodePlugin>> = {
@@ -25,6 +35,16 @@ export const resetBlockTypePlugin: Partial<MyPlatePlugin<ResetNodePlugin>> = {
         ...resetBlockTypesCommonRule,
         hotkey: 'Backspace',
         predicate: isSelectionAtBlockStart,
+      },
+      {
+        ...resetBlockTypesCodeBlockRule,
+        hotkey: 'Enter',
+        predicate: isCodeBlockEmpty,
+      },
+      {
+        ...resetBlockTypesCodeBlockRule,
+        hotkey: 'Backspace',
+        predicate: isSelectionAtCodeBlockStart,
       },
     ],
   },

--- a/packages/editor/reset-node/src/onKeyDownResetNode.spec.tsx
+++ b/packages/editor/reset-node/src/onKeyDownResetNode.spec.tsx
@@ -1,15 +1,19 @@
 /** @jsx jsx */
 
-import { ELEMENT_BLOCKQUOTE } from '@udecode/plate-block-quote/src/createBlockquotePlugin';
-import { ELEMENT_CODE_BLOCK } from '@udecode/plate-code-block/src/index';
+import { ELEMENT_BLOCKQUOTE } from '@udecode/plate-block-quote/src/index';
+import {
+  ELEMENT_CODE_BLOCK,
+  isCodeBlockEmpty,
+  isSelectionAtCodeBlockStart,
+  unwrapCodeBlock,
+} from '@udecode/plate-code-block/src/index';
 import {
   isBlockAboveEmpty,
   isSelectionAtBlockStart,
   mockPlugin,
   PlateEditor,
 } from '@udecode/plate-core';
-import { ELEMENT_LI } from '@udecode/plate-list';
-import { unwrapList } from '@udecode/plate-list/src/index';
+import { ELEMENT_LI, unwrapList } from '@udecode/plate-list/src/index';
 import { ELEMENT_PARAGRAPH } from '@udecode/plate-paragraph';
 import { jsx } from '@udecode/plate-test-utils';
 import { createPlateUIEditor } from '@udecode/plate-ui/src/index';
@@ -19,187 +23,363 @@ import { onKeyDownResetNode } from './onKeyDownResetNode';
 jsx;
 
 describe('onKeyDownResetNode', () => {
-  describe('when delete in a blockquote', () => {
-    const input = ((
-      <editor>
-        <hblockquote>
-          <cursor />
-          test
-        </hblockquote>
-      </editor>
-    ) as any) as PlateEditor;
+  const enterRule = {
+    hotkey: 'Enter',
+    predicate: isBlockAboveEmpty,
+  };
 
-    const output = (
-      <editor>
-        <hp>
-          <cursor />
-          test
-        </hp>
-      </editor>
-    ) as any;
+  const backspaceRule = {
+    hotkey: 'Backspace',
+    predicate: isSelectionAtBlockStart,
+  };
 
-    it('should render', () => {
-      jest.spyOn(isHotkey, 'default').mockReturnValue(true);
+  describe('when inside a blockquote', () => {
+    const blockquoteRule = {
+      types: [ELEMENT_BLOCKQUOTE],
+      defaultType: ELEMENT_PARAGRAPH,
+    };
 
-      onKeyDownResetNode(
-        input,
-        mockPlugin({
-          options: {
-            rules: [
-              {
-                types: [ELEMENT_BLOCKQUOTE],
-                defaultType: ELEMENT_PARAGRAPH,
-                hotkey: 'Backspace',
-                predicate: isSelectionAtBlockStart,
-              },
-            ],
-          },
-        })
-      )(new KeyboardEvent('keydown') as any);
-
-      expect(input.children).toEqual(output.children);
+    const plugin = mockPlugin({
+      options: {
+        rules: [
+          { ...blockquoteRule, ...enterRule },
+          { ...blockquoteRule, ...backspaceRule },
+        ],
+      },
     });
-  });
 
-  describe('when enter in a blockquote', () => {
-    const input = ((
-      <editor>
-        <hblockquote>
-          <htext />
-          <cursor />
-        </hblockquote>
-      </editor>
-    ) as any) as PlateEditor;
+    it('should reset on enter', () => {
+      const input = (
+        <editor>
+          <hblockquote>
+            <htext />
+            <cursor />
+          </hblockquote>
+        </editor>
+      ) as any;
 
-    const output = (
-      <editor>
-        <hp>
-          <htext />
-          <cursor />
-        </hp>
-      </editor>
-    ) as any;
+      const output = (
+        <editor>
+          <hp>
+            <htext />
+            <cursor />
+          </hp>
+        </editor>
+      ) as any;
 
-    it('should render', () => {
-      jest.spyOn(isHotkey, 'default').mockReturnValue(true);
-
-      onKeyDownResetNode(
-        input,
-        mockPlugin({
-          options: {
-            rules: [
-              {
-                types: [ELEMENT_BLOCKQUOTE],
-                defaultType: ELEMENT_PARAGRAPH,
-                hotkey: 'Enter',
-                predicate: isBlockAboveEmpty,
-              },
-            ],
-          },
-        })
-      )(new KeyboardEvent('keydown') as any);
-
-      expect(input.children).toEqual(output.children);
-    });
-  });
-
-  describe('when enter in a code block', () => {
-    const input = ((
-      <editor>
-        <hcodeblock>
-          <htext />
-          <cursor />
-        </hcodeblock>
-      </editor>
-    ) as any) as PlateEditor;
-
-    const output = (
-      <editor>
-        <hp>
-          <htext />
-          <cursor />
-        </hp>
-      </editor>
-    ) as any;
-
-    it('should render', () => {
-      jest.spyOn(isHotkey, 'default').mockReturnValue(true);
-
-      onKeyDownResetNode(
-        input,
-        mockPlugin({
-          options: {
-            rules: [
-              {
-                types: [ELEMENT_CODE_BLOCK],
-                defaultType: ELEMENT_PARAGRAPH,
-                hotkey: 'Enter',
-                predicate: isBlockAboveEmpty,
-              },
-            ],
-          },
-        })
-      )(new KeyboardEvent('keydown') as any);
-
-      expect(input.children).toEqual(output.children);
-    });
-  });
-
-  describe('when delete in a list', () => {
-    const input = (
-      <editor>
-        <hul>
-          <hli>
-            <hp>
-              <htext />
-              <cursor />
-            </hp>
-          </hli>
-        </hul>
-      </editor>
-    ) as any;
-
-    const output = (
-      <editor>
-        <hp>
-          <htext />
-          <cursor />
-        </hp>
-      </editor>
-    ) as any;
-
-    it('should be', () => {
       const editor = createPlateUIEditor({
         editor: input,
       });
 
-      jest.spyOn(isHotkey, 'default').mockReturnValue(true);
+      jest
+        .spyOn(isHotkey, 'default')
+        .mockImplementation((hotkey) => hotkey === 'Enter');
 
-      const resetBlockTypesListRule = {
-        types: [ELEMENT_LI],
-        defaultType: ELEMENT_PARAGRAPH,
-        onReset: unwrapList as any,
-      };
+      onKeyDownResetNode(editor, plugin)(new KeyboardEvent('keydown') as any);
 
-      onKeyDownResetNode(
-        input,
-        mockPlugin({
-          options: {
-            rules: [
-              {
-                ...resetBlockTypesListRule,
-                hotkey: 'Enter',
-                predicate: isBlockAboveEmpty,
-              },
-              {
-                ...resetBlockTypesListRule,
-                hotkey: 'Backspace',
-                predicate: isSelectionAtBlockStart,
-              },
-            ],
+      expect(editor.children).toEqual(output.children);
+    });
+
+    it('should reset on backspace', () => {
+      const input = (
+        <editor>
+          <hblockquote>
+            <cursor />
+            test
+          </hblockquote>
+        </editor>
+      ) as any;
+
+      const output = (
+        <editor>
+          <hp>
+            <cursor />
+            test
+          </hp>
+        </editor>
+      ) as any;
+
+      const editor = createPlateUIEditor({
+        editor: input,
+      });
+
+      jest
+        .spyOn(isHotkey, 'default')
+        .mockImplementation((hotkey) => hotkey === 'Backspace');
+
+      onKeyDownResetNode(editor, plugin)(new KeyboardEvent('keydown') as any);
+
+      expect(editor.children).toEqual(output.children);
+    });
+  });
+
+  describe('when inside a code block', () => {
+    const codeBlockRule = {
+      types: [ELEMENT_CODE_BLOCK],
+      defaultType: ELEMENT_PARAGRAPH,
+      onReset: unwrapCodeBlock as any,
+    };
+
+    const plugin = mockPlugin({
+      options: {
+        rules: [
+          {
+            ...codeBlockRule,
+            ...enterRule,
+            predicate: isCodeBlockEmpty,
           },
-        })
-      )(new KeyboardEvent('keydown') as any);
+          {
+            ...codeBlockRule,
+            ...backspaceRule,
+            predicate: isSelectionAtCodeBlockStart,
+          },
+        ],
+      },
+    });
+
+    it('should reset on enter when code block is empty', () => {
+      const input = (
+        <editor>
+          <hcodeblock>
+            <hcodeline>
+              <htext />
+              <cursor />
+            </hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any;
+
+      const output = (
+        <editor>
+          <hp>
+            <htext />
+            <cursor />
+          </hp>
+        </editor>
+      ) as any;
+
+      const editor = createPlateUIEditor({
+        editor: input,
+      });
+
+      jest
+        .spyOn(isHotkey, 'default')
+        .mockImplementation((hotkey) => hotkey === 'Enter');
+
+      onKeyDownResetNode(editor, plugin)(new KeyboardEvent('keydown') as any);
+
+      expect(editor.children).toEqual(output.children);
+    });
+
+    // Since we're not actually performing the keydown, we don't need to test
+    // for its default behavior.
+    it('should not reset on enter when code block is not empty', () => {
+      const input = (
+        <editor>
+          <hcodeblock>
+            <hcodeline>
+              <htext />
+              <cursor />
+            </hcodeline>
+            <hcodeline>line 2</hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any;
+
+      const output = (
+        <editor>
+          <hcodeblock>
+            <hcodeline>
+              <htext />
+              <cursor />
+            </hcodeline>
+            <hcodeline>line 2</hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any;
+
+      const editor = createPlateUIEditor({
+        editor: input,
+      });
+
+      jest
+        .spyOn(isHotkey, 'default')
+        .mockImplementation((hotkey) => hotkey === 'Enter');
+
+      onKeyDownResetNode(editor, plugin)(new KeyboardEvent('keydown') as any);
+
+      expect(editor.children).toEqual(output.children);
+    });
+
+    it('should reset on backspace when on first line', () => {
+      const input = (
+        <editor>
+          <hcodeblock>
+            <hcodeline>
+              <cursor />
+              line 1
+            </hcodeline>
+            <hcodeline>line 2</hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any;
+
+      const output = (
+        <editor>
+          <hp>
+            <cursor />
+            line 1
+          </hp>
+          <hp>line 2</hp>
+        </editor>
+      ) as any;
+
+      const editor = createPlateUIEditor({
+        editor: input,
+      });
+
+      jest
+        .spyOn(isHotkey, 'default')
+        .mockImplementation((hotkey) => hotkey === 'Backspace');
+
+      onKeyDownResetNode(editor, plugin)(new KeyboardEvent('keydown') as any);
+
+      expect(editor.children).toEqual(output.children);
+    });
+
+    // Since we're not actually performing the keydown, we don't need to test
+    // for its default behavior.
+    it('should not reset on backspace when on line after first', () => {
+      const input = (
+        <editor>
+          <hcodeblock>
+            <hcodeline>line 1</hcodeline>
+            <hcodeline>
+              <cursor />
+              line 2
+            </hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any;
+
+      const output = (
+        <editor>
+          <hcodeblock>
+            <hcodeline>line 1</hcodeline>
+            <hcodeline>
+              <cursor />
+              line 2
+            </hcodeline>
+          </hcodeblock>
+        </editor>
+      ) as any;
+
+      const editor = createPlateUIEditor({
+        editor: input,
+      });
+
+      jest
+        .spyOn(isHotkey, 'default')
+        .mockImplementation((hotkey) => hotkey === 'Backspace');
+
+      onKeyDownResetNode(editor, plugin)(new KeyboardEvent('keydown') as any);
+
+      expect(editor.children).toEqual(output.children);
+    });
+  });
+
+  describe('when inside a list', () => {
+    const listRule = {
+      types: [ELEMENT_LI],
+      defaultType: ELEMENT_PARAGRAPH,
+      onReset: unwrapList as any,
+    };
+
+    const plugin = mockPlugin({
+      options: {
+        rules: [
+          { ...listRule, ...enterRule },
+          { ...listRule, ...backspaceRule },
+        ],
+      },
+    });
+
+    it('should reset on enter', () => {
+      const input = (
+        <editor>
+          <hul>
+            <hli>
+              <hp>
+                <htext />
+                <cursor />
+              </hp>
+            </hli>
+          </hul>
+        </editor>
+      ) as any;
+
+      const output = (
+        <editor>
+          <hp>
+            <htext />
+            <cursor />
+          </hp>
+        </editor>
+      ) as any;
+
+      const editor = createPlateUIEditor({
+        editor: input,
+      });
+
+      jest
+        .spyOn(isHotkey, 'default')
+        .mockImplementation((hotkey) => hotkey === 'Enter');
+
+      onKeyDownResetNode(editor, plugin)(new KeyboardEvent('keydown') as any);
+
+      expect(editor.children).toEqual(output.children);
+    });
+
+    it('should reset on backspace', () => {
+      const input = (
+        <editor>
+          <hul>
+            <hli>
+              <hp>
+                <cursor />
+                line 1
+              </hp>
+            </hli>
+            <hli>
+              <hp>line 2</hp>
+            </hli>
+          </hul>
+        </editor>
+      ) as any;
+
+      const output = (
+        <editor>
+          <hp>
+            <cursor />
+            line 1
+          </hp>
+          <hul>
+            <hli>
+              <hp>line 2</hp>
+            </hli>
+          </hul>
+        </editor>
+      ) as any;
+
+      const editor = createPlateUIEditor({
+        editor: input,
+      });
+
+      jest
+        .spyOn(isHotkey, 'default')
+        .mockImplementation((hotkey) => hotkey === 'Backspace');
+
+      onKeyDownResetNode(editor, plugin)(new KeyboardEvent('keydown') as any);
 
       expect(editor.children).toEqual(output.children);
     });

--- a/packages/nodes/code-block/src/queries/index.ts
+++ b/packages/nodes/code-block/src/queries/index.ts
@@ -4,3 +4,5 @@
 
 export * from './getCodeLineEntry';
 export * from './getIndentDepth';
+export * from './isCodeBlockEmpty';
+export * from './isSelectionAtCodeBlockStart';

--- a/packages/nodes/code-block/src/queries/isCodeBlockEmpty.spec.tsx
+++ b/packages/nodes/code-block/src/queries/isCodeBlockEmpty.spec.tsx
@@ -1,0 +1,77 @@
+/** @jsx jsx */
+
+import { PlateEditor } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { createPlateUIEditor } from '../../../../ui/plate/src/utils/createPlateUIEditor';
+import { createCodeBlockPlugin } from '../createCodeBlockPlugin';
+import { isCodeBlockEmpty } from './isCodeBlockEmpty';
+
+jsx;
+
+describe('isCodeBlockEmpty', () => {
+  it('should be false when not in a code block', () => {
+    const input = ((
+      <editor>
+        <hp>
+          <htext />
+          <cursor />
+        </hp>
+        <hcodeblock>
+          <hcodeline>
+            <htext />
+          </hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any) as PlateEditor;
+
+    expect(isCodeBlockEmpty(input)).toBe(false);
+  });
+
+  it('should be false when in a code block with multiple lines', () => {
+    const input = ((
+      <editor>
+        <hcodeblock>
+          <hcodeline>
+            <htext />
+            <cursor />
+          </hcodeline>
+          <hcodeline>
+            <htext />
+          </hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any) as PlateEditor;
+
+    expect(isCodeBlockEmpty(input)).toBe(false);
+  });
+
+  it('should be false when in a non-empty code line', () => {
+    const input = ((
+      <editor>
+        <hcodeblock>
+          <hcodeline>
+            test
+            <cursor />
+          </hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any) as PlateEditor;
+
+    expect(isCodeBlockEmpty(input)).toBe(false);
+  });
+
+  it('should be true when in an empty code line', () => {
+    const input = ((
+      <editor>
+        <hcodeblock>
+          <hcodeline>
+            <htext />
+            <cursor />
+          </hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any) as PlateEditor;
+
+    expect(isCodeBlockEmpty(input)).toBe(true);
+  });
+});

--- a/packages/nodes/code-block/src/queries/isCodeBlockEmpty.ts
+++ b/packages/nodes/code-block/src/queries/isCodeBlockEmpty.ts
@@ -1,0 +1,22 @@
+import {
+  getChildren,
+  getNodeString,
+  PlateEditor,
+  Value,
+} from '@udecode/plate-core';
+import { getCodeLineEntry } from './getCodeLineEntry';
+
+/**
+ * Is the selection inside an empty code block
+ */
+export const isCodeBlockEmpty = <V extends Value>(editor: PlateEditor<V>) => {
+  const { codeBlock } = getCodeLineEntry(editor) ?? {};
+  if (!codeBlock) return false;
+
+  const codeLines = Array.from(getChildren(codeBlock));
+  if (codeLines.length === 0) return true;
+  if (codeLines.length > 1) return false;
+
+  const firstCodeLineNode = codeLines[0][0];
+  return !getNodeString(firstCodeLineNode);
+};

--- a/packages/nodes/code-block/src/queries/isSelectionAtCodeBlockStart.spec.tsx
+++ b/packages/nodes/code-block/src/queries/isSelectionAtCodeBlockStart.spec.tsx
@@ -1,0 +1,78 @@
+/** @jsx jsx */
+
+import { PlateEditor } from '@udecode/plate-core';
+import { jsx } from '@udecode/plate-test-utils';
+import { createPlateUIEditor } from '../../../../ui/plate/src/utils/createPlateUIEditor';
+import { createCodeBlockPlugin } from '../createCodeBlockPlugin';
+import { isSelectionAtCodeBlockStart } from './isSelectionAtCodeBlockStart';
+
+jsx;
+
+describe('isSelectionAtCodeBlockStart', () => {
+  it('should be false when not in a code block', () => {
+    const input = ((
+      <editor>
+        <hp>
+          <htext />
+          <cursor />
+        </hp>
+        <hcodeblock>
+          <hcodeline>
+            <htext />
+          </hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any) as PlateEditor;
+
+    expect(isSelectionAtCodeBlockStart(input)).toBe(false);
+  });
+
+  it('should be false when on a non-first line of a code block', () => {
+    const input = ((
+      <editor>
+        <hcodeblock>
+          <hcodeline>
+            <htext />
+          </hcodeline>
+          <hcodeline>
+            <htext />
+            <cursor />
+          </hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any) as PlateEditor;
+
+    expect(isSelectionAtCodeBlockStart(input)).toBe(false);
+  });
+
+  it('should be false when not at the start of a code line', () => {
+    const input = ((
+      <editor>
+        <hcodeblock>
+          <hcodeline>
+            test
+            <cursor />
+          </hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any) as PlateEditor;
+
+    expect(isSelectionAtCodeBlockStart(input)).toBe(false);
+  });
+
+  it('should be true when at the start of the first line of a code block', () => {
+    const input = ((
+      <editor>
+        <hcodeblock>
+          <hcodeline>
+            <cursor />
+            line 1
+          </hcodeline>
+          <hcodeline>line 2</hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any) as PlateEditor;
+
+    expect(isSelectionAtCodeBlockStart(input)).toBe(true);
+  });
+});

--- a/packages/nodes/code-block/src/queries/isSelectionAtCodeBlockStart.ts
+++ b/packages/nodes/code-block/src/queries/isSelectionAtCodeBlockStart.ts
@@ -1,0 +1,22 @@
+import {
+  isExpanded,
+  isStartPoint,
+  PlateEditor,
+  Value,
+} from '@udecode/plate-core';
+import { getCodeLineEntry } from './getCodeLineEntry';
+
+/**
+ * Is the selection at the start of the first code line in a code block
+ */
+export const isSelectionAtCodeBlockStart = <V extends Value>(
+  editor: PlateEditor<V>
+) => {
+  const { selection } = editor;
+  if (!selection || isExpanded(selection)) return false;
+
+  const { codeBlock } = getCodeLineEntry(editor) ?? {};
+  if (!codeBlock) return false;
+
+  return isStartPoint(editor, selection.anchor, codeBlock[1]);
+};


### PR DESCRIPTION
**Description**

This PR adds two queries to code block which can be used in reset node rules to ensure the correct behaviour. It also rewrites the tests for `onKeyDownResetNode` to be more clear about what they test and to demonstrate the intended usage with code blocks.

I've updated the Reset Nodes example to add rules for code blocks. 

Fixes #2046
Fixes #2026