### PR TITLE
[TablePlugin] Table cells merging POC

### DIFF
--- a/apps/www/src/components/icons.tsx
+++ b/apps/www/src/components/icons.tsx
@@ -76,6 +76,7 @@ import {
   Unlink,
   WrapText,
   X,
+  Combine
 } from 'lucide-react';
 
 import type { LucideIcon } from 'lucide-react';
@@ -281,6 +282,7 @@ export const Icons = {
   codeblock: FileCode,
   color: Baseline,
   column: RectangleVertical,
+  combine: Combine,
   comment: MessageSquare,
   commentAdd: MessageSquarePlus,
   conflict: Unlink,

--- a/apps/www/src/registry/default/plate-ui/table-cell-element.tsx
+++ b/apps/www/src/registry/default/plate-ui/table-cell-element.tsx
@@ -13,10 +13,11 @@ import {
   useTableCellElementResizable,
   useTableCellElementResizableState,
   useTableCellElementState,
-  useTableStore,
 } from '@udecode/plate-table';
 
 import { cn } from '@/lib/utils';
+
+import { ResizeHandle } from './resizable';
 
 export interface TableCellElementProps
   extends PlateElementProps<Value, TTableCellElement> {
@@ -43,8 +44,6 @@ const TableCellElement = React.forwardRef<
   const { props: cellProps } = useTableCellElement({ element: props.element });
   const editor = usePlateEditorRef();
 
-  const hoveredColIndex = useTableStore().get.hoveredColIndex();
-
   const content = element.children
     .map((node: TElement) => node.children[0].text)
     .join(' ');
@@ -57,12 +56,6 @@ const TableCellElement = React.forwardRef<
     useTableCellElementResizable(resizableState);
 
   const Cell = isHeader ? 'th' : 'td';
-
-  // console.log('render cell', element);
-
-  // if (element.children[0].children[0].text === 'Void') {
-  //   console.log('render void cell', nodePath);
-  // }
 
   return (
     <PlateElement
@@ -119,17 +112,17 @@ const TableCellElement = React.forwardRef<
                 {/* <ResizeHandle
                   {...rightProps}
                   className="-top-3 right-[-5px] w-[10px]"
-                />
+                /> */}
                 <ResizeHandle
                   {...bottomProps}
                   className="bottom-[-5px] h-[10px]"
                 />
-                {!hiddenLeft && (
+                {/* {!hiddenLeft && (
                   <ResizeHandle
                     {...leftProps}
                     className="-top-3 left-[-5px] w-[10px]"
                   />
-                )} */}
+                )}  */}
 
                 {/* {rowIndex === 0 && (
                   <ResizeHandle
@@ -140,7 +133,7 @@ const TableCellElement = React.forwardRef<
                     )}
                     {...rightProps}
                   />
-                )} */}
+                )}
 
                 {/* {hovered && rowIndex === 0 && (
                   <div
@@ -151,14 +144,14 @@ const TableCellElement = React.forwardRef<
                   />
                 )} */}
 
-                {hoveredLeft && rowIndex === 0 && (
+                {/* {hoveredLeft && rowIndex === 0 && (
                   <div
                     className={cn(
                       'absolute -top-3 z-30 h-[150px] w-1 bg-ring',
                       'left-[-1.5px]'
                     )}
                   />
-                )}
+                )} */}
               </>
             )}
           </div>

