### PR TITLE
Disable server side resizing of GIF files

### DIFF
--- a/.changeset/nervous-doors-film.md
+++ b/.changeset/nervous-doors-film.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-ui-cloud": patch
+---
+
+Disable server side resizing of GIF files

--- a/packages/ui/cloud/src/CloudImageElement/generateSrcAndSrcSet.ts
+++ b/packages/ui/cloud/src/CloudImageElement/generateSrcAndSrcSet.ts
@@ -12,6 +12,7 @@ function generateSrc({
    */
   if (url.startsWith('blob:')) return url;
   if (size[0] >= maxSize[0] || size[1] >= maxSize[1]) return url;
+  if (url.endsWith('.gif')) return url;
   return `${url}?size=${size[0]}x${size[1]}`;
 }
 


### PR DESCRIPTION
**Description**

Server side resizing of animated GIFs does not work with the current server-side image resizing library SharpJS.

Typically, the only use case for GIFs is animated GIFs as PNGs are typically used for static images.

For this reason, it's probably best if we just don't resize animated GIFs on the server side. Even if we can support this in the sever-side resizing library, this can lead to complications and trade-offs in the way that GIFs use an adaptive palette which is not necessarily a good fit for resizing which will cause more colors to be required.

This PR allows the GIF image to be resized on the client, but does not cause the image to be resized on the server.

This PR is related to this issue #2260