### PR TITLE
Ignore defaultPrevented keydown event in list plugin

### DIFF
--- a/.changeset/warm-buttons-kneel.md
+++ b/.changeset/warm-buttons-kneel.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-list': patch
+---
+
+Ignore defaultPrevented keydown event

--- a/packages/nodes/list/src/onKeyDownList.ts
+++ b/packages/nodes/list/src/onKeyDownList.ts
@@ -27,6 +27,8 @@ export const onKeyDownList = <
     options: { hotkey, enableResetOnShiftTab },
   }: WithPlatePlugin<ListPlugin, V, E>
 ): KeyboardHandlerReturnType => (e) => {
+  if (e.defaultPrevented) return;
+
   const isTab = Hotkeys.isTab(editor, e);
   const isUntab = Hotkeys.isUntab(editor, e);
 


### PR DESCRIPTION
**Description**

See changesets.

**Context**

I'm working on a plugin, which I'm hoping to share once it's finished, that lets you tab into and out of void elements as you would expect. To do this, I need to be able to conditionally prevent the list plugin from handling the tab event, and this seemed to be the simplest way of doing that.

If this change to the list plugin might have undesirable results, I'm happy to close this PR and expore alternative solutions.