### PR TITLE
Remove instruction to build registry from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,10 +107,7 @@ apps
         │   └── plate-ui
 ```
 
-When adding or modifying components, please ensure that:
-
-1. You update the documentation.
-2. You run `yarn build:registry` to update the registry.
+When adding or modifying components, please ensure that you update the documentation.
 
 ## CLI
 


### PR DESCRIPTION
**Description**

Running `yarn build:registry` manually is not necessary, since it's [handled in CI](https://github.com/udecode/plate/blob/main/.github/workflows/registry.yml#L41).