### PR TITLE
Ensure the return type of `unhangRange` matches the argument type

### DIFF
--- a/.changeset/slow-cats-thank.md
+++ b/.changeset/slow-cats-thank.md
@@ -1,0 +1,5 @@
+---
+'@udecode/slate': patch
+---
+
+Ensure the return type of `unhangRange` matches the argument type

--- a/packages/slate/src/interfaces/editor/unhangRange.ts
+++ b/packages/slate/src/interfaces/editor/unhangRange.ts
@@ -7,7 +7,6 @@ import {
   Span,
 } from 'slate';
 
-import { TRange } from '../../types/interfaces';
 import { TEditor, Value } from './TEditor';
 
 export type UnhangRangeOptions = EditorUnhangRangeOptions & {
@@ -19,14 +18,19 @@ export type UnhangRangeOptions = EditorUnhangRangeOptions & {
  * - `unhang` is true,
  * - `at` (default: selection) is a range.
  */
-export const unhangRange = <V extends Value>(
+export const unhangRange = <
+  V extends Value,
+  R extends Range | Path | Point | Span | null | undefined,
+>(
   editor: TEditor<V>,
-  range?: Range | Path | Point | Span | null,
+  range: R,
   options: UnhangRangeOptions = {}
-) => {
+): R => {
   const { voids, unhang = true } = options;
 
   if (Range.isRange(range) && unhang) {
-    return Editor.unhangRange(editor as any, range, { voids }) as TRange;
+    return Editor.unhangRange(editor as any, range, { voids }) as R;
   }
+
+  return range;
 };


### PR DESCRIPTION
**Description**

See changesets.

**Examples**

```ts
unhangRange(editor, selection as Range | null) // has type Range | null
unhangRange(editor, selection as Range) // has type Range
unhangRange(editor, point) // has type Point
```