### PR TITLE
fix: add delay to DnD scroller

### DIFF
--- a/.changeset/blue-cats-wave.md
+++ b/.changeset/blue-cats-wave.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-dnd": patch
+---
+
+fix: add delay to DnD scroller

--- a/packages/dnd/src/components/Scroller/DndScroller.tsx
+++ b/packages/dnd/src/components/Scroller/DndScroller.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { dndStore } from '../../dndStore';
 import { Scroller, ScrollerProps } from './Scroller';
 

--- a/packages/dnd/src/components/Scroller/DndScroller.tsx
+++ b/packages/dnd/src/components/Scroller/DndScroller.tsx
@@ -4,6 +4,18 @@ import { Scroller, ScrollerProps } from './Scroller';
 
 export const DndScroller = (props: Partial<ScrollerProps>) => {
   const isDragging = dndStore.use.isDragging();
+  const [show, setShow] = React.useState(false)
 
-  return <Scroller enabled={isDragging} {...props} />;
+  useEffect(() => {
+    if (isDragging) {
+      const timeout = setTimeout(() => {
+        setShow(true);
+      }, 100);
+      return () => clearTimeout(timeout);
+    } else {
+      setShow(false)
+    }
+  }, [isDragging, show]);
+
+  return <Scroller enabled={isDragging && show} {...props} />;
 };


### PR DESCRIPTION
Scroller only appears after a delay after dragging.

This fixes #2081, as the scroll area doesn't come immediately over the dragged element, causing the drag to fail/cancel.