### PR TITLE
Add cloud options for min and max resize width of images

### DIFF
--- a/.changeset/rude-seas-work.md
+++ b/.changeset/rude-seas-work.md
@@ -1,0 +1,17 @@
+---
+"@udecode/plate-cloud": minor
+"@udecode/plate-ui-cloud": minor
+---
+
+Add options to set `minResizeWidth` and `maxResizeWidth` to `CloudImagePlugin`.
+
+```typescript
+    createCloudImagePlugin({
+      options: {
+        maxInitialWidth: 320,
+        maxInitialHeight: 320,
+        minResizeWidth: 100,
+        maxResizeWidth: 720,
+      },
+    }),
+```

--- a/examples/src/CloudApp.tsx
+++ b/examples/src/CloudApp.tsx
@@ -41,6 +41,8 @@ const plugins = createMyPlugins(
       options: {
         maxInitialWidth: 320,
         maxInitialHeight: 320,
+        minResizeWidth: 100,
+        maxResizeWidth: 720,
       },
     }),
   ],

--- a/packages/cloud/src/cloud/withCloud.ts
+++ b/packages/cloud/src/cloud/withCloud.ts
@@ -14,7 +14,7 @@ export const withCloud = <
   e: E,
   plugin: WithPlatePlugin<CloudPlugin, V, E>
 ) => {
-  const editor = e as EE;
+  const editor = (e as unknown) as EE;
 
   const {
     apiKey,

--- a/packages/cloud/src/image/createCloudImagePlugin.ts
+++ b/packages/cloud/src/image/createCloudImagePlugin.ts
@@ -1,6 +1,5 @@
 import { createPluginFactory, Value } from '@udecode/plate-core';
-import { PlateCloudEditor } from '../cloud/types';
-import { CloudImagePlugin } from './types';
+import { CloudImagePlugin, PlateCloudImageEditor } from './types';
 import { withCloudImage } from './withCloudImage';
 
 export const ELEMENT_CLOUD_IMAGE = 'cloud_image';
@@ -8,7 +7,7 @@ export const ELEMENT_CLOUD_IMAGE = 'cloud_image';
 export const createCloudImagePlugin = createPluginFactory<
   CloudImagePlugin,
   Value,
-  PlateCloudEditor
+  PlateCloudImageEditor
 >({
   key: ELEMENT_CLOUD_IMAGE,
   isElement: true,

--- a/packages/cloud/src/image/types.ts
+++ b/packages/cloud/src/image/types.ts
@@ -1,9 +1,23 @@
-import { TElement } from '@udecode/plate-core';
+import { PlateEditor, TElement, Value } from '@udecode/plate-core';
 
 export type CloudImagePlugin = {
   maxInitialWidth?: number;
   maxInitialHeight?: number;
+  minResizeWidth?: number;
+  maxResizeWidth?: number;
 };
+
+export type CloudImageEditorProps = {
+  cloudImage: {
+    maxInitialWidth: number;
+    maxInitialHeight: number;
+    minResizeWidth: number;
+    maxResizeWidth: number;
+  };
+};
+
+export type PlateCloudImageEditor<V extends Value = Value> = PlateEditor<V> &
+  CloudImageEditorProps;
 
 export interface TCloudImageElement extends TElement {
   url: string;

--- a/packages/cloud/src/image/withCloudImage.ts
+++ b/packages/cloud/src/image/withCloudImage.ts
@@ -1,17 +1,47 @@
 import { resizeIn } from '@portive/client';
 import { insertNode, Value, WithPlatePlugin } from '@udecode/plate-core';
 import Defer from 'p-defer';
-import { PlateCloudEditor } from '../cloud/types';
+import { PlateCloudEditor } from '../cloud';
 import { UploadError, UploadSuccess } from '../upload';
-import { CloudImagePlugin, TCloudImageElement } from './types';
+import {
+  CloudImagePlugin,
+  PlateCloudImageEditor,
+  TCloudImageElement,
+} from './types';
+
+const DEFAULT_MAX_INITIAL_WIDTH = 320;
+const DEFAULT_MAX_INITIAL_HEIGHT = 320;
+const DEFAULT_MIN_RESIZE_WIDTH = 100;
+const DEFAULT_MAX_RESIZE_WIDTH = 640;
 
 export const withCloudImage = <
   V extends Value = Value,
-  E extends PlateCloudEditor<V> = PlateCloudEditor<V>
+  E extends PlateCloudImageEditor<V> = PlateCloudImageEditor<V>
 >(
-  editor: E,
+  $editor: E,
   plugin: WithPlatePlugin<CloudImagePlugin, V, E>
 ) => {
+  const editor = $editor as E & PlateCloudEditor<V>;
+  const {
+    maxInitialWidth,
+    maxInitialHeight,
+    minResizeWidth,
+    maxResizeWidth,
+  } = {
+    maxInitialWidth: DEFAULT_MAX_INITIAL_WIDTH,
+    maxInitialHeight: DEFAULT_MAX_INITIAL_HEIGHT,
+    minResizeWidth: DEFAULT_MIN_RESIZE_WIDTH,
+    maxResizeWidth: DEFAULT_MAX_RESIZE_WIDTH,
+    ...plugin.options,
+  };
+
+  editor.cloudImage = {
+    maxInitialWidth,
+    maxInitialHeight,
+    minResizeWidth,
+    maxResizeWidth,
+  };
+
   /**
    * We create a deferredFinish which is an object with a `promise` and a way
    * to `resolve` or `reject` the Promise outside of the Promise. We use
@@ -24,10 +54,9 @@ export const withCloudImage = <
 
   editor.cloud.imageFileHandlers = {
     onStart(e) {
-      const { maxInitialWidth, maxInitialHeight } = plugin.options;
       const { width, height } = resizeIn(
         { width: e.width, height: e.height },
-        { width: maxInitialWidth || 320, height: maxInitialHeight || 320 }
+        { width: maxInitialWidth, height: maxInitialHeight }
       );
       const node: TCloudImageElement = {
         type: 'cloud_image',

--- a/packages/ui/cloud/src/CloudImageElement/ResizeControls.tsx
+++ b/packages/ui/cloud/src/CloudImageElement/ResizeControls.tsx
@@ -1,16 +1,12 @@
 import React, { useCallback, useRef, useState } from 'react';
 import { resizeInWidth } from '@portive/client';
-import { PlateCloudEditor, TCloudImageElement } from '@udecode/plate-cloud';
+import {
+  PlateCloudEditor,
+  PlateCloudImageEditor,
+  TCloudImageElement,
+} from '@udecode/plate-cloud';
 import { findNodePath, setNodes, useEditorRef } from '@udecode/plate-core';
 import { ImageSize, SetImageSize } from './types';
-// import { ImageFileInterface } from '../types';
-// import { useHostedImageContext } from './hosted-image-context';
-
-/**
- * FIXME: These constant should be options in the plugin.
- */
-const PLUGIN_MIN_RESIZE_WIDTH = 100;
-const PLUGIN_MAX_RESIZE_WIDTH = 640;
 
 /**
  * The resize label that shows the width/height of the image
@@ -106,8 +102,10 @@ export function ResizeControls({
   size: ImageSize;
   setSize: SetImageSize;
 }) {
-  const editor = useEditorRef() as PlateCloudEditor;
+  const editor = useEditorRef() as PlateCloudEditor & PlateCloudImageEditor;
   const [isResizing, setIsResizing] = useState(false);
+
+  const { minResizeWidth, maxResizeWidth } = editor.cloudImage;
 
   const currentSizeRef = useRef<{ width: number; height: number }>();
 
@@ -116,8 +114,8 @@ export function ResizeControls({
       setIsResizing(true);
       const startX = mouseDownEvent.clientX;
       const startWidth = size.width;
-      const minWidth = PLUGIN_MIN_RESIZE_WIDTH;
-      const maxWidth = Math.min(element.maxWidth, PLUGIN_MAX_RESIZE_WIDTH);
+      const minWidth = minResizeWidth;
+      const maxWidth = Math.min(element.maxWidth, maxResizeWidth);
       /**
        * Handle resize dragging through an event handler on mouseMove on the
        * document.
@@ -178,10 +176,10 @@ export function ResizeControls({
        */
       document.body.style.cursor = 'ew-resize';
     },
-    [editor, element, size, setSize]
+    [size.width, minResizeWidth, element, maxResizeWidth, setSize, editor]
   );
 
-  if (element.width < PLUGIN_MIN_RESIZE_WIDTH) return null;
+  if (element.width < minResizeWidth) return null;
 
   return (
     <>


### PR DESCRIPTION
**Description**

See changesets.

Add options to set minResizeWidth and maxResizeWidth to CloudImagePlugin
 
Enables options like this when defining the CloudImagePlugin

```typescript
    createCloudImagePlugin({
      options: {
        maxInitialWidth: 320,
        maxInitialHeight: 320,
        minResizeWidth: 100,
        maxResizeWidth: 720,
      },
    }),
```