### PR TITLE
[SelectOnBackspace] Remove empty node

### DIFF
--- a/.changeset/six-trees-change.md
+++ b/.changeset/six-trees-change.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-select': minor
+---
+
+select plugin: add support for removing empty nodes

--- a/packages/select/src/createSelectOnBackspacePlugin.ts
+++ b/packages/select/src/createSelectOnBackspacePlugin.ts
@@ -4,6 +4,7 @@ import { withSelectOnBackspace } from './withSelectOnBackspace';
 
 export type SelectOnBackspacePlugin = {
   query?: QueryNodeOptions;
+  removeNodeIfEmpty?: boolean;
 };
 
 export const KEY_SELECT_ON_BACKSPACE = 'selectOnBackspace';
@@ -15,4 +16,7 @@ export const createSelectOnBackspacePlugin =
   createPluginFactory<SelectOnBackspacePlugin>({
     key: KEY_SELECT_ON_BACKSPACE,
     withOverrides: withSelectOnBackspace,
+    options: {
+      removeNodeIfEmpty: false,
+    },
   });

--- a/packages/select/src/withSelectOnBackspace.ts
+++ b/packages/select/src/withSelectOnBackspace.ts
@@ -24,7 +24,9 @@ export const withSelectOnBackspace = <
   E extends PlateEditor<V> = PlateEditor<V>,
 >(
   editor: E,
-  { options: { query } }: WithPlatePlugin<SelectOnBackspacePlugin, V, E>
+  {
+    options: { query, removeNodeIfEmpty },
+  }: WithPlatePlugin<SelectOnBackspacePlugin, V, E>
 ) => {
   const { deleteBackward } = editor;
 
@@ -45,7 +47,11 @@ export const withSelectOnBackspace = <
         if (!!prevCell && pointBefore) {
           const point = getPoint(editor, selection as Slate.Location);
           const selectedNode = getNode(editor, point.path);
-          if (selectedNode && !getNodeString(selectedNode as any)) {
+          if (
+            removeNodeIfEmpty &&
+            selectedNode &&
+            !getNodeString(selectedNode as any)
+          ) {
             // remove node if empty
             removeNodes(editor);
           }

--- a/packages/select/src/withSelectOnBackspace.ts
+++ b/packages/select/src/withSelectOnBackspace.ts
@@ -1,9 +1,13 @@
 import {
+  getNode,
   getNodeEntries,
+  getNodeString,
+  getPoint,
   getPointBefore,
   isCollapsed,
   PlateEditor,
   queryNode,
+  removeNodes,
   select,
   Value,
   WithPlatePlugin,
@@ -39,6 +43,13 @@ export const withSelectOnBackspace = <
         });
 
         if (!!prevCell && pointBefore) {
+          const point = getPoint(editor, selection as Slate.Location);
+          const selectedNode = getNode(editor, point.path);
+          if (selectedNode && !getNodeString(selectedNode as any)) {
+            // remove node if empty
+            removeNodes(editor);
+          }
+
           // don't delete image, set selection there
           select(editor, pointBefore);
         } else {


### PR DESCRIPTION
## Summary

This PR removes node if empty on selection change.

**Before**

https://github.com/udecode/plate/assets/39378793/56c7b18e-3972-4bc8-95f6-c047466bddd4

**After**

https://github.com/udecode/plate/assets/39378793/f030347a-0f06-4499-a35b-8b868657a1b8




