### PR TITLE
[ListPlugin] Fix elements remove 

### DIFF
--- a/.changeset/violet-ravens-jam.md
+++ b/.changeset/violet-ravens-jam.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-list": patch
+---
+
+- list plugin: call `deleteFragmentList` only if in a list

--- a/packages/list/src/deleteFragmentList.ts
+++ b/packages/list/src/deleteFragmentList.ts
@@ -18,6 +18,14 @@ import { getHighestEmptyList } from './queries/getHighestEmptyList';
 import { hasListChild } from './queries/hasListChild';
 import { isAcrossListItems } from './queries/isAcrossListItems';
 
+const getLiStart = <V extends Value>(editor: PlateEditor<V>) => {
+  const start = getStartPoint(editor, editor.selection as Range);
+  return getAboveNode(editor, {
+    at: start,
+    match: { type: getPluginType(editor, ELEMENT_LI) },
+  });
+};
+
 export const deleteFragmentList = <V extends Value>(editor: PlateEditor<V>) => {
   let deleted = false;
 
@@ -39,16 +47,18 @@ export const deleteFragmentList = <V extends Value>(editor: PlateEditor<V>) => {
       ? createPathRef(editor, liEnd![1])
       : undefined;
 
+    // use deleteFragment when selection wrapped around list
+    if (!getLiStart(editor) || !liEnd) {
+      deleted = false;
+      return;
+    }
+
     /**
      * Delete fragment and move end block children to start block
      */
     deleteMerge(editor);
 
-    const start = getStartPoint(editor, editor.selection as Range);
-    const liStart = getAboveNode(editor, {
-      at: start,
-      match: { type: getPluginType(editor, ELEMENT_LI) },
-    });
+    const liStart = getLiStart(editor);
 
     if (liEndPathRef) {
       const liEndPath = liEndPathRef.unref()!;

--- a/packages/slate/src/interfaces/editor/deleteMerge.ts
+++ b/packages/slate/src/interfaces/editor/deleteMerge.ts
@@ -3,6 +3,7 @@ import { Editor, Location, Path, Point, Range } from 'slate';
 import { TNodeEntry } from '../node/TNodeEntry';
 import { mergeNodes } from '../transforms/mergeNodes';
 import { removeNodes } from '../transforms/removeNodes';
+import { select } from '../transforms/select';
 import { createPathRef } from './createPathRef';
 import { createPointRef } from './createPointRef';
 import { getAboveNode } from './getAboveNode';
@@ -174,6 +175,12 @@ export const deleteMerge = <V extends Value>(
         hanging: true,
         voids,
       });
+    }
+
+    const point = endRef.unref() || startRef.unref();
+
+    if (options.at == null && point) {
+      select(editor as any, point);
     }
   });
 };

--- a/packages/slate/src/interfaces/editor/deleteMerge.ts
+++ b/packages/slate/src/interfaces/editor/deleteMerge.ts
@@ -3,7 +3,6 @@ import { Editor, Location, Path, Point, Range } from 'slate';
 import { TNodeEntry } from '../node/TNodeEntry';
 import { mergeNodes } from '../transforms/mergeNodes';
 import { removeNodes } from '../transforms/removeNodes';
-import { select } from '../transforms/select';
 import { createPathRef } from './createPathRef';
 import { createPointRef } from './createPointRef';
 import { getAboveNode } from './getAboveNode';
@@ -175,15 +174,6 @@ export const deleteMerge = <V extends Value>(
         hanging: true,
         voids,
       });
-    }
-
-    const point = endRef.unref() || startRef.unref();
-
-
-    console.log('selecting at point', options.at, point);
-
-    if (options.at == null && point) {
-      select(editor as any, point);
     }
   });
 };

--- a/packages/slate/src/interfaces/editor/deleteMerge.ts
+++ b/packages/slate/src/interfaces/editor/deleteMerge.ts
@@ -179,6 +179,9 @@ export const deleteMerge = <V extends Value>(
 
     const point = endRef.unref() || startRef.unref();
 
+
+    console.log('selecting at point', options.at, point);
+
     if (options.at == null && point) {
       select(editor as any, point);
     }


### PR DESCRIPTION
## Summary

This PR fixes elements remove caused by list plugin handlers. So, removing content with `ctrl+a` and `backspace` triggers list plugin handlers which is already incorrect from my perspective. Then selection change from `path: [0, 2]` to `path: [0, 0]` keeps 2 last elements, no matter which type they have.

https://github.com/udecode/plate/assets/39378793/91c2fb7a-53b4-428d-929f-92d753ce6fcf

The problem with the following lines

https://github.com/udecode/plate/blob/e7f73457e5682f350d11b82e75baabb3b4334a77/packages/slate/src/interfaces/editor/deleteMerge.ts#L182-L184


