### PR TITLE
Make Plate Cloud state not found look correct for collaborative uploads

### DIFF
--- a/.changeset/strong-bags-relate.md
+++ b/.changeset/strong-bags-relate.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-ui-cloud": patch
+---
+
+Make Plate Cloud state not found look correct for collaborative uploads

--- a/packages/ui/cloud/src/CloudImageElement/CloudImageElement.tsx
+++ b/packages/ui/cloud/src/CloudImageElement/CloudImageElement.tsx
@@ -109,14 +109,30 @@ export const CloudImageElement = <V extends Value>(
           userSelect: 'none',
         }}
       >
-        <img
-          css={styles.img?.css}
-          src={src}
-          srcSet={srcSet}
-          width={size.width}
-          height={size.height}
-          alt=""
-        />
+        {src !== '' ? (
+          <img
+            css={styles.img?.css}
+            src={src}
+            srcSet={srcSet}
+            width={size.width}
+            height={size.height}
+            alt=""
+          />
+        ) : (
+          /**
+           * TODO:
+           * We might want to make a custom `styles` for the placeholder to
+           * allow customization  of the background color for example.
+           */
+          <div
+            css={styles.img?.css}
+            style={{
+              width: size.width,
+              height: size.height,
+              background: '#e0e0e0',
+            }}
+          />
+        )}
         <div css={styles.statusBarContainer?.css}>
           <StatusBar
             upload={upload}

--- a/packages/ui/cloud/src/StatusBar/StatusBar.styles.ts
+++ b/packages/ui/cloud/src/StatusBar/StatusBar.styles.ts
@@ -12,7 +12,7 @@ import tw from 'twin.macro';
  * - `CloudImageElement.styles.ts`
  */
 export const statusBarStyleValues = {
-  progressBarTrack: [tw`h-4 bg-white bg-gray-100 rounded-lg shadow-md`],
+  progressBarTrack: [tw`h-4 bg-gray-100 rounded-lg shadow-md`],
   progressBarBar: [tw`h-4 duration-100 bg-blue-500 rounded-lg`],
   failBar: [
     tw`h-4 text-xs font-bold leading-tight text-center text-white uppercase bg-red-700 border rounded-lg shadow-md`,

--- a/packages/ui/cloud/src/StatusBar/StatusBar.tsx
+++ b/packages/ui/cloud/src/StatusBar/StatusBar.tsx
@@ -106,7 +106,7 @@ export function StatusBar(props: {
     case 'error':
       return <FailBar failBarCss={failBarCss}>Upload Failed</FailBar>;
     case 'not-found':
-      return <FailBar failBarCss={failBarCss}>State Not Found</FailBar>;
+      return <FailBar failBarCss={failBarCss}>Uploading...</FailBar>;
     case 'success':
       return children || null;
     default:


### PR DESCRIPTION
**Description**

This is part 2 to the Plate Cloud Collaborative Fix.

When uploading state is not found, which will happen for any collaborators that are not doing the upload, the UI will now show "uploading" instead of "state not found". Additionally, the image placeholder will not be a broken image and will instead show a gray background as would be appropriate in a collaborative environment.