### PR TITLE
Fix document with Plate Cloud so it contains the URLs for improved ex…

### DIFF
--- a/.changeset/twenty-suits-agree.md
+++ b/.changeset/twenty-suits-agree.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-ui-cloud": patch
+---
+
+Fix document with Plate Cloud so it contains the URLs for improved ex…

--- a/examples/src/cloud/CloudToolbarButtons.tsx
+++ b/examples/src/cloud/CloudToolbarButtons.tsx
@@ -14,7 +14,8 @@ const buttonStyle: React.CSSProperties = {
 export const CloudToolbarButtons = () => {
   const editor = useMyPlateEditorRef(useEventPlateId()) as PlateCloudEditor;
   const getSaveValue = () => {
-    console.info(editor.cloud.getSaveValue());
+    console.info('editor.children', editor.children);
+    console.info('editor.cloud.getSaveValue()', editor.cloud.getSaveValue());
   };
 
   const finishUploads = async () => {

--- a/packages/ui/cloud/src/CloudImageElement/CloudImageElement.tsx
+++ b/packages/ui/cloud/src/CloudImageElement/CloudImageElement.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { useUpload } from '@udecode/plate-cloud';
-import { Value } from '@udecode/plate-common';
+import { TCloudImageElement, useUpload } from '@udecode/plate-cloud';
+import { findNodePath, setNodes, Value } from '@udecode/plate-common';
 import { getRootProps } from '@udecode/plate-styled-components';
 import { useFocused, useSelected } from 'slate-react';
 import { StatusBar } from '../StatusBar';
@@ -12,9 +12,39 @@ import { ResizeControls } from './ResizeControls';
 export const CloudImageElement = <V extends Value>(
   props: CloudImageElementProps<V>
 ) => {
-  const { attributes, children, element, nodeProps } = props;
+  const { attributes, children, editor, element, nodeProps } = props;
 
   const upload = useUpload(element.url);
+
+  const url = upload.status !== 'not-found' ? upload.url : undefined;
+
+  useEffect(() => {
+    /**
+     * We only want to update the actual URL of the element if the URL is not
+     * a blob URL and if it's different from the current URL.
+     *
+     * NOTE:
+     *
+     * If the user does an undo, this may cause some issues. The ideal solution
+     * is to change the URL once the upload is complete to the final URL and
+     * change the edit history so that the initial insertion of the cloud image
+     * appears to have the final URL.
+     */
+    if (
+      typeof url === 'string' &&
+      !url.startsWith('blob:') &&
+      url !== element.url
+    ) {
+      const path = findNodePath(editor, element);
+      setNodes<TCloudImageElement>(
+        editor,
+        { url },
+        {
+          at: path,
+        }
+      );
+    }
+  }, [editor, element, url]);
 
   const [size, setSize] = useState<{ width: number; height: number }>({
     width: element.width,


### PR DESCRIPTION
Make Plate Cloud work better with collaborative editing

**Description**

Plate Cloud does not persist the URLs into the document value (editor.children) because it keeps these values in a "store".  This was done because we don't want the upload progress to be in the undo history.

But because of this, Plate Cloud does not work with collaborative editing because the other collaborators don't have access to the store values. This fix updates the URL of the cloud image element once the upload is complete so other collaborators will be able to see the uploaded image.