### PR TITLE
Add `ignoreReadOnly` prop to BalloonToolbar

### DIFF
--- a/.changeset/sweet-chairs-confess.md
+++ b/.changeset/sweet-chairs-confess.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-ui-toolbar': minor
+---
+
+Add `ignoreReadOnly` prop to BalloonToolbar

--- a/examples/src/balloon-toolbar/MarkBalloonToolbar.tsx
+++ b/examples/src/balloon-toolbar/MarkBalloonToolbar.tsx
@@ -5,11 +5,13 @@ import { FormatUnderlined } from '@styled-icons/material/FormatUnderlined';
 import { TippyProps } from '@tippyjs/react';
 import {
   BalloonToolbar,
+  BalloonToolbarProps,
   getPluginType,
   MARK_BOLD,
   MARK_ITALIC,
   MARK_UNDERLINE,
   MarkToolbarButton,
+  WithPartial,
 } from '@udecode/plate';
 import { useMyPlateEditorRef } from '../typescript/plateTypes';
 
@@ -22,7 +24,12 @@ export const markTooltip: TippyProps = {
   placement: 'top',
 };
 
-export const MarkBalloonToolbar = ({ children }: { children?: ReactNode }) => {
+export const MarkBalloonToolbar = (props: WithPartial<BalloonToolbarProps, 'children'>) => {
+  const {
+    children,
+    ...balloonToolbarProps
+  } = props;
+
   const editor = useMyPlateEditorRef();
 
   const arrow = false;
@@ -36,7 +43,7 @@ export const MarkBalloonToolbar = ({ children }: { children?: ReactNode }) => {
   };
 
   return (
-    <BalloonToolbar theme={theme} arrow={arrow}>
+    <BalloonToolbar theme={theme} arrow={arrow} {...balloonToolbarProps}>
       <MarkToolbarButton
         type={getPluginType(editor, MARK_BOLD)}
         icon={<FormatBold />}

--- a/examples/src/comments/CommentBalloonToolbar.tsx
+++ b/examples/src/comments/CommentBalloonToolbar.tsx
@@ -1,20 +1,24 @@
 import React from 'react';
 import { Chat } from '@styled-icons/material/Chat';
 import { TippyProps } from '@tippyjs/react';
-import { PlateCommentToolbarButton } from '@udecode/plate';
+import {
+  BalloonToolbarProps,
+  PlateCommentToolbarButton,
+  WithPartial,
+} from '@udecode/plate';
 import {
   MarkBalloonToolbar,
   markTooltip,
 } from '../balloon-toolbar/MarkBalloonToolbar';
 
-export const CommentBalloonToolbar = () => {
+export const CommentBalloonToolbar = (props: WithPartial<BalloonToolbarProps, 'children'>) => {
   const commentTooltip: TippyProps = {
     content: 'Comment (⌘+⇧+M)',
     ...markTooltip,
   };
 
   return (
-    <MarkBalloonToolbar>
+    <MarkBalloonToolbar {...props}>
       <PlateCommentToolbarButton
         icon={<Chat />}
         tooltip={commentTooltip}

--- a/packages/ui/toolbar/src/BalloonToolbar/BalloonToolbar.tsx
+++ b/packages/ui/toolbar/src/BalloonToolbar/BalloonToolbar.tsx
@@ -12,10 +12,12 @@ export const BalloonToolbar = (props: BalloonToolbarProps) => {
     arrow = false,
     portalElement,
     floatingOptions,
+    ignoreReadOnly,
   } = props;
 
   const { floating, style, placement, open } = useFloatingToolbar({
     floatingOptions,
+    ignoreReadOnly,
   });
 
   const styles = getBalloonToolbarStyles({

--- a/packages/ui/toolbar/src/BalloonToolbar/BalloonToolbar.types.ts
+++ b/packages/ui/toolbar/src/BalloonToolbar/BalloonToolbar.types.ts
@@ -23,4 +23,6 @@ export interface BalloonToolbarProps extends StyledProps<ToolbarProps> {
   portalElement?: Element;
 
   floatingOptions?: UseVirtualFloatingOptions;
+
+  ignoreReadOnly?: boolean;
 }

--- a/packages/ui/toolbar/src/BalloonToolbar/useFloatingToolbar.ts
+++ b/packages/ui/toolbar/src/BalloonToolbar/useFloatingToolbar.ts
@@ -21,7 +21,7 @@ export const useFloatingToolbar = ({
   ignoreReadOnly = false,
 }: {
   floatingOptions?: UseVirtualFloatingOptions;
-  ignoreReadOnly: boolean;
+  ignoreReadOnly?: boolean;
 } = {}): UseVirtualFloatingReturn & {
   open: boolean;
 } => {

--- a/packages/ui/toolbar/src/BalloonToolbar/useFloatingToolbar.ts
+++ b/packages/ui/toolbar/src/BalloonToolbar/useFloatingToolbar.ts
@@ -18,8 +18,10 @@ import { useFocused } from 'slate-react';
 
 export const useFloatingToolbar = ({
   floatingOptions,
+  ignoreReadOnly = false,
 }: {
   floatingOptions?: UseVirtualFloatingOptions;
+  ignoreReadOnly: boolean;
 } = {}): UseVirtualFloatingReturn & {
   open: boolean;
 } => {
@@ -39,17 +41,21 @@ export const useFloatingToolbar = ({
   // On refocus, the editor keeps the previous selection,
   // so we need to wait it's collapsed at the new position before displaying the floating toolbar.
   useEffect(() => {
-    if (!focused) {
+    if (!focused || ignoreReadOnly) {
       setWaitForCollapsedSelection(true);
     }
 
     if (!selectionExpanded) {
       setWaitForCollapsedSelection(false);
     }
-  }, [focused, selectionExpanded]);
+  }, [focused, ignoreReadOnly, selectionExpanded]);
 
   useEffect(() => {
-    if (!selectionExpanded || !selectionText || editor.id !== focusedEditorId) {
+    if (
+      !selectionExpanded ||
+      !selectionText ||
+      !(editor.id === focusedEditorId || ignoreReadOnly)
+    ) {
       setOpen(false);
     } else if (
       selectionText &&
@@ -62,6 +68,7 @@ export const useFloatingToolbar = ({
     editor.id,
     editor.selection,
     focusedEditorId,
+    ignoreReadOnly,
     selectionExpanded,
     selectionText,
     waitForCollapsedSelection,


### PR DESCRIPTION
**Description**

See changesets.

The changes in `/examples` aren't used, but show how options can be passed down to BalloonToolbar. I can revert them if preferred.