### PR TITLE
Fix combobox `targetRange` for mention input

### DIFF
--- a/.changeset/blue-rules-attack.md
+++ b/.changeset/blue-rules-attack.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-mention': patch
+---
+
+Fix combobox targetRange to account for normalization

--- a/packages/mention/src/withMention.ts
+++ b/packages/mention/src/withMention.ts
@@ -180,11 +180,16 @@ export const withMention = <
           focus: { path: operation.path.concat([0]), offset: text.length },
         });
 
-        comboboxActions.open({
-          activeId: id!,
-          text,
-          targetRange: editor.selection,
-        });
+        // Make sure that we read the updated selection after normalization.
+        // Slate may insert an empty text node before or after the mention input
+        // during normalization.
+        setTimeout(() => {
+          comboboxActions.open({
+            activeId: id!,
+            text,
+            targetRange: editor.selection,
+          });
+        }, 0);
       }
     } else if (
       operation.type === 'remove_node' &&


### PR DESCRIPTION
**Description**

Fixes #1843
Fixes #2533

After investigating #1843 I discovered that Slate inserts an empty text node before the mention input to fulfil this normalization constraint:

> 4. **Inline nodes cannot be the first or last child of a parent block, nor can it be next to another inline node in the children array.** If this is the case, an empty text node will be added to correct this to be in compliance with the constraint.

Source: https://docs.slatejs.org/concepts/11-normalizing

Is there any better way to wait for normalization without `setTimeout()`?