### PR TITLE
Print view fix

### DIFF
--- a/apps/www/src/components/plate-ui/playground-floating-toolbar-buttons.tsx
+++ b/apps/www/src/components/plate-ui/playground-floating-toolbar-buttons.tsx
@@ -23,7 +23,7 @@ export function PlaygroundFloatingToolbarButtons({ id }: { id?: ValueId }) {
   const readOnly = usePlateReadOnly();
 
   return (
-    <>
+    <div className="print:hidden">
       {!readOnly && (
         <>
           <PlaygroundTurnIntoDropdownMenu />
@@ -59,6 +59,6 @@ export function PlaygroundFloatingToolbarButtons({ id }: { id?: ValueId }) {
       {isEnabled('comment', id) && <CommentToolbarButton />}
 
       <PlaygroundMoreDropdownMenu />
-    </>
+    </div>
   );
 }

--- a/apps/www/src/registry/default/plate-ui/image-element.tsx
+++ b/apps/www/src/registry/default/plate-ui/image-element.tsx
@@ -59,6 +59,7 @@ export function ImageElement({
 
           <Caption align={align} style={{ width }}>
             <CaptionTextarea
+              className="print:placeholder:text-transparent"
               placeholder="Write a caption..."
               options={{}}
               readOnly={readOnly}

--- a/apps/www/src/registry/default/plate-ui/link-floating-toolbar.tsx
+++ b/apps/www/src/registry/default/plate-ui/link-floating-toolbar.tsx
@@ -69,7 +69,7 @@ export function LinkFloatingToolbar({ readOnly }: TEditableProps) {
   const editContent = isEditing ? (
     input
   ) : (
-    <div className="box-content flex h-9 items-center gap-1">
+    <div className="print:hidden box-content flex h-9 items-center gap-1">
       <button
         type="button"
         className={buttonVariants({ variant: 'ghost', size: 'sm' })}

--- a/apps/www/src/registry/default/plate-ui/media-popover.tsx
+++ b/apps/www/src/registry/default/plate-ui/media-popover.tsx
@@ -69,7 +69,7 @@ export function MediaPopover({ pluginKey, children }: MediaPopoverProps) {
             </div>
           </div>
         ) : (
-          <div className="box-content flex h-9 items-center gap-1">
+          <div className="box-content print:hidden flex h-9 items-center gap-1">
             <FloatingMediaPrimitive.EditButton
               className={buttonVariants({ variant: 'ghost', size: 'sm' })}
             >

--- a/apps/www/src/registry/default/plate-ui/table-element.tsx
+++ b/apps/www/src/registry/default/plate-ui/table-element.tsx
@@ -162,7 +162,7 @@ const TableElement = React.forwardRef<
   const { props: tableProps, colGroupProps } = useTableElement();
 
   return (
-    <TableFloatingToolbar>
+    <TableFloatingToolbar className="print:hidden">
       <div style={{ paddingLeft: marginLeft }}>
         <PlateElement
           asChild

--- a/templates/plate-playground-template/src/components/plate-ui/media-popover.tsx
+++ b/templates/plate-playground-template/src/components/plate-ui/media-popover.tsx
@@ -50,7 +50,7 @@ export function MediaPopover({ pluginKey, children }: MediaPopoverProps) {
 
       <PopoverContent className="w-auto p-1">
         {isEditing ? (
-          <div className="flex w-[330px] flex-col">
+          <div className="print:hidden flex w-[330px] flex-col">
             <div className="flex items-center">
               <div className="flex items-center pl-3 text-muted-foreground">
                 <Icons.link className="h-4 w-4" />


### PR DESCRIPTION
**Description**

When attempting to print content from the Plate Editor, users encounter an issue where the floating toolbars and empty image captions associated with the editor remain visible in the print output. This behavior is unintended and disrupts the appearance of printed content.

The floating toolbars, which are meant to provide editing and formatting options while interacting with the editor, should ideally be hidden when generating a print preview or printing the content.
Also, when the caption for image is empty, should be hidden

**Steps to Reproduce**

Pre-requirements: You've a setup of Plate Editor with following plugins enabled
1. Image
2. Balloon Toolbar

1. Add content to Plate Editor (include image with empty caption).
2. Select some text (This should trigger balloon toolbar to appear).
3. Initiate print preview using `window.print` or Ctrl + P (Windows) or Command + P (macOS).
4. Empty caption of image and Toolbar components will be visible in the print preview.

**Expected Behavior**
The toolbar components and image caption(when empty) should only be visible in the regular view of the Plate Editor and not interfere with the printed version.