### PR TITLE
Adds optional ondrop handler to draggableProps

### DIFF
--- a/.changeset/early-mayflies-build.md
+++ b/.changeset/early-mayflies-build.md
@@ -1,0 +1,7 @@
+---
+"@udecode/plate-dnd": patch
+"@udecode/plate-ui-dnd": patch
+---
+
+- add an **optional** `onDropHandler` to the `draggableProps` property. This handler takes the same arguments as the `drop`function in the `useDropNode` hook and should return `boolean`.If the function returns `true`, the default onDropNode behavior will not be called since it would be considered handled. If the function returns `false`, the default onDropNode will be triggered.
+- add an `editorId` property to the `dragItem` property so there is always a reference to the editor from which the item was dragged. This allows for better support and more control when working with nested editors.

--- a/packages/dnd/src/components/useDraggableState.ts
+++ b/packages/dnd/src/components/useDraggableState.ts
@@ -1,8 +1,8 @@
 import React, { useRef } from 'react';
-import { ConnectDragSource } from 'react-dnd';
-import { TElement } from '@udecode/plate-common';
+import { ConnectDragSource, DropTargetMonitor } from 'react-dnd';
+import { TEditor, TElement } from '@udecode/plate-common';
 import { useDndBlock } from '../hooks';
-import { DropLineDirection } from '../types';
+import { DragItemNode, DropLineDirection } from '../types';
 
 export type DraggableState = {
   dropLine: DropLineDirection;
@@ -13,12 +13,23 @@ export type DraggableState = {
 
 export const useDraggableState = (props: {
   element: TElement;
+  onDropHandler?: (
+    editor: TEditor,
+    props: {
+      monitor: DropTargetMonitor<DragItemNode, unknown>;
+      dragItem: DragItemNode;
+      nodeRef: any;
+      id: string;
+    }
+  ) => boolean;
 }): DraggableState => {
-  const { element } = props;
+  const { element, onDropHandler } = props;
+
   const rootRef = useRef<HTMLDivElement>(null);
   const { dropLine, isDragging, dragRef } = useDndBlock({
     id: element.id as string,
     nodeRef: rootRef,
+    onDropHandler,
   });
 
   return { dropLine, isDragging, rootRef, dragRef };

--- a/packages/dnd/src/hooks/useDndNode.ts
+++ b/packages/dnd/src/hooks/useDndNode.ts
@@ -1,7 +1,8 @@
 import { useState } from 'react';
+import { DropTargetMonitor } from 'react-dnd';
 import { getEmptyImage } from 'react-dnd-html5-backend';
-import { useEditorRef } from '@udecode/plate-common';
-import { DropLineDirection } from '../types';
+import { TEditor, useEditorRef } from '@udecode/plate-common';
+import { DragItemNode, DropLineDirection } from '../types';
 import { useDragNode, UseDragNodeOptions } from './useDragNode';
 import { useDropNode, UseDropNodeOptions } from './useDropNode';
 
@@ -10,6 +11,15 @@ export interface UseDndNodeOptions
     Pick<UseDragNodeOptions, 'type'> {
   drag?: UseDragNodeOptions;
   drop?: UseDropNodeOptions;
+  onDropHandler?: (
+    editor: TEditor,
+    props: {
+      monitor: DropTargetMonitor<DragItemNode, unknown>;
+      dragItem: DragItemNode;
+      nodeRef: any;
+      id: string;
+    }
+  ) => boolean;
   preview?: {
     /**
      * Whether to disable the preview.
@@ -35,6 +45,7 @@ export const useDndNode = ({
   preview: previewOptions = {},
   drag: dragOptions,
   drop: dropOptions,
+  onDropHandler,
 }: UseDndNodeOptions) => {
   const editor = useEditorRef();
 
@@ -51,6 +62,7 @@ export const useDndNode = ({
     nodeRef,
     dropLine,
     onChangeDropLine: setDropLine,
+    onDropHandler,
     ...dropOptions,
   });
 

--- a/packages/dnd/src/hooks/useDragNode.ts
+++ b/packages/dnd/src/hooks/useDragNode.ts
@@ -37,6 +37,7 @@ export const useDragNode = <V extends Value>(
 
         return {
           id,
+          editorId: editor.id,
           ..._item,
         };
       },

--- a/packages/ui/dnd/src/PlateDraggable.tsx
+++ b/packages/ui/dnd/src/PlateDraggable.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef } from 'react';
-import { EElement, Value } from '@udecode/plate-common';
+import { DropTargetMonitor } from 'react-dnd';
+import { EElement, TEditor, Value } from '@udecode/plate-common';
 import {
   DraggableBlock,
   DraggableBlockToolbar,
@@ -8,6 +9,7 @@ import {
   DraggableGutterLeft,
   DraggableRoot,
   DragHandle as DefaultDragHandle,
+  DragItemNode,
   useDraggableState,
 } from '@udecode/plate-dnd';
 import { StyledElementProps } from '@udecode/plate-styled-components';
@@ -20,6 +22,20 @@ export interface PlateDraggableProps
    * An override to render the drag handle.
    */
   onRenderDragHandle?: (props: DragHandleProps) => JSX.Element;
+  /**
+   * Intercepts the drop handling.
+   * If `false` is returned, the default drop behavior is called after.
+   * If `true` is returned, the default behavior is not called.
+   */
+  onDropHandler?: (
+    editor: TEditor,
+    props: {
+      monitor: DropTargetMonitor<DragItemNode, unknown>;
+      dragItem: DragItemNode;
+      nodeRef: any;
+      id: string;
+    }
+  ) => boolean;
 }
 
 export const PlateDraggable = forwardRef<HTMLDivElement, PlateDraggableProps>(


### PR DESCRIPTION
**Description**

This PR does two things:

- It adds an **optional** `onDropHandler` to the `draggableProps` property. This handler takes the same arguments as the `drop`function in the `useDropNode` hook and should return `boolean`.
If the function returns `true`, the default onDropNode behavior will not be called since it would be considered handled. If the function returns `false`, the default onDropNode will be triggered.

- It adds an `editorId` property to the `dragItem` property so there is always a reference to the editor from which the item was dragged. This allows for better support and more control when working with nested editors.
