### PR TITLE
Fix column deletion early return

### DIFF
--- a/.changeset/nine-singers-change.md
+++ b/.changeset/nine-singers-change.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-table": patch
+---
+
+Fix column deletion early return

--- a/packages/table/src/queries/isTableBorderHidden.spec.tsx
+++ b/packages/table/src/queries/isTableBorderHidden.spec.tsx
@@ -1,9 +1,9 @@
 /** @jsx jsx */
 
 import { createPlateEditor, PlateEditor } from '@udecode/plate-common';
-import { createTablePlugin } from '@udecode/plate-table';
 import { jsx } from '@udecode/plate-test-utils';
 
+import { createTablePlugin } from '../createTablePlugin';
 import { isTableBorderHidden } from './isTableBorderHidden';
 
 jsx;

--- a/packages/table/src/transforms/deleteColumn.spec.tsx
+++ b/packages/table/src/transforms/deleteColumn.spec.tsx
@@ -119,7 +119,7 @@ describe('deleteColumn', () => {
   });
 
   describe('when first row has 2 cells, second row has 1 cell, focus 11', () => {
-    it('should do nothing', () => {
+    it('should delete 11', () => {
       const input = (
         <editor>
           <htable>

--- a/packages/table/src/transforms/deleteColumn.ts
+++ b/packages/table/src/transforms/deleteColumn.ts
@@ -58,8 +58,14 @@ export const deleteColumn = <V extends Value>(editor: PlateEditor<V>) => {
         tableNode.children.forEach((row, rowIdx) => {
           pathToDelete[replacePathPos] = rowIdx;
 
-          // for rows with different lengths
-          if (colIndex > (row.children as TElement[]).length - 1) return;
+          // for tables containing rows of different lengths
+          // - don't delete if only one cell in row
+          // - don't delete if row doesn't have this cell
+          if (
+            (row.children as TElement[]).length === 1 ||
+            colIndex > (row.children as TElement[]).length - 1
+          )
+            return;
 
           removeNodes(editor, {
             at: pathToDelete,

--- a/packages/table/src/transforms/deleteColumn.ts
+++ b/packages/table/src/transforms/deleteColumn.ts
@@ -55,11 +55,11 @@ export const deleteColumn = <V extends Value>(editor: PlateEditor<V>) => {
       const replacePathPos = pathToDelete.length - 2;
 
       withoutNormalizing(editor, () => {
-        tableEntry[0].children.forEach((row, rowIdx) => {
+        tableNode.children.forEach((row, rowIdx) => {
           pathToDelete[replacePathPos] = rowIdx;
 
           // for rows with different lengths
-          if ((row.children as TElement[]).length < replacePathPos + 1) return;
+          if (colIndex > (row.children as TElement[]).length - 1) return;
 
           removeNodes(editor, {
             at: pathToDelete,


### PR DESCRIPTION
This PR fixes a bug where a path index was being used instead of the value at that index 🤔🤔🤔

Emerged as you cannot delete columns in tables with parent nodes with the current implementation.