### PR TITLE
Get right mention input type when overriden

### DIFF
--- a/.changeset/tricky-garlics-guess.md
+++ b/.changeset/tricky-garlics-guess.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-mention": patch
+---
+
+Get right mention input type when overriden

--- a/packages/nodes/mention/src/getMentionOnSelectItem.ts
+++ b/packages/nodes/mention/src/getMentionOnSelectItem.ts
@@ -20,7 +20,8 @@ import {
   withoutMergingHistory,
   withoutNormalizing,
 } from '@udecode/plate-common';
-import { ELEMENT_MENTION, ELEMENT_MENTION_INPUT } from './createMentionPlugin';
+import { isNodeMentionInput } from './queries/isNodeMentionInput';
+import { ELEMENT_MENTION } from './createMentionPlugin';
 import { MentionPlugin, TMentionElement } from './types';
 
 export interface CreateMentionNode<TData extends Data> {
@@ -63,7 +64,7 @@ export const getMentionOnSelectItem = <TData extends Data = NoData>({
 
     withoutMergingHistory(editor, () =>
       removeNodes(editor, {
-        match: (node) => node.type === ELEMENT_MENTION_INPUT,
+        match: (node) => isNodeMentionInput(editor, node),
       })
     );
 


### PR DESCRIPTION
When overriding `ELEMENT_MENTION_INPUT` this function was still used the hardcoded value.

See changesets.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

