### PR TITLE
Fix: "Cannot resolve a DOM node from Slate node" floating link case

### DIFF
--- a/.changeset/fast-eggs-burn.md
+++ b/.changeset/fast-eggs-burn.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-link": patch
+---
+
+Fix: "Cannot resolve a DOM node from Slate node" floating link case

--- a/packages/link/src/transforms/submitFloatingLink.ts
+++ b/packages/link/src/transforms/submitFloatingLink.ts
@@ -39,7 +39,9 @@ export const submitFloatingLink = <V extends Value>(editor: PlateEditor<V>) => {
     skipValidation: true,
   });
 
-  focusEditor(editor, editor.selection!);
+  setTimeout(() => {
+    focusEditor(editor, editor.selection!);
+  }, 0);
 
   return true;
 };


### PR DESCRIPTION
Fix exception when Enter is pressed in link input.


**Description**

Fix issue when pressing Enter in link input on floating toolbar with latest plate/slate:
https://github.com/udecode/plate/issues/2674

Steps to reproduce:
- select text
- click "link" on a floating toolbar
- enter some url and click enter -> exception "Cannot resolve a DOM node from Slate node"




 


