### PR TITLE
Apply isUrl option to pasted links #2239

### DIFF
--- a/.changeset/great-actors-work-core.md
+++ b/.changeset/great-actors-work-core.md
@@ -2,6 +2,4 @@
 '@udecode/plate-core': minor
 ---
 
-`@udecode/plate-core`:
-
 - Add `sanitizeUrl` util to check if URL has an allowed scheme

--- a/.changeset/great-actors-work-core.md
+++ b/.changeset/great-actors-work-core.md
@@ -1,0 +1,7 @@
+---
+'@udecode/plate-core': minor
+---
+
+`@udecode/plate-core`:
+
+- Add `sanitizeUrl` util to check if URL has an allowed scheme

--- a/.changeset/great-actors-work.md
+++ b/.changeset/great-actors-work.md
@@ -1,11 +1,8 @@
 ---
-'@udecode/plate-link': major
+'@udecode/plate-link': minor
 ---
 
-`@udecode/plate-link`:
-
-- Add `allowedSchemes` plugin option
-- Breaking change to the interface of `upsertLink`:
+- `upsertLink`:
   - Removed `isUrl`
   - Added `skipValidation`
 - Check that URL scheme is valid when:

--- a/.changeset/great-actors-work.md
+++ b/.changeset/great-actors-work.md
@@ -1,11 +1,6 @@
 ---
-'@udecode/plate-core': minor
 '@udecode/plate-link': major
 ---
-
-`@udecode/plate-core`:
-
-- Add `sanitizeUrl` util to check if URL has an allowed scheme
 
 `@udecode/plate-link`:
 

--- a/.changeset/great-actors-work.md
+++ b/.changeset/great-actors-work.md
@@ -1,7 +1,20 @@
 ---
 '@udecode/plate-core': minor
-'@udecode/plate-link': minor
+'@udecode/plate-link': major
 ---
 
-- Add `sanitizeUrl` util to core which makes sure URL has an allowed scheme
-- Use `sanitizeUrl` when deserializing from HTML or upserting a link
+`@udecode/plate-core`:
+
+- Add `sanitizeUrl` util to check if URL has an allowed scheme
+
+`@udecode/plate-link`:
+
+- Add `allowedSchemes` plugin option
+- Breaking change to the interface of `upsertLink`:
+  - Removed `isUrl`
+  - Added `skipValidation`
+- Check that URL scheme is valid when:
+  - Upserting links
+  - Deserializing links from HTL
+  - Passing `href` to `nodeProps`
+  - Rendering the `OpenLinkButton` in `FloatingLink`

--- a/.changeset/great-actors-work.md
+++ b/.changeset/great-actors-work.md
@@ -1,0 +1,7 @@
+---
+'@udecode/plate-core': minor
+'@udecode/plate-link': minor
+---
+
+- Add `sanitizeUrl` util to core which makes sure URL has an allowed scheme
+- Use `sanitizeUrl` when deserializing from HTML or upserting a link

--- a/.changeset/quiet-wombats-hug.md
+++ b/.changeset/quiet-wombats-hug.md
@@ -1,0 +1,6 @@
+---
+'@udecode/plate-link': major
+---
+
+- Add `allowedSchemes` plugin option
+  - Any URL schemes other than `http(s)`, `mailto` and `tel` must be added to `allowedSchemes`, otherwise they will not be included in links

