### PR TITLE
Add `asChild` to the TooltipTrigger in ToolbarButton

### DIFF
--- a/apps/www/src/registry/default/plate-ui/toolbar.tsx
+++ b/apps/www/src/registry/default/plate-ui/toolbar.tsx
@@ -146,7 +146,7 @@ const ToolbarButton = React.forwardRef<
 
     return isLoaded && tooltip ? (
       <Tooltip>
-        <TooltipTrigger>{content}</TooltipTrigger>
+        <TooltipTrigger asChild>{content}</TooltipTrigger>
 
         <TooltipPortal>
           <TooltipContent>{tooltip}</TooltipContent>


### PR DESCRIPTION
**Description**

This prevents nesting multiple `<button>`s