### PR TITLE
Fix Plate Cloud attachments so that it works with collaborative

### DIFF
--- a/packages/ui/cloud/src/CloudAttachmentElement/CloudAttachmentElement.tsx
+++ b/packages/ui/cloud/src/CloudAttachmentElement/CloudAttachmentElement.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useUpload } from '@udecode/plate-cloud';
-import { Value } from '@udecode/plate-common';
+import { findNodePath, setNodes, Value } from '@udecode/plate-common';
 import { getRootProps } from '@udecode/plate-styled-components';
 import { useFocused, useSelected } from 'slate-react';
 import { StatusBar } from '../StatusBar';
@@ -12,9 +12,40 @@ import { CloudDownloadIcon } from './CloudDownloadIcon';
 export const CloudAttachmentElement = <V extends Value>(
   props: CloudAttachmentElementProps<V>
 ) => {
-  const { attributes, children, element, nodeProps } = props;
+  const { attributes, children, editor, element, nodeProps } = props;
 
   const upload = useUpload(element.url);
+
+  const url = upload.status !== 'not-found' ? upload.url : undefined;
+
+  useEffect(() => {
+    /**
+     * We only want to update the actual URL of the element if the URL is not
+     * a blob URL and if it's different from the current URL.
+     *
+     * NOTE:
+     *
+     * If the user does an undo, this may cause some issues. The ideal solution
+     * is to change the URL once the upload is complete to the final URL and
+     * change the edit history so that the initial insertion of the cloud image
+     * appears to have the final URL.
+     */
+    if (
+      typeof url === 'string' &&
+      !url.startsWith('blob:') &&
+      url !== element.url
+    ) {
+      const path = findNodePath(editor, element);
+      setNodes<TCloudImageElement>(
+        editor,
+        { url },
+        {
+          at: path,
+        }
+      );
+    }
+  }, [editor, element, url]);
+
   const selected = useSelected();
   const focused = useFocused();
   const rootProps = getRootProps(props);


### PR DESCRIPTION
Fixes Plate Cloud Attachments to work with collaborative

**Description**

In order for the URL to propagate to the other collaborators in collaborative editing, we updated the `element.url` for the cloud attachments once the attachment is finished uploading.