### PR TITLE
[HtmlDeserializer] Fix pasting tables with empty cells

### DIFF
--- a/.changeset/funny-plants-listen.md
+++ b/.changeset/funny-plants-listen.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-core": patch
+---
+
+HTML deserializer: fix pasting tables with empty cells

--- a/packages/core/src/plugins/html-deserializer/utils/cleanHtmlEmptyElements.ts
+++ b/packages/core/src/plugins/html-deserializer/utils/cleanHtmlEmptyElements.ts
@@ -1,6 +1,6 @@
 import { traverseHtmlElements } from './traverseHtmlElements';
 
-const ALLOWED_EMPTY_ELEMENTS = ['BR', 'IMG'];
+const ALLOWED_EMPTY_ELEMENTS = ['BR', 'IMG', 'TH', 'TD'];
 
 const isEmpty = (element: Element): boolean => {
   return (


### PR DESCRIPTION
## Summary

Fixes pasting tables from clipoboard which have empty cells.

**Before**

https://github.com/udecode/plate/assets/39378793/e27b960f-3d61-41af-b0d8-4f30fb93d733

**After**

https://github.com/udecode/plate/assets/39378793/7c8415e4-ec50-4aa2-a8bd-b0df13a20104

