### PR TITLE
[serializeHtml] Fix for serializing tables

### DIFF
--- a/packages/nodes/table/src/components/TableCellElement/TableCellElementResizable.tsx
+++ b/packages/nodes/table/src/components/TableCellElement/TableCellElementResizable.tsx
@@ -57,7 +57,7 @@ export const useTableCellElementResizableProps = ({
 } => {
   const editor = usePlateEditorRef();
   const element = useElement();
-  const tableElement = useElement<TTableElement>(ELEMENT_TABLE);
+  const tableElement = useElement<TTableElement>();
   const { minColumnWidth = 0 } = getPluginOptions<TablePlugin>(
     editor,
     ELEMENT_TABLE

--- a/packages/nodes/table/src/components/TableCellElement/useTableCellElementState.ts
+++ b/packages/nodes/table/src/components/TableCellElement/useTableCellElementState.ts
@@ -1,6 +1,5 @@
 import { useElement, usePlateEditorRef } from '@udecode/plate-common';
 import { useReadOnly } from 'slate-react';
-import { ELEMENT_TABLE, ELEMENT_TR } from '../../createTablePlugin';
 import { getTableColumnIndex, getTableRowIndex } from '../../queries';
 import { useTableStore } from '../../stores/tableStore';
 import {
@@ -44,8 +43,8 @@ export const useTableCellElementState = ({
   const isCellSelected = useIsCellSelected(cellElement);
   const hoveredColIndex = useTableStore().get.hoveredColIndex();
 
-  const tableElement = useElement<TTableElement>(ELEMENT_TABLE);
-  const rowElement = useElement<TTableRowElement>(ELEMENT_TR);
+  const tableElement = useElement<TTableElement>();
+  const rowElement = useElement<TTableRowElement>();
   const rowSizeOverrides = useTableStore().get.rowSizeOverrides();
   const rowSize =
     rowSizeOverrides.get(rowIndex) ?? rowElement?.size ?? undefined;


### PR DESCRIPTION
**Description**

Fixes: #2442 

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->
A component which calls serializeHtml on an editor containing a table element results in `TypeError: tableElement.children is undefined`, as seen in this code sandbox:
https://codesandbox.io/s/sandpack-project-forked-mz8n6p?file=/serializing-html/formatHTML.ts

The modified calls to useElement were the only useElement calls where the application that did not pass in an element as a parameter. The changelog for version 16 mentions that this would attempt to retrieve an ancestor element. I don't fully understand how this application works, but I believe this was causing serializeHtml to attempt to serialize its parent, the root element in this case, as if it were a table. I think the reason it still worked until version 20 is due to that version being the first release where the application attempted to access a property that did not exist during the serialization process.

`packages/nodes/table/src/components/TableCellElement/TableCellElementResizable.tsx:48` doesn't need to be changed in order to successfully serialize an editor containing a table, but leaving it as-is would make it the only call to `useElement` in the application that attempts to change its scope, which I believe is not intended.

These changes can be tested by replacing `deserializeHtmlValue` with `tableValue` in `examples/src/SerializingHtmlApp.tsx:67` after adding `import { tableValue } from './table/tableValue';`

This requested fix allows tables to be serialized to html, as shown in this image:
![image](https://github.com/udecode/plate/assets/96903217/d8c9b549-fa7b-408c-b832-c52db2d35d2f)

