### PR TITLE
Fix: `serializeHtml` mutates the live `editor` instance

### DIFF
--- a/.changeset/silver-rings-own.md
+++ b/.changeset/silver-rings-own.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-serializer-html': patch
+---
+
+Fix: `serializeHtml` mutates the live `editor` instance

--- a/packages/serializer-html/src/elementToHtml.ts
+++ b/packages/serializer-html/src/elementToHtml.ts
@@ -50,7 +50,6 @@ export const elementToHtml = <V extends Value>(
       renderToStaticMarkup(
         createElementWithSlate(
           {
-            editor: editor as any,
             ...plateProps,
             children:
               plugin.serializeHtml?.(props as any) ??

--- a/packages/serializer-html/src/utils/createElementWithSlate.ts
+++ b/packages/serializer-html/src/utils/createElementWithSlate.ts
@@ -1,5 +1,5 @@
 import React, { ComponentClass, FunctionComponent } from 'react';
-import { Plate, PlateProps } from '@udecode/plate-common';
+import { createPlateEditor, Plate, PlateProps } from '@udecode/plate-common';
 
 /**
  * Create a React element wrapped in a Plate provider.
@@ -9,7 +9,7 @@ export const createElementWithSlate = (
   dndWrapper?: string | FunctionComponent | ComponentClass
 ) => {
   const {
-    editor,
+    editor = createPlateEditor(),
     value = [],
     onChange = () => {},
     children,


### PR DESCRIPTION
**Description**

Fixes #2796

See changesets.