### PR TITLE
feat(mentions): add triggerPreviousCharPattern parameter

### DIFF
--- a/.changeset/tricky-donkeys-grab.md
+++ b/.changeset/tricky-donkeys-grab.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-mention': minor
+---
+
+Add `triggerPreviousCharPattern` option to mention plugin.

--- a/apps/www/content/docs/mention.mdx
+++ b/apps/www/content/docs/mention.mdx
@@ -49,7 +49,7 @@ const plugins = [
 <APIOptions>
 
 <APIItem name="createMentionNode" type="(item: TComboboxItem<TData>, meta: CreateMentionNodeMeta) => TNodeProps<TMentionElement>" optional>
- 
+
 A function to create the mention node.
 
 </APIItem>
@@ -62,6 +62,10 @@ A function to create the mention node.
 <APIItem name="trigger" type="string" optional>
   The character that triggers the mention (for example, '@' in the case of a
   user mention).
+</APIItem>
+<APIItem name="triggerPreviousCharPattern" type="RegExp" optional>
+  The pattern that matches the char before the trigger character
+  (for example, /[\s"]/ to match space and double quote)
 </APIItem>
 
 <APIItem name="inputCreation" type="{ key: string; value: string }" optional>

--- a/apps/www/src/registry/default/example/playground-demo.tsx
+++ b/apps/www/src/registry/default/example/playground-demo.tsx
@@ -142,7 +142,12 @@ export const usePlaygroundPlugins = ({
           }),
           createImagePlugin({ enabled: !!enabled.img }),
           createMediaEmbedPlugin({ enabled: !!enabled.media_embed }),
-          createMentionPlugin({ enabled: !!enabled.mention }),
+          createMentionPlugin({
+            enabled: !!enabled.mention,
+            options: {
+              triggerPreviousCharPattern: /[\s()]/,
+            },
+          }),
           createTablePlugin({ enabled: !!enabled.table }),
           createTodoListPlugin({ enabled: !!enabled.action_item }),
           createExcalidrawPlugin({ enabled: !!enabled.excalidraw }),

--- a/packages/mention/src/__tests__/createEditorWithMentions.tsx
+++ b/packages/mention/src/__tests__/createEditorWithMentions.tsx
@@ -13,6 +13,7 @@ export type CreateEditorOptions = {
   pluginOptions?: {
     key?: string;
     trigger?: string;
+    triggerPreviousCharPattern?: RegExp;
   };
 };
 
@@ -20,12 +21,15 @@ export const createEditorWithMentions = <V extends Value>(
   state: JSX.Element,
   {
     multipleMentionPlugins,
-    pluginOptions: { trigger, key } = {},
+    pluginOptions: { trigger, key, triggerPreviousCharPattern } = {},
   }: CreateEditorOptions = {}
 ): PlateEditor<V> => {
   const plugins = [
     createParagraphPlugin(),
-    createMentionPlugin({ key, options: { trigger } }),
+    createMentionPlugin({
+      key,
+      options: { trigger, triggerPreviousCharPattern },
+    }),
   ];
   if (multipleMentionPlugins) {
     plugins.push(

--- a/packages/mention/src/types.ts
+++ b/packages/mention/src/types.ts
@@ -16,6 +16,7 @@ export interface MentionPlugin<TData extends Data = NoData> {
   id?: string;
   insertSpaceAfterMention?: boolean;
   trigger?: string;
+  triggerPreviousCharPattern?: RegExp;
   inputCreation?: { key: string; value: string };
   query?: (editor: PlateEditor) => boolean;
 }

--- a/packages/mention/src/withMention.spec.tsx
+++ b/packages/mention/src/withMention.spec.tsx
@@ -27,7 +27,10 @@ describe('withMention', () => {
   const trigger = '@';
   const key = 'mention';
 
-  type CreateEditorOptions = { multipleMentionPlugins?: boolean };
+  type CreateEditorOptions = {
+    multipleMentionPlugins?: boolean;
+    triggerPreviousCharPattern?: RegExp;
+  };
 
   const createEditor = <V extends Value>(
     state: JSX.Element,
@@ -35,7 +38,11 @@ describe('withMention', () => {
   ): PlateEditor<V> =>
     createEditorWithMentions(state, {
       ...options,
-      pluginOptions: { ...options, key, trigger },
+      pluginOptions: {
+        ...options,
+        key,
+        trigger,
+      },
     });
 
   const createEditorWithMentionInput = <V extends Value>(
@@ -186,6 +193,30 @@ describe('withMention', () => {
       editor.insertText('a');
 
       expect(editor.children).toEqual([<hp>a</hp>]);
+    });
+
+    it('should insert a mention input when the trigger is inserted after the specified pattern', () => {
+      const editor = createEditor(
+        <hp>
+          hello "<cursor />"
+        </hp>,
+        {
+          triggerPreviousCharPattern: /[\s"]/,
+        }
+      );
+
+      editor.insertText(trigger);
+
+      expect(editor.children).toEqual([
+        <hp>
+          <htext>hello "</htext>
+          <hmentioninput trigger={trigger}>
+            <htext />
+            <cursor />
+          </hmentioninput>
+          <htext>"</htext>
+        </hp>,
+      ]);
     });
   });
 

--- a/packages/mention/src/withMention.ts
+++ b/packages/mention/src/withMention.ts
@@ -29,7 +29,7 @@ export const withMention = <
 >(
   editor: E,
   {
-    options: { id, trigger, query, inputCreation },
+    options: { id, trigger, triggerPreviousCharPattern, query, inputCreation },
   }: WithPlatePlugin<MentionPlugin, V, E>
 ) => {
   const { type } = getPlugin<{}, V>(editor, ELEMENT_MENTION_INPUT);
@@ -115,10 +115,11 @@ export const withMention = <
       )
     );
 
+    const previousCharPattern = triggerPreviousCharPattern ?? /\s/;
+    const matchesPreviousCharPattern = previousCharPattern.test(previousChar);
     const beginningOfLine = previousChar === '';
-    const precededByWhitespace = previousChar === ' ';
 
-    if ((beginningOfLine || precededByWhitespace) && text === trigger) {
+    if ((beginningOfLine || matchesPreviousCharPattern) && text === trigger) {
       const data: TMentionInputElement = {
         type,
         children: [{ text: '' }],


### PR DESCRIPTION
**Description**

See changesets.

Now, if you want to create a mention, it either be at beginning of line or after a space. The option `triggerPreviousCharPattern` allows users to create mentions after custom characters.

For instance, if you want to create a tag between parenthesis, or between quotes.
 
<!-- **Example** -->
Using:
```
createMentionPlugin({
  enabled: !!enabled.mention,
  options: {
    triggerPreviousCharPattern: /[\s()]/,
  },
}),
```

https://github.com/udecode/plate/assets/30879716/11bdf9f5-4aa8-41fb-ac2a-34cafb6e3ee3

