### PR TITLE
Fix/2399 deserialize validAttribute nullcheck

### DIFF
--- a/.changeset/large-trains-taste.md
+++ b/.changeset/large-trains-taste.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-core": patch
+---
+
+Fix/2399 deserialize validAttribute nullcheck

--- a/packages/core/src/plugins/html-deserializer/utils/pluginDeserializeHtml.spec.ts
+++ b/packages/core/src/plugins/html-deserializer/utils/pluginDeserializeHtml.spec.ts
@@ -29,6 +29,55 @@ describe('when element is p and validNodeName is P', () => {
   });
 });
 
+describe('when element is p, validAttribute', () => {
+  it('returns p type with an existing attribute', () => {
+    const element = document.createElement('p');
+    element.setAttribute('tabIndex', '0');
+
+    expect(
+      pluginDeserializeHtml(
+        createPlateEditor(),
+        mockPlugin({
+          type: ELEMENT_PARAGRAPH,
+          deserializeHtml: {
+            isElement: true,
+            getNode: node,
+            rules: [
+              {
+                validAttribute: { tabIndex: '0' },
+              },
+            ],
+          },
+        }),
+        { element }
+      )?.node
+    ).toEqual(node());
+  });
+
+  it('doesnt return p type with an unset attribute', () => {
+    const element = document.createElement('p');
+
+    expect(
+      pluginDeserializeHtml(
+        createPlateEditor(),
+        mockPlugin({
+          type: ELEMENT_PARAGRAPH,
+          deserializeHtml: {
+            isElement: true,
+            getNode: node,
+            rules: [
+              {
+                validAttribute: { tabIndex: '0' },
+              },
+            ],
+          },
+        }),
+        { element }
+      )?.node
+    ).not.toEqual(node());
+  });
+});
+
 describe('when element is p with color and rule style is different', () => {
   it('should not be p type', () => {
     const element = document.createElement('p');

--- a/packages/core/src/plugins/html-deserializer/utils/pluginDeserializeHtml.spec.ts
+++ b/packages/core/src/plugins/html-deserializer/utils/pluginDeserializeHtml.spec.ts
@@ -32,7 +32,7 @@ describe('when element is p and validNodeName is P', () => {
 describe('when element is p, validAttribute', () => {
   it('returns p type with an existing attribute', () => {
     const element = document.createElement('p');
-    element.setAttribute('tabIndex', '0');
+    element.setAttribute('title', '');
 
     expect(
       pluginDeserializeHtml(
@@ -44,7 +44,7 @@ describe('when element is p, validAttribute', () => {
             getNode: node,
             rules: [
               {
-                validAttribute: { tabIndex: '0' },
+                validAttribute: { title: '' },
               },
             ],
           },
@@ -67,7 +67,7 @@ describe('when element is p, validAttribute', () => {
             getNode: node,
             rules: [
               {
-                validAttribute: { tabIndex: '0' },
+                validAttribute: { title: '' },
               },
             ],
           },

--- a/packages/core/src/plugins/html-deserializer/utils/pluginDeserializeHtml.ts
+++ b/packages/core/src/plugins/html-deserializer/utils/pluginDeserializeHtml.ts
@@ -1,12 +1,11 @@
 import { Value } from '@udecode/slate';
-import { AnyObject } from '@udecode/utils';
+import { AnyObject, isDefined } from '@udecode/utils';
 import castArray from 'lodash/castArray';
 import { Nullable } from '../../../types';
 import { PlateEditor } from '../../../types/PlateEditor';
 import { DeserializeHtml } from '../../../types/plugin/DeserializeHtml';
 import { WithPlatePlugin } from '../../../types/plugin/PlatePlugin';
 import { getInjectedPlugins } from '../../../utils/getInjectedPlugins';
-import { isDefined } from '@udecode/utils';
 
 /**
  * Get a deserializer by type, node names, class names and styles.

--- a/packages/core/src/plugins/html-deserializer/utils/pluginDeserializeHtml.ts
+++ b/packages/core/src/plugins/html-deserializer/utils/pluginDeserializeHtml.ts
@@ -6,6 +6,7 @@ import { PlateEditor } from '../../../types/PlateEditor';
 import { DeserializeHtml } from '../../../types/plugin/DeserializeHtml';
 import { WithPlatePlugin } from '../../../types/plugin/PlatePlugin';
 import { getInjectedPlugins } from '../../../utils/getInjectedPlugins';
+import { isDefined } from '@udecode/utils';
 
 /**
  * Get a deserializer by type, node names, class names and styles.
@@ -95,7 +96,10 @@ export const pluginDeserializeHtml = <V extends Value>(
               const attributeValues = castArray<string>(attributeValue);
               const elAttribute = el.getAttribute(attributeName);
 
-              if (!elAttribute || !attributeValues.includes(elAttribute))
+              if (
+                !isDefined(elAttribute) ||
+                !attributeValues.includes(elAttribute)
+              )
                 return false;
             }
           }


### PR DESCRIPTION
**Description**

Alter existence check to only check for null and undefined values.  This allows the validAttribute to check for empty strings .
Per https://github.com/udecode/plate/discussions/2399#discussion-5206912



Before the following rule would fail to match when checking for an attribute that equals ''.
```
deserializeHtml: {
    isElement: true,
    rules: [
      {
        validAttribute: { href: '' },
        validNodeName: 'A',
      },
    ],
  }
```