### PR TITLE
Pass full comment object to `onCommentAdd`

### DIFF
--- a/.changeset/fast-pots-enjoy.md
+++ b/.changeset/fast-pots-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-comments': patch
+---
+
+Include `createdAt` and `userId` (if present) in comment passed to `onCommentAdd`

--- a/packages/comments/src/components/CommentNewSubmitButton.tsx
+++ b/packages/comments/src/components/CommentNewSubmitButton.tsx
@@ -33,18 +33,19 @@ export const useCommentNewSubmitButton = ({
     disabled: !editingCommentText?.trim().length,
     children: submitButtonText,
     onClick: () => {
-      const newComment = isReplyComment
-        ? {
-            id: nanoid(),
-            parentId: comment.id,
-            value: newValue,
-          }
-        : {
-            id: activeCommentId,
-            value: newValue,
-          };
+      const newComment = addComment(
+        isReplyComment
+          ? {
+              id: nanoid(),
+              parentId: comment.id,
+              value: newValue,
+            }
+          : {
+              id: activeCommentId,
+              value: newValue,
+            }
+      );
 
-      addComment(newComment);
       onCommentAdd?.(newComment);
 
       resetNewCommentValue();

--- a/packages/comments/src/stores/comments/CommentsProvider.tsx
+++ b/packages/comments/src/stores/comments/CommentsProvider.tsx
@@ -39,7 +39,7 @@ export interface CommentsStoreState {
 
   focusTextarea: boolean;
 
-  onCommentAdd: ((value: Partial<TComment>) => void) | null;
+  onCommentAdd: ((value: WithPartial<TComment, 'userId'>) => void) | null;
   onCommentUpdate:
     | ((value: Pick<TComment, 'id'> & Partial<Omit<TComment, 'id'>>) => void)
     | null;
@@ -175,19 +175,23 @@ export const useAddComment = () => {
   const myUserId = useCommentsSelectors().myUserId();
 
   return (value: WithPartial<TComment, 'id' | 'userId' | 'createdAt'>) => {
-    if (!myUserId) return;
-
     const id = value.id ?? nanoid();
 
-    setComments({
-      ...comments,
-      [id]: {
-        id,
-        userId: myUserId,
-        createdAt: Date.now(),
-        ...value,
-      },
-    });
+    const newComment: WithPartial<TComment, 'userId'> = {
+      id,
+      userId: myUserId ?? undefined,
+      createdAt: Date.now(),
+      ...value,
+    };
+
+    if (newComment.userId) {
+      setComments({
+        ...comments,
+        [id]: newComment as TComment,
+      });
+    }
+
+    return newComment;
   };
 };
 


### PR DESCRIPTION
**Description**

See changesets.

Since `myUserId` is `string | null`, `onCommentAdd` receives a `WithPartial<TComment, 'userId'>`. This can safely be converted to a `TComment` so long as `myUserId` is non-null. 