### PR TITLE
fix: add missing readOnly dep in useEditableProps

### DIFF
--- a/.changeset/twelve-months-bow.md
+++ b/.changeset/twelve-months-bow.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-core': patch
+---
+
+fix readOnly not being properly updated on Editable

--- a/packages/core/src/hooks/useEditableProps.ts
+++ b/packages/core/src/hooks/useEditableProps.ts
@@ -67,7 +67,7 @@ export const useEditableProps = ({
     });
 
     return _props;
-  }, [decorate, editableProps, renderElement, renderLeaf]);
+  }, [decorate, editableProps, renderElement, renderLeaf, readOnly]);
 
   return useDeepCompareMemo(
     () => ({


### PR DESCRIPTION
**Description**

The `readOnly` value coming from Plate store was not passed as a dependency of `useDeepCompareMemo` in `useEditableProps` which could cause `Editable` to receive an stale `readOnly` prop.
