### PR TITLE
fix: support slate 0.94.1 after changing prop name for value to initialValue

### DIFF
--- a/.changeset/metal-toys-shop.md
+++ b/.changeset/metal-toys-shop.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-core': patch
+---
+
+support new prop name initialValue on Slate after 0.94.1

--- a/packages/core/src/hooks/useSlateProps.ts
+++ b/packages/core/src/hooks/useSlateProps.ts
@@ -37,6 +37,7 @@ export const useSlateProps = <V extends Value>({
       editor,
       onChange,
       value,
+      initialValue: value,
     };
   }, [editor, onChange, value]);
 };


### PR DESCRIPTION
**Description**
[Slate 0.94.1 changed value to initialValue](https://github.com/ianstormtaylor/slate/pull/5421). In order to support support the new version and still support previous versions I added this new property and still kept the old one.