### PR TITLE
Override addMark and removeMark in withTable #2263

### DIFF
--- a/packages/nodes/table/src/withAddMarkTable.ts
+++ b/packages/nodes/table/src/withAddMarkTable.ts
@@ -1,0 +1,51 @@
+import {
+  getEndPoint,
+  getPluginType,
+  getStartPoint,
+  isRangeInSameBlock,
+  PlateEditor,
+  select,
+  Value,
+  withoutNormalizing,
+} from '@udecode/plate-common';
+import { ELEMENT_TABLE } from './createTablePlugin';
+import { getTableGridAbove } from './queries';
+
+export const withAddMarkTable = <
+  V extends Value = Value,
+  E extends PlateEditor<V> = PlateEditor<V>
+>(
+  editor: E
+) => {
+  const { addMark } = editor;
+
+  editor.addMark = (key, value) => {
+    if (
+      isRangeInSameBlock(editor, {
+        match: (n) => n.type === getPluginType(editor, ELEMENT_TABLE),
+      })
+    ) {
+      const cellEntries = getTableGridAbove(editor, { format: 'cell' });
+      if (cellEntries.length > 1) {
+        withoutNormalizing(editor, () => {
+          cellEntries.forEach(([, cellPath]) => {
+            select(editor, cellPath);
+            addMark(key, value);
+          });
+
+          // set back the selection
+          select(editor, {
+            anchor: getStartPoint(editor, cellEntries[0][1]),
+            focus: getEndPoint(editor, cellEntries[cellEntries.length - 1][1]),
+          });
+        });
+
+        return;
+      }
+    }
+
+    addMark(key, value);
+  };
+
+  return editor;
+};

--- a/packages/nodes/table/src/withDeleteTable.ts
+++ b/packages/nodes/table/src/withDeleteTable.ts
@@ -94,10 +94,6 @@ export const withDeleteTable = <
   };
 
   editor.deleteFragment = (direction) => {
-    isRangeInSameBlock(editor, {
-      match: (n) => n.type === getPluginType(editor, ELEMENT_TABLE),
-    });
-
     if (
       isRangeInSameBlock(editor, {
         match: (n) => n.type === getPluginType(editor, ELEMENT_TABLE),

--- a/packages/nodes/table/src/withRemoveMarkTable.ts
+++ b/packages/nodes/table/src/withRemoveMarkTable.ts
@@ -1,0 +1,54 @@
+import {
+  getEndPoint,
+  getPluginType,
+  getStartPoint,
+  isRangeInSameBlock,
+  PlateEditor,
+  select,
+  Value,
+  withoutNormalizing,
+} from '@udecode/plate-common';
+import { ELEMENT_TABLE } from './createTablePlugin';
+import { getTableGridAbove } from './queries';
+
+export const withRemoveMarkTable = <
+  V extends Value = Value,
+  E extends PlateEditor<V> = PlateEditor<V>
+>(
+  editor: E
+) => {
+  const { removeMark, marks } = editor;
+
+  editor.removeMark = (key) => {
+    console.log('removeMark', key);
+    console.log('marks', marks);
+
+    if (
+      isRangeInSameBlock(editor, {
+        match: (n) => n.type === getPluginType(editor, ELEMENT_TABLE),
+      })
+    ) {
+      const cellEntries = getTableGridAbove(editor, { format: 'cell' });
+      if (cellEntries.length > 1) {
+        withoutNormalizing(editor, () => {
+          cellEntries.forEach(([, cellPath]) => {
+            select(editor, cellPath);
+            removeMark(key);
+          });
+
+          // set back the selection
+          select(editor, {
+            anchor: getStartPoint(editor, cellEntries[0][1]),
+            focus: getEndPoint(editor, cellEntries[cellEntries.length - 1][1]),
+          });
+        });
+
+        return;
+      }
+    }
+
+    removeMark(key);
+  };
+
+  return editor;
+};

--- a/packages/nodes/table/src/withTable.ts
+++ b/packages/nodes/table/src/withTable.ts
@@ -1,10 +1,12 @@
 import { PlateEditor, Value, WithPlatePlugin } from '@udecode/plate-common';
 import { TablePlugin } from './types';
+import { withAddMarkTable } from './withAddMarkTable';
 import { withDeleteTable } from './withDeleteTable';
 import { withGetFragmentTable } from './withGetFragmentTable';
 import { withInsertFragmentTable } from './withInsertFragmentTable';
 import { withInsertTextTable } from './withInsertTextTable';
 import { withNormalizeTable } from './withNormalizeTable';
+import { withRemoveMarkTable } from './withRemoveMarkTable';
 import { withSelectionTable } from './withSelectionTable';
 import { withSetFragmentDataTable } from './withSetFragmentDataTable';
 
@@ -22,6 +24,8 @@ export const withTable = <
   editor = withInsertTextTable<V, E>(editor, plugin);
   editor = withSelectionTable<V, E>(editor);
   editor = withSetFragmentDataTable<V, E>(editor);
+  editor = withAddMarkTable<V, E>(editor);
+  editor = withRemoveMarkTable<V, E>(editor);
 
   return editor;
 };


### PR DESCRIPTION
Working towards a fix for #2263. Adding marks now works as expected, but toggling existing marks still has the current undesirable behaviour. This is because I have not been able to override `isMarkActive` so the new `removeMark` is never called. Can anyone help with this?