### PR TITLE
Ignore `defaultPrevented` keydowns for most handlers

### DIFF
--- a/.changeset/odd-moles-smoke.md
+++ b/.changeset/odd-moles-smoke.md
@@ -1,0 +1,13 @@
+---
+'@udecode/plate-autoformat': patch
+'@udecode/plate-break': patch
+'@udecode/plate-reset-node': patch
+'@udecode/plate-media': patch
+'@udecode/plate-emoji': patch
+'@udecode/plate-indent': patch
+'@udecode/plate-indent-list': patch
+'@udecode/plate-table': patch
+'@udecode/plate-utils': patch
+---
+
+Ignore `defaultPrevented` keydown events

--- a/packages/editor/autoformat/src/onKeyDownAutoformat.ts
+++ b/packages/editor/autoformat/src/onKeyDownAutoformat.ts
@@ -22,8 +22,9 @@ export const onKeyDownAutoformat = <
     options: { rules, enableUndoOnDelete },
   }: WithPlatePlugin<AutoformatPlugin, V, E>
 ): KeyboardHandlerReturnType => (e: KeyboardEvent) => {
-  // Abort quicky if hotKey was not pressed.
+  if (e.defaultPrevented) return false;
 
+  // Abort quicky if hotKey was not pressed.
   if (!isHotkey('backspace', { byKey: true }, e)) return false;
 
   if (!rules) return false;

--- a/packages/editor/break/src/exit-break/onKeyDownExitBreak.ts
+++ b/packages/editor/break/src/exit-break/onKeyDownExitBreak.ts
@@ -17,6 +17,8 @@ export const onKeyDownExitBreak = <
   editor: E,
   { options: { rules = [] } }: WithPlatePlugin<ExitBreakPlugin, V, E>
 ): KeyboardHandlerReturnType => (event) => {
+  if (event.defaultPrevented) return;
+
   const entry = getBlockAbove(editor);
   if (!entry) return;
 

--- a/packages/editor/break/src/single-line/onKeyDownSingleLine.ts
+++ b/packages/editor/break/src/single-line/onKeyDownSingleLine.ts
@@ -1,6 +1,8 @@
 import { Hotkeys, KeyboardHandlerReturnType } from '@udecode/plate-common';
 
 export const onKeyDownSingleLine = (): KeyboardHandlerReturnType => (event) => {
+  if (event.defaultPrevented) return;
+
   if (Hotkeys.isSplitBlock(event)) {
     event.preventDefault();
   }

--- a/packages/editor/break/src/soft-break/onKeyDownSoftBreak.ts
+++ b/packages/editor/break/src/soft-break/onKeyDownSoftBreak.ts
@@ -16,6 +16,8 @@ export const onKeyDownSoftBreak = <
   editor: E,
   { options: { rules = [] } }: WithPlatePlugin<SoftBreakPlugin, V, E>
 ): KeyboardHandlerReturnType => (event) => {
+  if (event.defaultPrevented) return;
+
   const entry = getBlockAbove(editor);
   if (!entry) return;
 

--- a/packages/editor/reset-node/src/onKeyDownResetNode.ts
+++ b/packages/editor/reset-node/src/onKeyDownResetNode.ts
@@ -22,6 +22,8 @@ export const onKeyDownResetNode = <
   editor: E,
   { options: { rules } }: WithPlatePlugin<ResetNodePlugin, V, E>
 ): KeyboardHandlerReturnType => (event) => {
+  if (event.defaultPrevented) return;
+
   let reset;
 
   if (!editor.selection) return;

--- a/packages/media/src/caption/getOnKeyDownCaption.ts
+++ b/packages/media/src/caption/getOnKeyDownCaption.ts
@@ -9,6 +9,8 @@ import { captionGlobalStore } from './captionGlobalStore';
 export const getOnKeyDownCaption = (pluginKey: string): KeyboardHandler => (
   editor
 ) => (e) => {
+  if (e.defaultPrevented) return;
+
   // focus caption from image
   if (isHotkey('down', e)) {
     const entry = getBlockAbove(editor, {

--- a/packages/nodes/emoji/src/handlers/getOnKeyDownEmoji.ts
+++ b/packages/nodes/emoji/src/handlers/getOnKeyDownEmoji.ts
@@ -24,6 +24,8 @@ const moveSelectionByOffset: <V extends Value>(
 ) => KeyboardEventHandler = (editor, { query = () => true } = {}) => (
   event
 ) => {
+  if (event.defaultPrevented) return;
+
   const { selection } = editor;
 
   if (!selection || Range.isExpanded(selection) || !query(editor)) {

--- a/packages/nodes/indent-list/src/onKeyDownIndentList.ts
+++ b/packages/nodes/indent-list/src/onKeyDownIndentList.ts
@@ -22,6 +22,7 @@ export const onKeyDownIndentList = <
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   plugin: WithPlatePlugin<IndentListPlugin, V, E>
 ): KeyboardHandlerReturnType => (e) => {
+  if (e.defaultPrevented) return;
   if (!editor.selection) return;
 
   const entry = getBlockAbove(editor);

--- a/packages/nodes/indent/src/onKeyDownIndent.ts
+++ b/packages/nodes/indent/src/onKeyDownIndent.ts
@@ -12,6 +12,8 @@ export const onKeyDownIndent = <
 >(
   editor: E
 ): KeyboardHandlerReturnType => (e) => {
+  if (e.defaultPrevented) return;
+
   if (Hotkeys.isTab(editor, e)) {
     e.preventDefault();
     indent(editor);

--- a/packages/nodes/table/src/onKeyDownTable.ts
+++ b/packages/nodes/table/src/onKeyDownTable.ts
@@ -26,6 +26,8 @@ export const onKeyDownTable = <
   editor: E,
   { type }: WithPlatePlugin<P, V, E>
 ): KeyboardHandlerReturnType => (e) => {
+  if (e.defaultPrevented) return;
+
   const isKeyDown = {
     'shift+up': isHotkey('shift+up', e),
     'shift+down': isHotkey('shift+down', e),

--- a/packages/plate-utils/src/plate/onKeyDownToggleElement.ts
+++ b/packages/plate-utils/src/plate/onKeyDownToggleElement.ts
@@ -18,6 +18,8 @@ export const onKeyDownToggleElement = <
   editor: E,
   { type, options: { hotkey } }: WithPlatePlugin<HotkeyPlugin, V, E>
 ): KeyboardHandlerReturnType => (e) => {
+  if (e.defaultPrevented) return;
+
   const defaultType = getPluginType(editor, ELEMENT_DEFAULT);
 
   if (!hotkey) return;

--- a/packages/plate-utils/src/plate/onKeyDownToggleMark.ts
+++ b/packages/plate-utils/src/plate/onKeyDownToggleMark.ts
@@ -15,6 +15,7 @@ export const onKeyDownToggleMark = <
   editor: E,
   { type, options: { hotkey, clear } }: WithPlatePlugin<ToggleMarkPlugin, V, E>
 ): KeyboardHandlerReturnType => (e) => {
+  if (e.defaultPrevented) return;
   if (!hotkey) return;
 
   if (isHotkey(hotkey, e as any)) {


### PR DESCRIPTION
**Description**
Ignore `defaultPrevented` keydowns for most handlers. Mention and combobox are an exception, since they both need to handle the same escape key.

**Context**
Generally speaking, for good UX, any input event should map to at most one action. The standard way of enforcing this is by calling `event.preventDefault()` when handling an input event, and checking `event.defaultPrevented` if there's a chance that the event has already been handled.

This pattern is useful for preventing conflicts between standard Plate plugins and custom plugins. For example, the conflict that prompted this PR was between the soft break plugin and a custom combobox plugin.