### PR TITLE
fix: improve emoji plugin

### DIFF
--- a/.changeset/emoji-plugin.md
+++ b/.changeset/emoji-plugin.md
@@ -1,0 +1,3 @@
+---
+'@udecode/plate-emoji': patch
+---

--- a/.changeset/emoji-plugin.md
+++ b/.changeset/emoji-plugin.md
@@ -1,3 +1,6 @@
 ---
 '@udecode/plate-emoji': patch
 ---
+
+- if after ':' char was break inserted typing further would activate dropdown. Should be only activated in the same line.
+- if the emoji was enclosed whit the ':' sign nothing happened, now the emoji is created if it was found.

--- a/packages/nodes/emoji/src/handlers/getFindTriggeringInput.ts
+++ b/packages/nodes/emoji/src/handlers/getFindTriggeringInput.ts
@@ -25,14 +25,19 @@ const getFoundText = <V extends Value>(
 ) => getEditorString(editor, getRange(editor, start, end));
 
 const isBreakingCharInText = (text: string) => /\s/.test(text);
+const isNextCharacterInSameLine = (
+  firstPoint: BasePoint,
+  secondPoint?: BasePoint
+) => firstPoint?.path[0] === secondPoint?.path[0];
 
 export const getFindTriggeringInput = <V extends Value>(
   editor: PlateEditor<V>,
   emojiTriggeringController: IEmojiTriggeringController
 ) => (text = '') => {
-  const selection = editor.selection as BaseRange;
-  const startPoint = editor.selection as BaseRange;
   let currentText = text;
+  const selection = editor.selection as BaseRange;
+  const startRange = editor.selection as BaseRange;
+  const startPoint = startRange.anchor;
 
   let endPoint = selection.anchor;
   let nextPoint;
@@ -45,7 +50,13 @@ export const getFindTriggeringInput = <V extends Value>(
     if (emojiTriggeringController.hasTriggeringMark) break;
 
     nextPoint = getNextPoint(editor, endPoint);
-    const foundText = getFoundText(editor, startPoint, nextPoint);
+
+    if (!isNextCharacterInSameLine(startPoint, nextPoint)) {
+      emojiTriggeringController.reset();
+      break;
+    }
+
+    const foundText = getFoundText(editor, startRange, nextPoint);
 
     endPoint = nextPoint!;
     currentText = `${foundText}${text}`;

--- a/packages/nodes/emoji/src/utils/EmojiTriggeringController.ts
+++ b/packages/nodes/emoji/src/utils/EmojiTriggeringController.ts
@@ -40,6 +40,10 @@ export class EmojiTriggeringController implements IEmojiTriggeringController {
     return this.text.length;
   }
 
+  isEnclosingTriggeringCharacter(char: string): boolean {
+    return this.isTriggering && char === this.trigger;
+  }
+
   reset() {
     this.text = '';
     this.isTriggering = false;

--- a/packages/nodes/emoji/src/utils/EmojiTriggeringController.types.ts
+++ b/packages/nodes/emoji/src/utils/EmojiTriggeringController.types.ts
@@ -11,4 +11,5 @@ export interface IEmojiTriggeringController {
   reset: () => void;
   getOptions: () => EmojiTriggeringControllerOptions;
   getTextSize: () => number;
+  isEnclosingTriggeringCharacter: (char: string) => boolean;
 }

--- a/packages/nodes/emoji/src/utils/IndexSearch/IndexSearch.ts
+++ b/packages/nodes/emoji/src/utils/IndexSearch/IndexSearch.ts
@@ -76,5 +76,9 @@ export abstract class AIndexSearch<RData = IndexSearchReturnData>
     return emojis;
   }
 
+  getEmoji(): RData | undefined {
+    return this.get()[0];
+  }
+
   protected abstract transform(emoji: Emoji): RData;
 }


### PR DESCRIPTION
- if after ':' char was break inserted typing further would activate dropdown. Should be only activated in the same line.
- if the emoji was enclosed whit the ':' sign nothing happened, now the emoji is created if it was found.

https://www.loom.com/share/a849a1e2a1f745c6931e2d7c2f62f368