### PR TITLE
Fix mark toolbar button not applying mark properly

### DIFF
--- a/.changeset/old-cougars-destroy.md
+++ b/.changeset/old-cougars-destroy.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-ui-toolbar': patch
+---
+
+Fix mark toolbar button not applying mark properly

--- a/packages/ui/toolbar/src/MarkToolbarButton/MarkToolbarButton.tsx
+++ b/packages/ui/toolbar/src/MarkToolbarButton/MarkToolbarButton.tsx
@@ -29,9 +29,7 @@ export const MarkToolbarButton = <V extends Value>({
         e.stopPropagation();
 
         toggleMark(editor, { key: type!, clear });
-        setTimeout(() => {
-          focusEditor(editor, editor.selection ?? editor.prevSelection!);
-        }, 0);
+        focusEditor(editor);
       }}
       {...props}
     />


### PR DESCRIPTION
Fixes #2223

I'm pretty sure `ReactEditor.focus` should be sufficient, since the selection won't have changed since before the button was pressed. Would it be worth changing this in the [other types of toolbar button](https://github.com/search?q=repo%3Audecode%2Fplate%20Toolbar%20focusEditor&type=code)?