--- a/docs/docs/plugins/link.mdx
+++ b/docs/docs/plugins/link.mdx
@@ -48,6 +48,12 @@ interface LinkPlugin {
   triggerFloatingLinkHotkeys?: string | string[];
 
   /**
+   * List of allowed URL schemes.
+   * @default ['http', 'https', 'mailto', 'tel']
+   */
+  allowedSchemes?: string[];
+
+  /**
    * Callback to validate an url.
    * @default isUrl
    */

--- a/packages/core/src/utils/misc/index.ts
+++ b/packages/core/src/utils/misc/index.ts
@@ -15,5 +15,6 @@ export * from './jotai';
 export * from './mergeProps';
 export * from './nanoid';
 export * from './react-hotkeys-hook';
+export * from './sanitizeUrl';
 export * from './type-utils';
 export * from './zustood';

--- a/packages/core/src/utils/misc/sanitizeUrl.spec.ts
+++ b/packages/core/src/utils/misc/sanitizeUrl.spec.ts
@@ -1,0 +1,26 @@
+import { sanitizeUrl } from './sanitizeUrl';
+
+describe('sanitizeUrl', () => {
+  const options = {
+    allowedSchemes: ['http'],
+  };
+
+  it('should return null when url is empty', () => {
+    expect(sanitizeUrl('', options)).toBeNull();
+  });
+
+  it('should return null when url is invalid', () => {
+    expect(sanitizeUrl('invalid', options)).toBeNull();
+  });
+
+  it('should return null when url has disallowed scheme', () => {
+    // eslint-disable-next-line no-script-url
+    expect(sanitizeUrl('javascript://example.com/', options)).toBeNull();
+  });
+
+  it('should return url when url is valid', () => {
+    expect(sanitizeUrl('http://example.com/', options)).toBe(
+      'http://example.com/'
+    );
+  });
+});

--- a/packages/core/src/utils/misc/sanitizeUrl.spec.ts
+++ b/packages/core/src/utils/misc/sanitizeUrl.spec.ts
@@ -1,26 +1,47 @@
 import { sanitizeUrl } from './sanitizeUrl';
 
 describe('sanitizeUrl', () => {
-  const options = {
-    allowedSchemes: ['http'],
-  };
+  describe('when permitInvalid is false', () => {
+    const options = {
+      allowedSchemes: ['http'],
+      permitInvalid: false,
+    };
 
-  it('should return null when url is empty', () => {
-    expect(sanitizeUrl('', options)).toBeNull();
+    it('should return null when url is invalid', () => {
+      expect(sanitizeUrl('invalid', options)).toBeNull();
+    });
+
+    it('should return null when url has disallowed scheme', () => {
+      // eslint-disable-next-line no-script-url
+      expect(sanitizeUrl('javascript://example.com/', options)).toBeNull();
+    });
+
+    it('should return url when url is valid', () => {
+      expect(sanitizeUrl('http://example.com/', options)).toBe(
+        'http://example.com/'
+      );
+    });
   });
 
-  it('should return null when url is invalid', () => {
-    expect(sanitizeUrl('invalid', options)).toBeNull();
-  });
+  describe('when permitInvalid is true', () => {
+    const options = {
+      allowedSchemes: ['http'],
+      permitInvalid: true,
+    };
 
-  it('should return null when url has disallowed scheme', () => {
-    // eslint-disable-next-line no-script-url
-    expect(sanitizeUrl('javascript://example.com/', options)).toBeNull();
-  });
+    it('should return url when url is invalid', () => {
+      expect(sanitizeUrl('invalid', options)).toBe('invalid');
+    });
 
-  it('should return url when url is valid', () => {
-    expect(sanitizeUrl('http://example.com/', options)).toBe(
-      'http://example.com/'
-    );
+    it('should return null when url has disallowed scheme', () => {
+      // eslint-disable-next-line no-script-url
+      expect(sanitizeUrl('javascript://example.com/', options)).toBeNull();
+    });
+
+    it('should return url when url is valid', () => {
+      expect(sanitizeUrl('http://example.com/', options)).toBe(
+        'http://example.com/'
+      );
+    });
   });
 });

--- a/packages/core/src/utils/misc/sanitizeUrl.ts
+++ b/packages/core/src/utils/misc/sanitizeUrl.ts
@@ -1,17 +1,20 @@
 export interface SanitizeUrlOptions {
   allowedSchemes?: string[];
+  permitInvalid?: boolean;
 }
 
 export const sanitizeUrl = (
-  url: string,
-  { allowedSchemes }: SanitizeUrlOptions
+  url: string | undefined,
+  { allowedSchemes, permitInvalid = false }: SanitizeUrlOptions
 ): string | null => {
+  if (!url) return null;
+
   let parsedUrl: URL | null = null;
 
   try {
     parsedUrl = new URL(url);
   } catch (error) {
-    return null;
+    return permitInvalid ? url : null;
   }
 
   if (
@@ -21,5 +24,5 @@ export const sanitizeUrl = (
     return null;
   }
 
-  return url;
+  return parsedUrl.href;
 };

--- a/packages/core/src/utils/misc/sanitizeUrl.ts
+++ b/packages/core/src/utils/misc/sanitizeUrl.ts
@@ -1,0 +1,25 @@
+export interface SanitizeUrlOptions {
+  allowedSchemes?: string[];
+}
+
+export const sanitizeUrl = (
+  url: string,
+  { allowedSchemes }: SanitizeUrlOptions
+): string | null => {
+  let parsedUrl: URL | null = null;
+
+  try {
+    parsedUrl = new URL(url);
+  } catch (error) {
+    return null;
+  }
+
+  if (
+    allowedSchemes &&
+    !allowedSchemes.includes(parsedUrl.protocol.slice(0, -1))
+  ) {
+    return null;
+  }
+
+  return url;
+};

--- a/packages/nodes/link/src/components/FloatingLink/OpenLinkButton.tsx
+++ b/packages/nodes/link/src/components/FloatingLink/OpenLinkButton.tsx
@@ -4,8 +4,10 @@ import {
   createComponentAs,
   createElementAs,
   findNode,
+  getPluginOptions,
   getPluginType,
   HTMLPropsAs,
+  sanitizeUrl,
   useEditorRef,
   usePlateSelection,
 } from '@udecode/plate-core';
@@ -17,6 +19,8 @@ export const useOpenLinkButton = (
 ): HTMLPropsAs<'a'> => {
   const editor = useEditorRef();
   const selection = usePlateSelection();
+
+  const { allowedSchemes } = getPluginOptions(editor, ELEMENT_LINK);
 
   const entry = useMemo(
     () =>
@@ -31,12 +35,13 @@ export const useOpenLinkButton = (
     return {};
   }
 
-  const [link] = entry;
+  const [{ url }] = entry;
+  const href = sanitizeUrl(url, { allowedSchemes }) || undefined;
 
   return {
     'aria-label': 'Open link in a new tab',
     target: '_blank',
-    href: link.url,
+    href,
     onMouseOver: (e) => {
       e.stopPropagation();
     },

--- a/packages/nodes/link/src/components/FloatingLink/OpenLinkButton.tsx
+++ b/packages/nodes/link/src/components/FloatingLink/OpenLinkButton.tsx
@@ -4,23 +4,20 @@ import {
   createComponentAs,
   createElementAs,
   findNode,
-  getPluginOptions,
   getPluginType,
   HTMLPropsAs,
-  sanitizeUrl,
   useEditorRef,
   usePlateSelection,
 } from '@udecode/plate-core';
 import { ELEMENT_LINK } from '../../createLinkPlugin';
 import { TLinkElement } from '../../types';
+import { getLinkAttributes } from '../../utils/index';
 
 export const useOpenLinkButton = (
   props: HTMLPropsAs<'a'>
 ): HTMLPropsAs<'a'> => {
   const editor = useEditorRef();
   const selection = usePlateSelection();
-
-  const { allowedSchemes } = getPluginOptions(editor, ELEMENT_LINK);
 
   const entry = useMemo(
     () =>
@@ -35,13 +32,13 @@ export const useOpenLinkButton = (
     return {};
   }
 
-  const [{ url }] = entry;
-  const href = sanitizeUrl(url, { allowedSchemes }) || undefined;
+  const [element] = entry;
+  const linkAttributes = getLinkAttributes(editor, element);
 
   return {
-    'aria-label': 'Open link in a new tab',
+    ...linkAttributes,
     target: '_blank',
-    href,
+    'aria-label': 'Open link in a new tab',
     onMouseOver: (e) => {
       e.stopPropagation();
     },

--- a/packages/nodes/link/src/components/Link.tsx
+++ b/packages/nodes/link/src/components/Link.tsx
@@ -12,16 +12,10 @@ export type LinkRootProps = PlateRenderElementProps<Value, TLinkElement> &
   HTMLPropsAs<'a'>;
 
 export const useLink = (props: LinkRootProps): HTMLPropsAs<'a'> => {
-  const _props = useElementProps<TLinkElement, 'a'>({
-    ...props,
-    elementToAttributes: (element) => ({
-      href: element.url,
-      target: element.target,
-    }),
-  });
+  const elementProps = useElementProps(props);
 
   return {
-    ..._props,
+    ...elementProps,
     // quick fix: hovering <a> with href loses the editor focus
     onMouseOver: (e) => {
       e.stopPropagation();

--- a/packages/nodes/link/src/components/Link.tsx
+++ b/packages/nodes/link/src/components/Link.tsx
@@ -7,15 +7,21 @@ import {
   Value,
 } from '@udecode/plate-core';
 import { TLinkElement } from '../types';
+import { getLinkAttributes } from '../utils/index';
 
 export type LinkRootProps = PlateRenderElementProps<Value, TLinkElement> &
   HTMLPropsAs<'a'>;
 
 export const useLink = (props: LinkRootProps): HTMLPropsAs<'a'> => {
-  const elementProps = useElementProps(props);
+  const { editor } = props;
+
+  const _props = useElementProps<TLinkElement, 'a'>({
+    ...props,
+    elementToAttributes: (element) => getLinkAttributes(editor, element),
+  });
 
   return {
-    ...elementProps,
+    ..._props,
     // quick fix: hovering <a> with href loses the editor focus
     onMouseOver: (e) => {
       e.stopPropagation();

--- a/packages/nodes/link/src/createLinkPlugin.ts
+++ b/packages/nodes/link/src/createLinkPlugin.ts
@@ -66,18 +66,26 @@ export const createLinkPlugin = createPluginFactory<LinkPlugin>({
     },
     triggerFloatingLinkHotkeys: 'meta+k, ctrl+k',
   },
-  then: (editor, { type }) => ({
+  then: (editor, { type, options }) => ({
     deserializeHtml: {
       rules: [
         {
           validNodeName: 'A',
         },
       ],
-      getNode: (el) => ({
-        type,
-        url: el.getAttribute('href'),
-        target: el.getAttribute('target') || '_blank',
-      }),
+      getNode: (el) => {
+        const href = el.getAttribute('href');
+
+        if (href && (!options.isUrl || options.isUrl(href))) {
+          return {
+            type,
+            url: href,
+            target: el.getAttribute('target') || '_blank',
+          };
+        }
+
+        return undefined;
+      },
     },
   }),
 });

--- a/packages/nodes/link/src/createLinkPlugin.ts
+++ b/packages/nodes/link/src/createLinkPlugin.ts
@@ -2,9 +2,8 @@ import {
   createPluginFactory,
   isUrl,
   RangeBeforeOptions,
-  sanitizeUrl,
 } from '@udecode/plate-core';
-import { validateUrl } from './utils/index';
+import { getLinkAttributes, validateUrl } from './utils/index';
 import { TLinkElement } from './types';
 import { withLink } from './withLink';
 
@@ -73,12 +72,9 @@ export const createLinkPlugin = createPluginFactory<LinkPlugin>({
     },
     triggerFloatingLinkHotkeys: 'meta+k, ctrl+k',
   },
-  then: (editor, { type, options: { allowedSchemes } }) => ({
-    props: ({ element }: { element: TLinkElement }) => ({
-      nodeProps: {
-        href: sanitizeUrl(element.url, { allowedSchemes }) || undefined,
-        target: element.target,
-      },
+  then: (editor, { type }) => ({
+    props: ({ element }) => ({
+      nodeProps: getLinkAttributes(editor, element as TLinkElement),
     }),
     deserializeHtml: {
       rules: [

--- a/packages/nodes/link/src/transforms/submitFloatingLink.ts
+++ b/packages/nodes/link/src/transforms/submitFloatingLink.ts
@@ -9,6 +9,7 @@ import {
   floatingLinkSelectors,
 } from '../components/FloatingLink/floatingLinkStore';
 import { ELEMENT_LINK, LinkPlugin } from '../createLinkPlugin';
+import { validateUrl } from '../utils/index';
 import { upsertLink } from './index';
 
 /**
@@ -20,14 +21,10 @@ import { upsertLink } from './index';
 export const submitFloatingLink = <V extends Value>(editor: PlateEditor<V>) => {
   if (!editor.selection) return;
 
-  const { isUrl, forceSubmit } = getPluginOptions<LinkPlugin, V>(
-    editor,
-    ELEMENT_LINK
-  );
+  const { forceSubmit } = getPluginOptions<LinkPlugin, V>(editor, ELEMENT_LINK);
 
   const url = floatingLinkSelectors.url();
-  const isValid = isUrl?.(url) || forceSubmit;
-  if (!isValid) return;
+  if (!forceSubmit && !validateUrl(editor, url)) return;
 
   const text = floatingLinkSelectors.text();
   const target = floatingLinkSelectors.newTab() ? undefined : '_self';
@@ -38,7 +35,7 @@ export const submitFloatingLink = <V extends Value>(editor: PlateEditor<V>) => {
     url,
     text,
     target,
-    isUrl: (_url) => (forceSubmit || !isUrl ? true : isUrl(_url)),
+    skipValidation: true,
   });
 
   setTimeout(() => {

--- a/packages/nodes/link/src/transforms/upsertLink.spec.tsx
+++ b/packages/nodes/link/src/transforms/upsertLink.spec.tsx
@@ -415,7 +415,7 @@ describe('upsertLink', () => {
     });
   });
 
-  describe('when isUrl returns false', () => {
+  describe('when skipValidation is false and url is invalid', () => {
     const input = (
       <editor>
         <hp>
@@ -434,15 +434,15 @@ describe('upsertLink', () => {
     it('should do nothing', () => {
       const editor = createEditor(input);
       upsertLink(editor, {
-        url: 'https://example.com/',
-        isUrl: (_url) => false,
+        url: 'invalid',
+        skipValidation: false,
       });
 
       expect(input.children).toEqual(output.children);
     });
   });
 
-  describe('when isUrl returns true', () => {
+  describe('when skipValidation is true and url is invalid', () => {
     const input = (
       <editor>
         <hp>
@@ -455,7 +455,7 @@ describe('upsertLink', () => {
     const output = (
       <editor>
         <hp>
-          insert link<ha url="https://example.com/">https://example.com/</ha>.
+          insert link<ha url="invalid">invalid</ha>.
         </hp>
       </editor>
     ) as any;
@@ -463,8 +463,8 @@ describe('upsertLink', () => {
     it('should insert', () => {
       const editor = createEditor(input);
       upsertLink(editor, {
-        url: 'https://example.com/',
-        isUrl: (_url) => true,
+        url: 'invalid',
+        skipValidation: true,
       });
 
       expect(input.children).toEqual(output.children);

--- a/packages/nodes/link/src/transforms/upsertLink.spec.tsx
+++ b/packages/nodes/link/src/transforms/upsertLink.spec.tsx
@@ -415,7 +415,34 @@ describe('upsertLink', () => {
     });
   });
 
-  describe('when isUrl always true', () => {
+  describe('when isUrl returns false', () => {
+    const input = (
+      <editor>
+        <hp>
+          insert link
+          <cursor />.
+        </hp>
+      </editor>
+    ) as any;
+
+    const output = (
+      <editor>
+        <hp>insert link.</hp>
+      </editor>
+    ) as any;
+
+    it('should do nothing', () => {
+      const editor = createEditor(input);
+      upsertLink(editor, {
+        url: 'https://example.com/',
+        isUrl: (_url) => false,
+      });
+
+      expect(input.children).toEqual(output.children);
+    });
+  });
+
+  describe('when isUrl returns true', () => {
     const input = (
       <editor>
         <hp>
@@ -428,14 +455,17 @@ describe('upsertLink', () => {
     const output = (
       <editor>
         <hp>
-          insert link<ha url="test">test</ha>.
+          insert link<ha url="https://example.com/">https://example.com/</ha>.
         </hp>
       </editor>
     ) as any;
 
     it('should insert', () => {
       const editor = createEditor(input);
-      upsertLink(editor, { url: 'test', isUrl: (_url) => true });
+      upsertLink(editor, {
+        url: 'https://example.com/',
+        isUrl: (_url) => true,
+      });
 
       expect(input.children).toEqual(output.children);
     });

--- a/packages/nodes/link/src/utils/getLinkAttributes.spec.ts
+++ b/packages/nodes/link/src/utils/getLinkAttributes.spec.ts
@@ -1,0 +1,60 @@
+import { createPlateEditor } from '@udecode/plate-core';
+import { createLinkPlugin, LinkPlugin } from '../createLinkPlugin';
+import { TLinkElement } from '../types';
+import { getLinkAttributes } from './getLinkAttributes';
+
+const baseLink = {
+  type: 'a',
+  children: [{ text: 'Link text' }],
+};
+
+describe('getLinkAttributes', () => {
+  const editor = createPlateEditor({
+    plugins: [createLinkPlugin()],
+  });
+
+  describe('when url is valid', () => {
+    const link: TLinkElement = {
+      ...baseLink,
+      url: 'https://example.com/',
+      target: '_self',
+    };
+
+    it('should return href and target', () => {
+      expect(getLinkAttributes(editor, link)).toEqual({
+        href: 'https://example.com/',
+        target: '_self',
+      });
+    });
+  });
+
+  describe('when url is invalid', () => {
+    const link: TLinkElement = {
+      ...baseLink,
+      // eslint-disable-next-line no-script-url
+      url: 'javascript://example.com/',
+      target: '_self',
+    };
+
+    it('href should be undefined', () => {
+      expect(getLinkAttributes(editor, link)).toEqual({
+        href: undefined,
+        target: '_self',
+      });
+    });
+  });
+
+  describe('when target is not set', () => {
+    const link: TLinkElement = {
+      ...baseLink,
+      url: 'https://example.com/',
+    };
+
+    it('target should be undefiend', () => {
+      expect(getLinkAttributes(editor, link)).toEqual({
+        href: 'https://example.com/',
+        target: undefined,
+      });
+    });
+  });
+});

--- a/packages/nodes/link/src/utils/getLinkAttributes.ts
+++ b/packages/nodes/link/src/utils/getLinkAttributes.ts
@@ -1,0 +1,23 @@
+import {
+  getPluginOptions,
+  PlateEditor,
+  sanitizeUrl,
+  Value,
+} from '@udecode/plate-core';
+import { ELEMENT_LINK, LinkPlugin } from '../createLinkPlugin';
+import { TLinkElement } from '../types';
+
+export const getLinkAttributes = <V extends Value>(
+  editor: PlateEditor<V>,
+  link: TLinkElement
+) => {
+  const { allowedSchemes } = getPluginOptions<LinkPlugin, V>(
+    editor,
+    ELEMENT_LINK
+  );
+
+  const href = sanitizeUrl(link.url, { allowedSchemes }) || undefined;
+  const { target } = link;
+
+  return { href, target };
+};

--- a/packages/nodes/link/src/utils/index.ts
+++ b/packages/nodes/link/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from './createLinkNode';
 export * from './triggerFloatingLink';
 export * from './triggerFloatingLinkEdit';
 export * from './triggerFloatingLinkInsert';
+export * from './validateUrl';

--- a/packages/nodes/link/src/utils/index.ts
+++ b/packages/nodes/link/src/utils/index.ts
@@ -3,6 +3,7 @@
  */
 
 export * from './createLinkNode';
+export * from './getLinkAttributes';
 export * from './triggerFloatingLink';
 export * from './triggerFloatingLinkEdit';
 export * from './triggerFloatingLinkInsert';

--- a/packages/nodes/link/src/utils/validateUrl.ts
+++ b/packages/nodes/link/src/utils/validateUrl.ts
@@ -1,0 +1,29 @@
+import {
+  getPluginOptions,
+  PlateEditor,
+  sanitizeUrl,
+  Value,
+} from '@udecode/plate-core';
+import { ELEMENT_LINK, LinkPlugin } from '../createLinkPlugin';
+
+export const validateUrl = <V extends Value>(
+  editor: PlateEditor<V>,
+  url: string
+): boolean => {
+  const { allowedSchemes, isUrl } = getPluginOptions<LinkPlugin, V>(
+    editor,
+    ELEMENT_LINK
+  );
+
+  if (isUrl && !isUrl(url)) return false;
+
+  if (
+    !sanitizeUrl(url, {
+      allowedSchemes,
+      permitInvalid: true,
+    })
+  )
+    return false;
+
+  return true;
+};


### PR DESCRIPTION
Links that are pasted as text are detected using the link plugin. Links pasted as HTML are not, leading to https://github.com/udecode/plate/issues/2239.

This PR applies the `isUrl` option, if present, to the href of any pasted `<a />` tag, and falls back to pasting as text if the href is not deemed to be a URL.

Realise this might be quite opinionated and/or a breaking change so happy to create a new "should validate pasted links" flag if preferred.