### PR TITLE
Add `removeEmpty` option to `insertNodes`

### DIFF
--- a/.changeset/tender-socks-dress.md
+++ b/.changeset/tender-socks-dress.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-media': patch
+---
+
+Pass additional options given to insertMedia to insertImage or insertMediaEmbed

--- a/.changeset/tiny-carpets-help.md
+++ b/.changeset/tiny-carpets-help.md
@@ -1,0 +1,5 @@
+---
+'@udecode/slate': minor
+---
+
+Add `removeEmpty: boolean | QueryNodeOptions` option to insertNodes

--- a/packages/media/src/media/insertMedia.ts
+++ b/packages/media/src/media/insertMedia.ts
@@ -1,4 +1,9 @@
-import { getPluginType, PlateEditor, Value } from '@udecode/plate-common';
+import {
+  getPluginType,
+  InsertNodesOptions,
+  PlateEditor,
+  Value,
+} from '@udecode/plate-common';
 
 import {
   ELEMENT_IMAGE,
@@ -7,7 +12,8 @@ import {
   insertMediaEmbed,
 } from '..';
 
-export interface InsertMediaOptions {
+export interface InsertMediaOptions<V extends Value>
+  extends InsertNodesOptions<V> {
   /**
    * Default onClick is getting the image url by calling this promise before inserting the image.
    */
@@ -21,7 +27,8 @@ export const insertMedia = async <V extends Value>(
   {
     getUrl,
     type = getPluginType(editor, ELEMENT_IMAGE),
-  }: InsertMediaOptions = {}
+    ...options
+  }: InsertMediaOptions<V> = {}
 ) => {
   const url = getUrl
     ? await getUrl()
@@ -33,8 +40,8 @@ export const insertMedia = async <V extends Value>(
   if (!url) return;
 
   if (type === getPluginType(editor, ELEMENT_IMAGE)) {
-    insertImage(editor, url);
+    insertImage(editor, url, options);
   } else {
-    insertMediaEmbed(editor, { url });
+    insertMediaEmbed(editor, { url }, options);
   }
 };

--- a/packages/slate/src/interfaces/transforms/insertNodes.ts
+++ b/packages/slate/src/interfaces/transforms/insertNodes.ts
@@ -66,16 +66,20 @@ export const insertNodes = <
       }
     }
 
-    if (nextBlock && options.at) {
-      const endPoint = getEndPoint(editor, options.at);
+    if (nextBlock) {
+      const { at = editor.selection } = options;
 
-      const blockEntry = getAboveNode(editor, {
-        at: endPoint,
-        block: true,
-      });
+      if (at) {
+        const endPoint = getEndPoint(editor, at);
 
-      if (blockEntry) {
-        options.at = Path.next(blockEntry[1]);
+        const blockEntry = getAboveNode(editor, {
+          at: endPoint,
+          block: true,
+        });
+
+        if (blockEntry) {
+          options.at = Path.next(blockEntry[1]);
+        }
       }
     }
 

--- a/packages/slate/src/interfaces/transforms/insertNodes.ts
+++ b/packages/slate/src/interfaces/transforms/insertNodes.ts
@@ -36,19 +36,11 @@ export const insertNodes = <
 >(
   editor: TEditor<V>,
   nodes: N | N[],
-  {
-    at: optionsAt,
-    nextBlock,
-    removeEmpty,
-    ...options
-  }: InsertNodesOptions<V> = {}
+  { nextBlock, removeEmpty, ...options }: InsertNodesOptions<V> = {}
 ) => {
-  let at = optionsAt || editor.selection;
-  if (!at) return;
-
   withoutNormalizing(editor as any, () => {
     if (removeEmpty) {
-      const blockEntry = getAboveNode(editor, { at: at! });
+      const blockEntry = getAboveNode(editor, { at: options.at });
 
       if (blockEntry) {
         const queryNodeOptions: QueryNodeOptions =
@@ -74,8 +66,8 @@ export const insertNodes = <
       }
     }
 
-    if (nextBlock) {
-      const endPoint = getEndPoint(editor, at!);
+    if (nextBlock && options.at) {
+      const endPoint = getEndPoint(editor, options.at);
 
       const blockEntry = getAboveNode(editor, {
         at: endPoint,
@@ -83,13 +75,10 @@ export const insertNodes = <
       });
 
       if (blockEntry) {
-        at = Path.next(blockEntry[1]);
+        options.at = Path.next(blockEntry[1]);
       }
     }
 
-    Transforms.insertNodes(editor as any, nodes, {
-      at,
-      ...options,
-    } as any);
+    Transforms.insertNodes(editor as any, nodes, options as any);
   });
 };


### PR DESCRIPTION
**Description**
Implements the `removeEmpty` option on `insertNodes` discussed [here](https://github.com/udecode/plate/issues/2704#issuecomment-1764797567). If a node is removed as a result of this option, the `nextBlock` option is ignored.

I wasn't able to import `ELEMENT_DEFAULT` or `isAncestorEmpty` since these are from packages that depend on `@udecode/slate`. @zbeyens Is there a workaround for this, or should we settle for duplicating them?

**Usage**
Most or all Plate transforms that insert a node accept an options type inheriting from `InsertNodesOptions`; if anyone finds a transform that does not expose these options, feel free to make a PR. This is where you can add the `removeEmpty: true` option to enable this behaviour.

If you want empty blocks other than paragraphs to be removed, you can pass a `QueryNodeOptions` object to `removeEmpty`. For example: `removeEmpty: { allow: [ELEMENT_DEFAULT, ...KEYS_HEADING] }`.