### PR TITLE
Modify insertTableRow and insertTableColumn to support header columns #2577

### DIFF
--- a/.changeset/bright-dryers-suffer.md
+++ b/.changeset/bright-dryers-suffer.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-table": patch
+---
+
+Modify insertTableRow and insertTableColumn to support header columns to preserve header columns if they exist + not blindly assume that it's a header row if the first cell in that row is a header cell.

--- a/packages/table/src/transforms/insertTableColumn.ts
+++ b/packages/table/src/transforms/insertTableColumn.ts
@@ -91,8 +91,9 @@ export const insertTableColumn = <V extends Value>(
 
       const isHeaderRow =
         header === undefined
-          ? (row as TElement).children[0].type ===
-            getPluginType(editor, ELEMENT_TH)
+          ? (row as TElement).children.every(
+              (c) => c.type === getPluginType(editor, ELEMENT_TH)
+            )
           : header;
 
       insertElements(

--- a/packages/table/src/transforms/insertTableRow.ts
+++ b/packages/table/src/transforms/insertTableRow.ts
@@ -12,9 +12,9 @@ import {
 } from '@udecode/plate-common';
 import { Path } from 'slate';
 
-import { ELEMENT_TABLE, ELEMENT_TR } from '../createTablePlugin';
+import { ELEMENT_TABLE, ELEMENT_TH, ELEMENT_TR } from '../createTablePlugin';
 import { TablePlugin } from '../types';
-import { getCellTypes, getEmptyRowNode } from '../utils/index';
+import { getCellTypes, getEmptyCellNode } from '../utils/index';
 
 export const insertTableRow = <V extends Value>(
   editor: PlateEditor<V>,
@@ -57,18 +57,24 @@ export const insertTableRow = <V extends Value>(
     ELEMENT_TABLE
   );
 
+  const getEmptyRowNode = () => ({
+    type: getPluginType(editor, ELEMENT_TR),
+    children: (trNode.children as TElement[]).map((_, i) =>
+      getEmptyCellNode(editor, {
+        header:
+          header ??
+          (tableEntry[0].children as TElement[]).every(
+            (n) => n.children[i].type === ELEMENT_TH
+          ),
+        ...newCellChildren,
+      })
+    ),
+  });
+
   withoutNormalizing(editor, () => {
-    insertElements(
-      editor,
-      getEmptyRowNode(editor, {
-        header,
-        colCount: (trNode.children as TElement[]).length,
-        newCellChildren,
-      }),
-      {
-        at: Path.isPath(at) ? at : Path.next(trPath),
-      }
-    );
+    insertElements(editor, getEmptyRowNode(), {
+      at: Path.isPath(at) ? at : Path.next(trPath),
+    });
   });
 
   if (!disableSelect) {


### PR DESCRIPTION
Fixes #2577

**Description**

Modify insertTableRow and insertTableColumn to support header columns to preserve header columns if they exist + not blindly assume that a header row if the first cell in that row is a header cell.

**Before**


https://github.com/udecode/plate/assets/33153339/dce6e359-92fe-433e-9c53-ea530d63bd9e



**After**



https://github.com/udecode/plate/assets/33153339/26c57080-b348-4c22-95df-7570c2c61fdd