--- a/apps/www/src/registry/default/plate-ui/table-cell-element.tsx
+++ b/apps/www/src/registry/default/plate-ui/table-cell-element.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { PlateElement, PlateElementProps, Value } from '@udecode/plate-common';
+import {
+  findNodePath,
+  PlateElement,
+  PlateElementProps,
+  TElement,
+  usePlateEditorRef,
+  Value,
+} from '@udecode/plate-common';
 import {
   TTableCellElement,
   useTableCellElement,
@@ -23,9 +30,8 @@ const TableCellElement = React.forwardRef<
   TableCellElementProps
 >(({ children, className, style, hideBorder, isHeader, ...props }, ref) => {
   const { element } = props;
-
   const {
-    colIndex,
+    // colIndex,
     rowIndex,
     readOnly,
     selected,
@@ -36,6 +42,25 @@ const TableCellElement = React.forwardRef<
     isSelectingCell,
   } = useTableCellElementState();
   const { props: cellProps } = useTableCellElement({ element: props.element });
+  const editor = usePlateEditorRef();
+  const nodePath = findNodePath(editor, element)!;
+
+  const [__rowIndex, __colIndex] = nodePath.slice(-2);
+  // const colIndex = __colIndex + ((element.colSpan || 1) - 1);
+  const colIndex = __colIndex;
+
+  // console.log(
+  //   element.children.map((node: TElement) => node.children[0].text).join(' '),
+  //   nodePath,
+  //   '__rowIndex',
+  //   __rowIndex,
+  //   '__colIndex',
+  //   __colIndex,
+  //   'rowIndex',
+  //   rowIndex,
+  //   'colIndex',
+  //   colIndex
+  // );
   const resizableState = useTableCellElementResizableState({
     colIndex,
     rowIndex,
@@ -45,8 +70,24 @@ const TableCellElement = React.forwardRef<
 
   const Cell = isHeader ? 'th' : 'td';
 
+  // console.log('render cell', element);
+
+  // if (element.children[0].children[0].text === 'Void') {
+  //   console.log('render void cell', nodePath);
+  // }
   if (element.merged) {
-    return null;
+    // console.log('return null for', nodePath);
+    return (
+      <PlateElement
+        asChild
+        editor={editor}
+        attributes={props.attributes}
+        element={element}
+        style={{ display: 'none' }}
+      >
+        {children}
+      </PlateElement>
+    );
   }
 
   return (

--- a/apps/www/src/registry/default/plate-ui/table-cell-element.tsx
+++ b/apps/www/src/registry/default/plate-ui/table-cell-element.tsx
@@ -13,11 +13,10 @@ import {
   useTableCellElementResizable,
   useTableCellElementResizableState,
   useTableCellElementState,
+  useTableStore,
 } from '@udecode/plate-table';
 
 import { cn } from '@/lib/utils';
-
-import { ResizeHandle } from './resizable';
 
 export interface TableCellElementProps
   extends PlateElementProps<Value, TTableCellElement> {
@@ -31,7 +30,7 @@ const TableCellElement = React.forwardRef<
 >(({ children, className, style, hideBorder, isHeader, ...props }, ref) => {
   const { element } = props;
   const {
-    // colIndex,
+    colIndex,
     rowIndex,
     readOnly,
     selected,
@@ -43,24 +42,13 @@ const TableCellElement = React.forwardRef<
   } = useTableCellElementState();
   const { props: cellProps } = useTableCellElement({ element: props.element });
   const editor = usePlateEditorRef();
-  const nodePath = findNodePath(editor, element)!;
 
-  const [__rowIndex, __colIndex] = nodePath.slice(-2);
-  // const colIndex = __colIndex + ((element.colSpan || 1) - 1);
-  const colIndex = __colIndex;
+  const hoveredColIndex = useTableStore().get.hoveredColIndex();
 
-  // console.log(
-  //   element.children.map((node: TElement) => node.children[0].text).join(' '),
-  //   nodePath,
-  //   '__rowIndex',
-  //   __rowIndex,
-  //   '__colIndex',
-  //   __colIndex,
-  //   'rowIndex',
-  //   rowIndex,
-  //   'colIndex',
-  //   colIndex
-  // );
+  const content = element.children
+    .map((node: TElement) => node.children[0].text)
+    .join(' ');
+
   const resizableState = useTableCellElementResizableState({
     colIndex,
     rowIndex,
@@ -75,20 +63,6 @@ const TableCellElement = React.forwardRef<
   // if (element.children[0].children[0].text === 'Void') {
   //   console.log('render void cell', nodePath);
   // }
-  if (element.merged) {
-    // console.log('return null for', nodePath);
-    return (
-      <PlateElement
-        asChild
-        editor={editor}
-        attributes={props.attributes}
-        element={element}
-        style={{ display: 'none' }}
-      >
-        {children}
-      </PlateElement>
-    );
-  }
 
   return (
     <PlateElement
@@ -142,7 +116,7 @@ const TableCellElement = React.forwardRef<
           >
             {!readOnly && (
               <>
-                <ResizeHandle
+                {/* <ResizeHandle
                   {...rightProps}
                   className="-top-3 right-[-5px] w-[10px]"
                 />
@@ -155,20 +129,32 @@ const TableCellElement = React.forwardRef<
                     {...leftProps}
                     className="-top-3 left-[-5px] w-[10px]"
                   />
-                )}
+                )} */}
 
-                {hovered && (
+                {/* {rowIndex === 0 && (
+                  <ResizeHandle
+                    className={cn(
+                      'absolute -top-3 z-30 h-[150px] w-1',
+                      'right-[-1.5px]',
+                      hovered && 'bg-ring'
+                    )}
+                    {...rightProps}
+                  />
+                )} */}
+
+                {/* {hovered && rowIndex === 0 && (
                   <div
                     className={cn(
-                      'absolute -top-3 z-30 h-[calc(100%_+_12px)] w-1 bg-ring',
+                      'absolute -top-3 z-30 h-[150px] w-1 bg-ring',
                       'right-[-1.5px]'
                     )}
                   />
-                )}
-                {hoveredLeft && (
+                )} */}
+
+                {hoveredLeft && rowIndex === 0 && (
                   <div
                     className={cn(
-                      'absolute -top-3 z-30 h-[calc(100%_+_12px)] w-1 bg-ring',
+                      'absolute -top-3 z-30 h-[150px] w-1 bg-ring',
                       'left-[-1.5px]'
                     )}
                   />

--- a/apps/www/src/registry/default/plate-ui/table-cell-element.tsx
+++ b/apps/www/src/registry/default/plate-ui/table-cell-element.tsx
@@ -45,6 +45,10 @@ const TableCellElement = React.forwardRef<
 
   const Cell = isHeader ? 'th' : 'td';
 
+  if (element.merged) {
+    return null;
+  }
+
   return (
     <PlateElement
       asChild

--- a/apps/www/src/registry/default/plate-ui/table-element.tsx
+++ b/apps/www/src/registry/default/plate-ui/table-element.tsx
@@ -164,8 +164,9 @@ const TableFloatingToolbar = React.forwardRef<
     </>
   );
 
+  
   return (
-    <Popover open={mergeToolbar || bordersToolbar} modal={false}>
+    <Popover open={mergeToolbar} modal={false}>
       <PopoverAnchor asChild>{children}</PopoverAnchor>
       <PopoverContent
         ref={ref}
@@ -174,7 +175,6 @@ const TableFloatingToolbar = React.forwardRef<
         {...props}
       >
         {mergeContent}
-        {bordersContent}
       </PopoverContent>
     </Popover>
   );

--- a/apps/www/src/registry/default/plate-ui/table-element.tsx
+++ b/apps/www/src/registry/default/plate-ui/table-element.tsx
@@ -13,6 +13,7 @@ import {
 import {
   TTableElement,
   useTableBordersDropdownMenuContentState,
+  useTableCellsMerge,
   useTableElement,
   useTableElementState,
 } from '@udecode/plate-table';
@@ -112,17 +113,59 @@ const TableFloatingToolbar = React.forwardRef<
   const element = useElement<TTableElement>();
   const { props: buttonProps } = useRemoveNodeButton({ element });
 
+  const { onMergeCells } = useTableCellsMerge();
+
   const readOnly = useReadOnly();
   const editor = usePlateEditorState();
-  const open =
+  const mergeToolbar =
+    !readOnly &&
+    someNode(editor, {
+      match: (n) => n === element,
+    }) &&
+    !isCollapsed(editor.selection);
+
+  const bordersToolbar =
     !readOnly &&
     someNode(editor, {
       match: (n) => n === element,
     }) &&
     isCollapsed(editor.selection);
 
+  const mergeContent = mergeToolbar && (
+    <Button
+      contentEditable={false}
+      variant="ghost"
+      isMenu
+      onClick={onMergeCells}
+    >
+      <Icons.combine className="mr-2 h-4 w-4" />
+      Merge
+    </Button>
+  );
+  const bordersContent = bordersToolbar && (
+    <>
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" isMenu>
+            <Icons.borderAll className="mr-2 h-4 w-4" />
+            Borders
+          </Button>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuPortal>
+          <TableBordersDropdownMenuContent />
+        </DropdownMenuPortal>
+      </DropdownMenu>
+
+      <Button contentEditable={false} variant="ghost" isMenu {...buttonProps}>
+        <Icons.delete className="mr-2 h-4 w-4" />
+        Delete
+      </Button>
+    </>
+  );
+
   return (
-    <Popover open={open} modal={false}>
+    <Popover open={mergeToolbar || bordersToolbar} modal={false}>
       <PopoverAnchor asChild>{children}</PopoverAnchor>
       <PopoverContent
         ref={ref}
@@ -130,23 +173,8 @@ const TableFloatingToolbar = React.forwardRef<
         onOpenAutoFocus={(e) => e.preventDefault()}
         {...props}
       >
-        <DropdownMenu modal={false}>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" isMenu>
-              <Icons.borderAll className="mr-2 h-4 w-4" />
-              Borders
-            </Button>
-          </DropdownMenuTrigger>
-
-          <DropdownMenuPortal>
-            <TableBordersDropdownMenuContent />
-          </DropdownMenuPortal>
-        </DropdownMenu>
-
-        <Button contentEditable={false} variant="ghost" isMenu {...buttonProps}>
-          <Icons.delete className="mr-2 h-4 w-4" />
-          Delete
-        </Button>
+        {mergeContent}
+        {bordersContent}
       </PopoverContent>
     </Popover>
   );

--- a/apps/www/src/registry/default/plate-ui/table-element.tsx
+++ b/apps/www/src/registry/default/plate-ui/table-element.tsx
@@ -270,14 +270,14 @@ const TableElement = React.forwardRef<
       const complement = (width: number) =>
         currentInitial + nextInitial - width;
 
-      console.log(
-        'currentInitial',
-        currentInitial,
-        'nextInitial',
-        nextInitial,
-        'minColumnWidth',
-        minColumnWidth
-      );
+      // console.log(
+      //   'currentInitial',
+      //   currentInitial,
+      //   'nextInitial',
+      //   nextInitial,
+      //   'minColumnWidth',
+      //   minColumnWidth
+      // );
 
       const currentNew = roundCellSizeToStep(
         resizeLengthClampStatic(currentInitial + delta, {

--- a/packages/resizable/src/components/ResizeHandle.tsx
+++ b/packages/resizable/src/components/ResizeHandle.tsx
@@ -88,6 +88,13 @@ export const useResizeHandleState = ({
 
       const currentPosition = isHorizontal ? clientX : clientY;
       const delta = currentPosition - initialPosition;
+      console.log(
+        'resize handle executed',
+        initialSize,
+        delta,
+        finished,
+        direction
+      );
       onResize?.({ initialSize, delta, finished, direction });
     };
 
@@ -154,6 +161,11 @@ export const useResizeHandle = ({
     setInitialPosition(isHorizontal ? clientX : clientY);
 
     const element = (event.target as HTMLElement).parentElement!;
+    console.log(
+      'setting initial size',
+      event.target,
+      isHorizontal ? element.offsetWidth : element.offsetHeight
+    );
     setInitialSize(isHorizontal ? element.offsetWidth : element.offsetHeight);
 
     setIsResizing(true);

--- a/packages/resizable/src/components/ResizeHandle.tsx
+++ b/packages/resizable/src/components/ResizeHandle.tsx
@@ -88,13 +88,13 @@ export const useResizeHandleState = ({
 
       const currentPosition = isHorizontal ? clientX : clientY;
       const delta = currentPosition - initialPosition;
-      console.log(
-        'resize handle executed',
-        initialSize,
-        delta,
-        finished,
-        direction
-      );
+      // console.log(
+      //   'resize handle executed',
+      //   initialSize,
+      //   delta,
+      //   finished,
+      //   direction
+      // );
       onResize?.({ initialSize, delta, finished, direction });
     };
 
@@ -161,11 +161,11 @@ export const useResizeHandle = ({
     setInitialPosition(isHorizontal ? clientX : clientY);
 
     const element = (event.target as HTMLElement).parentElement!;
-    console.log(
-      'setting initial size',
-      event.target,
-      isHorizontal ? element.offsetWidth : element.offsetHeight
-    );
+    // console.log(
+    //   'setting initial size',
+    //   event.target,
+    //   isHorizontal ? element.offsetWidth : element.offsetHeight
+    // );
     setInitialSize(isHorizontal ? element.offsetWidth : element.offsetHeight);
 
     setIsResizing(true);

--- a/packages/table/src/components/TableCellElement/index.ts
+++ b/packages/table/src/components/TableCellElement/index.ts
@@ -9,3 +9,4 @@ export * from './roundCellSizeToStep';
 export * from './useIsCellSelected';
 export * from './useTableBordersDropdownMenuContentState';
 export * from './useTableCellElementState';
+export * from './useTableCellsMerge';

--- a/packages/table/src/components/TableCellElement/useIsCellSelected.ts
+++ b/packages/table/src/components/TableCellElement/useIsCellSelected.ts
@@ -4,8 +4,7 @@ import { TElement } from '@udecode/plate-common';
 import { useTableStore } from '../../stores/tableStore';
 
 export const useIsCellSelected = (element: TElement) => {
-  const selectedCellEntries = useTableStore().get.selectedCells();
-  const selectedCells = (selectedCellEntries || []).map((entry) => entry[0]);
+  const selectedCells = useTableStore().get.selectedCells();
 
   return useMemo(
     () => !!selectedCells?.includes(element),

--- a/packages/table/src/components/TableCellElement/useIsCellSelected.ts
+++ b/packages/table/src/components/TableCellElement/useIsCellSelected.ts
@@ -4,7 +4,8 @@ import { TElement } from '@udecode/plate-common';
 import { useTableStore } from '../../stores/tableStore';
 
 export const useIsCellSelected = (element: TElement) => {
-  const selectedCells = useTableStore().get.selectedCells();
+  const selectedCellEntries = useTableStore().get.selectedCells();
+  const selectedCells = (selectedCellEntries || []).map((entry) => entry[0]);
 
   return useMemo(
     () => !!selectedCells?.includes(element),

--- a/packages/table/src/components/TableCellElement/useTableCellElementResizable.ts
+++ b/packages/table/src/components/TableCellElement/useTableCellElementResizable.ts
@@ -230,7 +230,7 @@ export const useTableCellElementResizable = ({
   const getHandleHoverProps = (colIndex: number) => ({
     onHover: () => {
       if (hoveredColIndex === null) {
-        // console.log('set hovered col index', colIndex);
+        console.log('set hovered col index', colIndex);
         setHoveredColIndex(colIndex);
       }
     },

--- a/packages/table/src/components/TableCellElement/useTableCellElementResizable.ts
+++ b/packages/table/src/components/TableCellElement/useTableCellElementResizable.ts
@@ -230,11 +230,13 @@ export const useTableCellElementResizable = ({
   const getHandleHoverProps = (colIndex: number) => ({
     onHover: () => {
       if (hoveredColIndex === null) {
+        // console.log('set hovered col index', colIndex);
         setHoveredColIndex(colIndex);
       }
     },
     onHoverEnd: () => {
       if (hoveredColIndex === colIndex) {
+        // console.log('set hovered col index end', colIndex);
         setHoveredColIndex(null);
       }
     },

--- a/packages/table/src/components/TableCellElement/useTableCellElementState.ts
+++ b/packages/table/src/components/TableCellElement/useTableCellElementState.ts
@@ -89,6 +89,7 @@ export const useTableCellElement = ({
   return {
     props: {
       colSpan: element.colSpan,
+      rowSpan: element.rowSpan,
     },
   };
 };

--- a/packages/table/src/components/TableCellElement/useTableCellsMerge.ts
+++ b/packages/table/src/components/TableCellElement/useTableCellsMerge.ts
@@ -39,7 +39,8 @@ export const useTableCellsMerge = () => {
     );
 
     const firstRowIndex = lastRowIndex + 1 - rowSpan;
-
+    //TODO: fix rowIndex
+    // TODO: fix resize for right handle
     // console.log(
     //   'settings',
     //   colSpan,
@@ -50,29 +51,23 @@ export const useTableCellsMerge = () => {
     // );
 
     const contents = [];
+
+    const latInFirstRow = selectedCellEntries.find(([el, path]) => {
+      const [rowIndex, colIndex] = path.slice(-2);
+      if (rowIndex === firstRowIndex && colIndex === lastColIndex) {
+        return true;
+      }
+      return false;
+    })!;
+
     for (const cellEntry of selectedCellEntries) {
       const [el, path] = cellEntry;
-      const [rowIndex, colIndex] = path.slice(-2);
       const cellElement: TTableCellElement = el;
 
       contents.push(...el.children);
 
-      if (rowIndex === firstRowIndex && colIndex === lastColIndex) {
-        removeNodes(editor, { at: path });
-        insertNodes<TTableCellElement>(
-          editor,
-          {
-            ...getEmptyCellNode(editor, {
-              header: cellElement.type === 'th',
-              newCellChildren: contents, // TODO: update content
-            }),
-            colSpan,
-            rowSpan,
-          },
-          { at: path }
-        );
-      } else {
-        removeNodes(editor, { at: path });
+      removeNodes(editor, { at: path });
+      if (cellEntry !== latInFirstRow) {
         insertNodes(
           editor,
           {
@@ -83,9 +78,23 @@ export const useTableCellsMerge = () => {
           },
           { at: path }
         );
-      }
+      } 
     }
-    console.log('contents', contents);
+
+    insertNodes<TTableCellElement>(
+      editor,
+      {
+        ...getEmptyCellNode(editor, {
+          header: latInFirstRow[0].type === 'th',
+          newCellChildren: contents, // TODO: update content
+        }),
+        colSpan,
+        // rowSpan,
+      },
+      { at: latInFirstRow[1] }
+    );
+
+    // console.log('contents 2', contents);
   };
 
   return { onMergeCells };

--- a/packages/table/src/components/TableCellElement/useTableCellsMerge.ts
+++ b/packages/table/src/components/TableCellElement/useTableCellsMerge.ts
@@ -1,0 +1,92 @@
+import {
+  insertNodes,
+  removeNodes,
+  usePlateEditorState,
+} from '@udecode/plate-common';
+
+import { useTableStore } from '../../stores/index';
+import { TTableCellElement } from '../../types';
+import { getEmptyCellNode } from '../../utils/index';
+
+export const useTableCellsMerge = () => {
+  const editor = usePlateEditorState();
+  const selectedCellEntries = useTableStore().get.selectedCellEntries() || [];
+  const onMergeCells = () => {
+    const {
+      colSpan,
+      rowSpan,
+      currentRowIndex: lastRowIndex,
+      currentColIndex: lastColIndex,
+    } = selectedCellEntries.reduce(
+      (acc, current) => {
+        const [el, path] = current;
+        const cellElement: TTableCellElement = el;
+        const [rowIndex, colIndex] = path.slice(-2);
+
+        if (acc.currentRowIndex !== rowIndex) {
+          acc.rowSpan += cellElement.rowSpan || 1;
+          acc.currentRowIndex = rowIndex;
+        }
+
+        if (colIndex > acc.currentColIndex) {
+          acc.colSpan += cellElement.colSpan || 1;
+          acc.currentColIndex = colIndex;
+        }
+
+        return acc;
+      },
+      { colSpan: 0, rowSpan: 0, currentRowIndex: 0, currentColIndex: 0 }
+    );
+
+    const firstRowIndex = lastRowIndex + 1 - rowSpan;
+
+    // console.log(
+    //   'settings',
+    //   colSpan,
+    //   rowSpan,
+    //   lastRowIndex,
+    //   firstRowIndex,
+    //   lastColIndex
+    // );
+
+    const contents = [];
+    for (const cellEntry of selectedCellEntries) {
+      const [el, path] = cellEntry;
+      const [rowIndex, colIndex] = path.slice(-2);
+      const cellElement: TTableCellElement = el;
+
+      contents.push(...el.children);
+
+      if (rowIndex === firstRowIndex && colIndex === lastColIndex) {
+        removeNodes(editor, { at: path });
+        insertNodes<TTableCellElement>(
+          editor,
+          {
+            ...getEmptyCellNode(editor, {
+              header: cellElement.type === 'th',
+              newCellChildren: contents, // TODO: update content
+            }),
+            colSpan,
+            rowSpan,
+          },
+          { at: path }
+        );
+      } else {
+        removeNodes(editor, { at: path });
+        insertNodes(
+          editor,
+          {
+            ...getEmptyCellNode(editor, {
+              header: cellElement.type === 'th',
+            }),
+            merged: true,
+          },
+          { at: path }
+        );
+      }
+    }
+    console.log('contents', contents);
+  };
+
+  return { onMergeCells };
+};

--- a/packages/table/src/components/TableElement/useSelectedCells.ts
+++ b/packages/table/src/components/TableElement/useSelectedCells.ts
@@ -16,6 +16,7 @@ export const useSelectedCells = () => {
   const editor = usePlateEditorRef();
 
   const [selectedCells, setSelectedCells] = useTableStore().use.selectedCells();
+  const [, setSelectedCellEntries] = useTableStore().use.selectedCellEntries();
 
   useEffect(() => {
     if (!selected || readOnly) setSelectedCells(null);
@@ -30,9 +31,18 @@ export const useSelectedCells = () => {
 
       if (JSON.stringify(cells) !== JSON.stringify(selectedCells)) {
         setSelectedCells(cells);
+        setSelectedCellEntries(cellEntries);
       }
     } else if (selectedCells) {
       setSelectedCells(null);
+      setSelectedCellEntries(null);
     }
-  }, [editor, editor?.selection, readOnly, selectedCells, setSelectedCells]);
+  }, [
+    editor,
+    editor.selection,
+    readOnly,
+    selectedCells,
+    setSelectedCellEntries,
+    setSelectedCells,
+  ]);
 };

--- a/packages/table/src/stores/tableStore.ts
+++ b/packages/table/src/stores/tableStore.ts
@@ -1,7 +1,8 @@
 import { useCallback } from 'react';
-import { createAtomStore, TElement } from '@udecode/plate-common';
+import { createAtomStore, TElementEntry } from '@udecode/plate-common';
 
 import { ELEMENT_TABLE } from '../createTablePlugin';
+import { TTableCellElement } from '../types';
 
 export type TableStoreSizeOverrides = Map<number, number>;
 
@@ -11,7 +12,8 @@ export const { tableStore, useTableStore } = createAtomStore(
     rowSizeOverrides: new Map() as TableStoreSizeOverrides,
     marginLeftOverride: null as number | null,
     hoveredColIndex: null as number | null,
-    selectedCells: null as TElement[] | null,
+    selectedCells: null as TTableCellElement[] | null,
+    selectedCellEntries: null as TElementEntry[] | null,
   },
   { name: 'table' as const, scope: ELEMENT_TABLE }
 );

--- a/packages/table/src/types.ts
+++ b/packages/table/src/types.ts
@@ -78,8 +78,10 @@ export interface TTableRowElement extends TElement {
 
 export interface TTableCellElement extends TElement {
   colSpan?: number;
+  rowSpan?: number;
   size?: number;
   background?: string;
+  merged?: boolean;
   borders?: {
     top?: BorderStyle;
     left?: BorderStyle;

--- a/packages/table/src/withNormalizeTable.ts
+++ b/packages/table/src/withNormalizeTable.ts
@@ -92,9 +92,15 @@ export const withNormalizeTable = <
       if (getCellTypes(editor).includes(node.type)) {
         const { children } = node;
 
+        // TODO: normalize tables pasted from somewhere and set normalized flag.
+        // handle ones which have colSpan > 1, the same for rowIndex > 1
+        // then at least getColIndex should work as expected. think about getRowIndex.
+        const [rowIndex, colIndex] = path.slice(-2);
+
         const parentEntry = getParentNode(editor, path);
 
         if (parentEntry?.[0].type !== getPluginType(editor, ELEMENT_TR)) {
+          // console.log('unwrapping cell');
           unwrapNodes(editor, {
             at: path,
           });
@@ -102,6 +108,7 @@ export const withNormalizeTable = <
         }
 
         if (isText(children[0])) {
+          // console.log('wrapping cell');
           wrapNodeChildren<TElement>(editor, editor.blockFactory({}, path), {
             at: path,
           });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7170,7 +7170,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-resizable@npm:23.0.0, @udecode/plate-resizable@workspace:^, @udecode/plate-resizable@workspace:packages/resizable":
+"@udecode/plate-resizable@npm:23.1.0, @udecode/plate-resizable@workspace:^, @udecode/plate-resizable@workspace:packages/resizable":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-resizable@workspace:packages/resizable"
   dependencies:
@@ -7214,13 +7214,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-serializer-csv@npm:23.0.0, @udecode/plate-serializer-csv@workspace:^, @udecode/plate-serializer-csv@workspace:packages/serializer-csv":
+"@udecode/plate-serializer-csv@npm:23.1.0, @udecode/plate-serializer-csv@workspace:^, @udecode/plate-serializer-csv@workspace:packages/serializer-csv":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-serializer-csv@workspace:packages/serializer-csv"
   dependencies:
     "@types/papaparse": "npm:^5.3.7"
     "@udecode/plate-common": "npm:22.0.2"
-    "@udecode/plate-table": "npm:23.0.0"
+    "@udecode/plate-table": "npm:23.1.0"
     papaparse: "npm:^5.4.1"
   peerDependencies:
     react: ">=16.8.0"
@@ -7232,7 +7232,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-serializer-docx@npm:23.0.0, @udecode/plate-serializer-docx@workspace:^, @udecode/plate-serializer-docx@workspace:packages/serializer-docx":
+"@udecode/plate-serializer-docx@npm:23.1.0, @udecode/plate-serializer-docx@workspace:^, @udecode/plate-serializer-docx@workspace:packages/serializer-docx":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-serializer-docx@workspace:packages/serializer-docx"
   dependencies:
@@ -7242,7 +7242,7 @@ __metadata:
     "@udecode/plate-indent-list": "npm:22.0.2"
     "@udecode/plate-media": "npm:23.0.0"
     "@udecode/plate-paragraph": "npm:22.0.2"
-    "@udecode/plate-table": "npm:23.0.0"
+    "@udecode/plate-table": "npm:23.1.0"
     validator: "npm:^13.9.0"
   peerDependencies:
     react: ">=16.8.0"
@@ -7322,12 +7322,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-table@npm:23.0.0, @udecode/plate-table@workspace:^, @udecode/plate-table@workspace:packages/table":
+"@udecode/plate-table@npm:23.1.0, @udecode/plate-table@workspace:^, @udecode/plate-table@workspace:packages/table":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-table@workspace:packages/table"
   dependencies:
     "@udecode/plate-common": "npm:22.0.2"
-    "@udecode/plate-resizable": "npm:23.0.0"
+    "@udecode/plate-resizable": "npm:23.1.0"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -7457,15 +7457,15 @@ __metadata:
     "@udecode/plate-normalizers": "npm:22.0.2"
     "@udecode/plate-paragraph": "npm:22.0.2"
     "@udecode/plate-reset-node": "npm:22.0.2"
-    "@udecode/plate-resizable": "npm:23.0.0"
+    "@udecode/plate-resizable": "npm:23.1.0"
     "@udecode/plate-select": "npm:22.0.2"
-    "@udecode/plate-serializer-csv": "npm:23.0.0"
-    "@udecode/plate-serializer-docx": "npm:23.0.0"
+    "@udecode/plate-serializer-csv": "npm:23.1.0"
+    "@udecode/plate-serializer-docx": "npm:23.1.0"
     "@udecode/plate-serializer-html": "npm:22.0.2"
     "@udecode/plate-serializer-md": "npm:22.0.2"
     "@udecode/plate-suggestion": "npm:22.0.2"
     "@udecode/plate-tabbable": "npm:22.0.2"
-    "@udecode/plate-table": "npm:23.0.0"
+    "@udecode/plate-table": "npm:23.1.0"
     "@udecode/plate-trailing-block": "npm:22.0.2"
   peerDependencies:
     react: ">=16.8.0"


### PR DESCRIPTION
## Summary

Table cells merging. 

https://github.com/udecode/plate/assets/39378793/ae811dcd-c057-407f-a521-0ace7754e9c3

### Why resize borders above table cells?
To render resize borders per each cell correctly we need to know `colIndex` exactly for each cell. In screenshot below, for `No1` and `Yes1` cells is difficult to know which `colIndex` they have accordingly. It depends on `Yes Yes Yes` cell.  So that is why I suggest to have resize detached from cells. 

![941D5467-4FB8-4D15-B9C9-252390679ACE](https://github.com/udecode/plate/assets/39378793/ca2cf83a-c4b5-49f0-aa7c-841193a13656)






