### PR TITLE
Fix comment popover button icons

### DIFF
--- a/.changeset/nasty-terms-heal.md
+++ b/.changeset/nasty-terms-heal.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-ui-table': patch
+---
+
+- Specify button icon width explicitly

--- a/.changeset/weak-ways-impress.md
+++ b/.changeset/weak-ways-impress.md
@@ -1,0 +1,6 @@
+---
+'@udecode/plate-ui-button': patch
+---
+
+- Remove hardcoded svg width and height
+  - Fixes overflow in comment popover button icons

--- a/packages/ui/button/src/Button/PlateButton.tsx
+++ b/packages/ui/button/src/Button/PlateButton.tsx
@@ -29,11 +29,6 @@ export const plateButtonCss = [
     :visited {
       color: inherit;
     }
-
-    svg {
-      width: 16px;
-      height: 16px;
-    }
   `,
 ];
 

--- a/packages/ui/button/src/Button/RemoveNodeButton.tsx
+++ b/packages/ui/button/src/Button/RemoveNodeButton.tsx
@@ -27,7 +27,7 @@ export const RemoveNodeButton = ({
       }}
       {...props}
     >
-      <DeleteIcon />
+      <DeleteIcon tw="w-4" />
       {children}
     </PlateButton>
   );

--- a/packages/ui/nodes/table/src/PlateTableBordersDropdownMenuContent.tsx
+++ b/packages/ui/nodes/table/src/PlateTableBordersDropdownMenuContent.tsx
@@ -28,7 +28,7 @@ const CheckIcon = (props: SVGProps<SVGSVGElement>) => (
 );
 
 const Check = ({ checked }: { checked?: boolean }) =>
-  checked ? <CheckIcon tw="block" /> : <div tw="w-4 h-4" />;
+  checked ? <CheckIcon tw="block w-4" /> : <div tw="w-4 h-4" />;
 
 export const PlateTableBordersDropdownMenuContent = () => {
   const {

--- a/packages/ui/nodes/table/src/PlateTablePopover.tsx
+++ b/packages/ui/nodes/table/src/PlateTablePopover.tsx
@@ -29,7 +29,7 @@ export const PlateTablePopover = ({ children, ...props }: PopoverProps) => {
                 tw="justify-start w-full"
                 aria-label="Borders"
               >
-                <BorderAllIcon />
+                <BorderAllIcon tw="w-4" />
                 <div>Borders</div>
               </PlateButton>
             </DropdownMenu.Trigger>


### PR DESCRIPTION
**Description**

See changesets. Table popover icons are unchanged.

**Before**
<img width="439" alt="image" src="https://github.com/udecode/plate/assets/4272090/fcc3d5e0-21ba-4c31-8c6b-3a2d93cb514f">

**After**
<img width="441" alt="image" src="https://github.com/udecode/plate/assets/4272090/344fbfb8-bef9-4ca9-874f-93aa862834a2">

**Unchanged**
<img width="467" alt="image" src="https://github.com/udecode/plate/assets/4272090/4af5042c-a2d0-4d22-b736-269404ea5b5b">
