### PR TITLE
fix: Cannot read properties of null (reading 'toString') when image width is null

### DIFF
--- a/.changeset/violet-buses-tell.md
+++ b/.changeset/violet-buses-tell.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-media": patch
+---
+
+fix: Cannot read properties of null (reading 'toString') when image width is null

--- a/packages/media/src/resizable/Resizable.tsx
+++ b/packages/media/src/resizable/Resizable.tsx
@@ -39,7 +39,7 @@ export const useResizable = ({
   const _readOnly = useReadOnly();
   readOnly = isDefined(readOnly) ? readOnly : _readOnly;
 
-  const { width: nodeWidth = '100%' } = element ?? {};
+  const nodeWidth = element?.width ?? '100%';
 
   const [width, setWidth] = useResizableStore().use.width();
 


### PR DESCRIPTION
**Description**

See changesets.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

