### PR TITLE
use prop active as active logic in MarktoolBarButton when prop active is defined;  if not , use default active logic

### DIFF
--- a/packages/ui/toolbar/src/MarkToolbarButton/MarkToolbarButton.tsx
+++ b/packages/ui/toolbar/src/MarkToolbarButton/MarkToolbarButton.tsx
@@ -6,6 +6,7 @@ import {
   useEventPlateId,
   usePlateEditorState,
   Value,
+  
 } from '@udecode/plate-core';
 import { ToolbarButton } from '../ToolbarButton/ToolbarButton';
 import { MarkToolbarButtonProps } from './MarkToolbarButton.types';
@@ -17,13 +18,15 @@ export const MarkToolbarButton = <V extends Value>({
   id,
   type,
   clear,
+  active: _active,
   ...props
 }: MarkToolbarButtonProps<V>) => {
   const editor = usePlateEditorState(useEventPlateId(id));
-
+  const active =
+    _active ?? (!!editor?.selection && isMarkActive(editor, type!));
   return (
     <ToolbarButton
-      active={!!editor?.selection && isMarkActive(editor, type!)}
+      active={active}
       onClick={(e) => {
         e.preventDefault();
         e.stopPropagation();


### PR DESCRIPTION
**Description**
use prop active as active logic in MarktoolBarButton when prop active is defined; if not , use default active logic
See changesets.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

