### PR TITLE
Use custom access token for changeset release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,5 +52,5 @@ jobs:
           publish: yarn changeset publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.X_GITHUB_CHANGESET_RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
**Description**

Use `X_GITHUB_CHANGESET_RELEASE_TOKEN` for changeset release action. Workaround for [this limitation](https://stackoverflow.com/questions/69063452/github-actions-on-release-created-workflow-trigger-not-working) of workflow triggers.