### PR TITLE
FIX #2677 : CommonJS validator import in cleanDocXImageElements

### DIFF
--- a/.changeset/great-files-boil.md
+++ b/.changeset/great-files-boil.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-serializer-docx": patch
+---
+
+Fixes #2677: CommonJS validator import in cleanDocXImageElements

--- a/packages/serializer-docx/src/docx-cleaner/utils/cleanDocxImageElements.ts
+++ b/packages/serializer-docx/src/docx-cleaner/utils/cleanDocxImageElements.ts
@@ -1,5 +1,5 @@
 import { hexToBase64, traverseHtmlElements } from '@udecode/plate-common';
-import isURL from 'validator/lib/isURL';
+import validator from 'validator';
 
 import { getRtfImagesMap } from './getRtfImagesMap';
 import { getVShapeSpid } from './getVShapeSpid';
@@ -30,7 +30,7 @@ export const cleanDocxImageElements = (
 
       const alt = element.getAttribute('alt');
 
-      if (typeof alt === 'string' && isURL(alt, { require_protocol: true })) {
+      if (typeof alt === 'string' && validator.isURL(alt, { require_protocol: true })) {
         element.setAttribute('src', alt);
         return true;
       }


### PR DESCRIPTION
**Description**

Replace `import isURL from 'validator/lib/isURL'` with `import validator from 'validator'` to fix CommonJS import issue when using `esModules` under vitest.

