### PR TITLE
Fix #2230: Stop accidental infinite recursion

### DIFF
--- a/.changeset/nasty-cougars-hear.md
+++ b/.changeset/nasty-cougars-hear.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-core": patch
+---
+
+Fixes #2230: infinite recursion when using plugin field `then`

--- a/packages/core/src/types/plugin/PlatePlugin.ts
+++ b/packages/core/src/types/plugin/PlatePlugin.ts
@@ -182,10 +182,16 @@ export type PlatePlugin<
      * Can be used to derive plugin fields from `editor` and `plugin`.
      * The returned value will be deeply merged to the plugin.
      */
-    then?: (
-      editor: E,
-      plugin: WithPlatePlugin<P, V, E>
-    ) => Partial<PlatePlugin<P, V, E>> | void;
+    then?: ((
+          editor: E,
+          plugin: WithPlatePlugin<P, V, E>
+        ) => Partial<PlatePlugin<P, V, E>>)
+      | void;
+
+    /**
+     * For internal use. Tracks if then has been replaced for recursive calls.
+     */
+    _thenReplaced?: boolean;
 
     /**
      * Hook called when the editor is initialized.

--- a/packages/core/src/types/plugin/PlatePlugin.ts
+++ b/packages/core/src/types/plugin/PlatePlugin.ts
@@ -182,11 +182,10 @@ export type PlatePlugin<
      * Can be used to derive plugin fields from `editor` and `plugin`.
      * The returned value will be deeply merged to the plugin.
      */
-    then?: ((
-          editor: E,
-          plugin: WithPlatePlugin<P, V, E>
-        ) => Partial<PlatePlugin<P, V, E>>)
-      | void;
+    then?: (
+      editor: E,
+      plugin: WithPlatePlugin<P, V, E>
+    ) => Partial<PlatePlugin<P, V, E>> | void;
 
     /**
      * For internal use. Tracks if then has been replaced for recursive calls.

--- a/packages/core/src/types/plugin/PlatePlugin.ts
+++ b/packages/core/src/types/plugin/PlatePlugin.ts
@@ -190,7 +190,7 @@ export type PlatePlugin<
     /**
      * For internal use. Tracks if then has been replaced for recursive calls.
      */
-    _thenReplaced?: boolean;
+    _thenReplaced?: number;
 
     /**
      * Hook called when the editor is initialized.

--- a/packages/core/src/utils/plate/overridePluginsByKey.ts
+++ b/packages/core/src/utils/plate/overridePluginsByKey.ts
@@ -46,20 +46,25 @@ export const overridePluginsByKey = <
     );
   }
 
-  const { then, _thenReplaced } = plugin;
+  const { then } = plugin;
 
   if (then) {
-    if(!_thenReplaced) {
+    if(typeof plugin._thenReplaced === 'undefined') {
+      plugin._thenReplaced = 0;
+    }
+    // Limit the number of times that `then` can be replaced.
+    // otherwise we will accidentally create a stack overflow.
+    // There is probably a better solution for this.
+    if((plugin._thenReplaced as number) < 3) {
       // override plugin.then
       plugin.then = (editor, p) => {
         const pluginThen = { key: plugin.key, ...then(editor, p) };
-
         return defaultsDeep(
           overridePluginsByKey(pluginThen as any, overrideByKey),
           pluginThen
         );
       };
-      plugin._thenReplaced = true;
+      (plugin._thenReplaced as number)++;
     }
   } else if (overrideByKey[plugin.key]?.then) {
     // TODO: recursvie

--- a/packages/core/src/utils/plate/overridePluginsByKey.ts
+++ b/packages/core/src/utils/plate/overridePluginsByKey.ts
@@ -46,18 +46,21 @@ export const overridePluginsByKey = <
     );
   }
 
-  const { then } = plugin;
+  const { then, _thenReplaced } = plugin;
 
   if (then) {
-    // override plugin.then
-    plugin.then = (editor, p) => {
-      const pluginThen = { key: plugin.key, ...then(editor, p) };
+    if(!_thenReplaced) {
+      // override plugin.then
+      plugin.then = (editor, p) => {
+        const pluginThen = { key: plugin.key, ...then(editor, p) };
 
-      return defaultsDeep(
-        overridePluginsByKey(pluginThen as any, overrideByKey),
-        pluginThen
-      );
-    };
+        return defaultsDeep(
+          overridePluginsByKey(pluginThen as any, overrideByKey),
+          pluginThen
+        );
+      };
+      plugin._thenReplaced = true;
+    }
   } else if (overrideByKey[plugin.key]?.then) {
     // TODO: recursvie
     plugin.then = overrideByKey[plugin.key].then as any;


### PR DESCRIPTION
**Description**

See changesets.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

Add check for `then` being replaced.  This will fix #2230.
 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

