### PR TITLE
handle new row header property

### DIFF
--- a/packages/table/src/transforms/insertTableRow.ts
+++ b/packages/table/src/transforms/insertTableRow.ts
@@ -59,16 +59,18 @@ export const insertTableRow = <V extends Value>(
 
   const getEmptyRowNode = () => ({
     type: getPluginType(editor, ELEMENT_TR),
-    children: (trNode.children as TElement[]).map((_, i) =>
-      getEmptyCellNode(editor, {
-        header:
-          header ??
-          (tableEntry[0].children as TElement[]).every(
-            (n) => n.children[i].type === ELEMENT_TH
-          ),
+    children: (trNode.children as TElement[]).map((_, i) => {
+      const hasSingleRow = tableEntry[0].children.length === 1;
+      const isHeaderColumn =
+        !hasSingleRow &&
+        (tableEntry[0].children as TElement[]).every(
+          (n) => n.children[i].type === ELEMENT_TH
+        );
+      return getEmptyCellNode(editor, {
+        header: header ?? isHeaderColumn,
         ...newCellChildren,
-      })
-    ),
+      });
+    }),
   });
 
   withoutNormalizing(editor, () => {


### PR DESCRIPTION
**Description**

fixes #2723 

When a new row is added below a row that has header styling only give the newly inserted cells the header styling property if a) all of the cells of that column are header cells AND b) there is more than one row in the table OR C) has a defined header property


There was some logic in insertTableRow which says if every cell in the column is a header, then the new cell for that column inserted in row below should be a header too. However this logic does not work if there is only one row (with a header) as all columns will be headers in a single row table and therefore all inserted cells in the row below will be header cells.



https://github.com/udecode/plate/assets/78092825/d2ee9efe-c63a-4621-8c33-45c4d05b29f1


