### PR TITLE
Feat/add touch event to resizable

### DIFF
--- a/.changeset/hot-teachers-complain.md
+++ b/.changeset/hot-teachers-complain.md
@@ -1,0 +1,9 @@
+---
+'@udecode/resizable': minor
+---
+
+Added touch events to Resizable
+
+We were lacking touch-related events on `ResizeHandle.tsx`. That made it so that mobile users will not be able to resize an element.
+With the addition of the functions, this functionality should be available as it was prior to the latest major bump.
+Additionally, we were missing the 'resizable' alias in 'aliases-plate', which made the local development quite complex.

--- a/config/aliases-plate.js
+++ b/config/aliases-plate.js
@@ -49,4 +49,5 @@ module.exports = {
   '@udecode/plate-trailing-block': 'editor/trailing-block',
   '@udecode/plate-utils': 'plate-utils',
   '@udecode/utils': 'utils',
+  '@udecode/resizable': 'resizable',
 };

--- a/packages/resizable/src/components/ResizeHandle.tsx
+++ b/packages/resizable/src/components/ResizeHandle.tsx
@@ -1,10 +1,16 @@
-import { MouseEventHandler, useEffect, useState } from 'react';
+import {
+  MouseEventHandler,
+  TouchEventHandler,
+  useEffect,
+  useState,
+} from 'react';
 import {
   createComponentAs,
   createElementAs,
   HTMLPropsAs,
 } from '@udecode/plate-common';
 import { ResizeDirection, ResizeEvent } from '../types';
+import { isTouchEvent } from '../utils';
 
 export type ResizeHandleProps = HTMLPropsAs<'div'> & {
   direction: ResizeDirection;
@@ -14,6 +20,7 @@ export type ResizeHandleProps = HTMLPropsAs<'div'> & {
   zIndex?: number;
   onResize?: (event: ResizeEvent) => void;
   onMouseDown?: MouseEventHandler;
+  onTouchStart?: TouchEventHandler;
   onHover?: () => void;
   onHoverEnd?: () => void;
 };
@@ -26,6 +33,7 @@ export const useResizeHandleProps = ({
   zIndex = 40,
   onResize,
   onMouseDown,
+  onTouchStart,
   onHover,
   onHoverEnd,
   style,
@@ -49,20 +57,38 @@ export const useResizeHandleProps = ({
     onMouseDown?.(event);
   };
 
+  const handleTouchStart: TouchEventHandler = (event) => {
+    const { touches } = event;
+    const touch = touches[0];
+    const { clientX, clientY } = touch;
+    setInitialPosition(isHorizontal ? clientX : clientY);
+
+    const element = (event.target as HTMLElement).parentElement!;
+    setInitialSize(isHorizontal ? element.offsetWidth : element.offsetHeight);
+    setIsResizing(true);
+    onTouchStart?.(event);
+  };
+
   useEffect(() => {
     if (!isResizing) return;
 
-    const sendResizeEvent = (event: MouseEvent, finished: boolean) => {
-      const { clientX, clientY } = event;
+    const sendResizeEvent = (
+      event: MouseEvent | TouchEvent,
+      finished: boolean
+    ) => {
+      const { clientX, clientY } = isTouchEvent(event)
+        ? event.touches[0] || event.changedTouches[0]
+        : event;
+
       const currentPosition = isHorizontal ? clientX : clientY;
       const delta = currentPosition - initialPosition;
       onResize?.({ initialSize, delta, finished, direction });
     };
 
-    const handleMouseMove = (event: MouseEvent) =>
+    const handleMouseMove = (event: MouseEvent | TouchEvent) =>
       sendResizeEvent(event, false);
 
-    const handleMouseUp = (event: MouseEvent) => {
+    const handleMouseUp = (event: MouseEvent | TouchEvent) => {
       setIsResizing(false);
       onHoverEnd?.();
       sendResizeEvent(event, true);
@@ -70,10 +96,14 @@ export const useResizeHandleProps = ({
 
     window.addEventListener('mousemove', handleMouseMove);
     window.addEventListener('mouseup', handleMouseUp);
+    window.addEventListener('touchmove', handleMouseMove);
+    window.addEventListener('touchend', handleMouseUp);
 
     return () => {
       window.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('mouseup', handleMouseUp);
+      window.removeEventListener('touchmove', handleMouseMove);
+      window.removeEventListener('touchend', handleMouseUp);
     };
   }, [
     isResizing,
@@ -112,8 +142,11 @@ export const useResizeHandleProps = ({
       ...style,
     },
     onMouseDown: handleMouseDown,
+    onTouchStart: handleTouchStart,
     onMouseOver: handleMouseOver,
     onMouseOut: handleMouseOut,
+    onTouchMove: handleMouseOver,
+    onTouchEnd: handleMouseOut,
     ...props,
   };
 };

--- a/packages/resizable/src/utils/index.ts
+++ b/packages/resizable/src/utils/index.ts
@@ -5,3 +5,4 @@
 export * from './resizeLengthClamp';
 export * from './resizeLengthToRelative';
 export * from './resizeLengthToStatic';
+export * from './isTouchEvent';

--- a/packages/resizable/src/utils/isTouchEvent.ts
+++ b/packages/resizable/src/utils/isTouchEvent.ts
@@ -1,0 +1,3 @@
+export const isTouchEvent = (
+  event: MouseEvent | TouchEvent
+): event is TouchEvent => 'touches' in event;


### PR DESCRIPTION
The objective of this PR is to add touch-events to Resizable, in order to make it work again as it did previous to the v20 update.

See changesets.

This PR does add the touch-related events, similar to the already existent mouse ones, in order to enable mobile support of the Resizable component.

