### PR TITLE
Add missing peer dependencies

### DIFF
--- a/.changeset/new-rabbits-smoke.md
+++ b/.changeset/new-rabbits-smoke.md
@@ -1,0 +1,5 @@
+---
+'@udecode/resizable': patch
+---
+
+Add missing peer dependencies to `@udecode/resizable`

--- a/packages/resizable/package.json
+++ b/packages/resizable/package.json
@@ -23,7 +23,10 @@
   },
   "peerDependencies": {
     "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "react-dom": ">=16.8.0",
+    "slate": ">=0.87.0",
+    "slate-history": ">=0.86.0",
+    "slate-react": ">=0.88.0"
   },
   "keywords": [
     "plate",


### PR DESCRIPTION
Missing peer dependencies cause yarn pnp to fail.