### PR TITLE
Fix CommentsProvider callbacks

### DIFF
--- a/.changeset/calm-tables-kick.md
+++ b/.changeset/calm-tables-kick.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-comments': patch
+---
+
+- Fix the `onCommentAdd`, `onCommentUpdate` and `onCommentDelete` callbacks on CommentsProvider

--- a/apps/www/src/lib/plate/demo/comments/CommentsProvider.tsx
+++ b/apps/www/src/lib/plate/demo/comments/CommentsProvider.tsx
@@ -8,6 +8,11 @@ export function CommentsProvider({ children }: { children: ReactNode }) {
       comments={commentsData}
       users={usersData}
       myUserId="1"
+      /* eslint-disable no-console */
+      onCommentAdd={(comment) => console.log('Comment added', comment)}
+      onCommentDelete={(comment) => console.log('Comment deleted', comment)}
+      onCommentUpdate={(comment) => console.log('Comment updated', comment)}
+      /* eslint-enable no-console */
     >
       {children}
     </CommentsProviderPrimitive>

--- a/packages/comments/src/components/CommentDeleteButton.tsx
+++ b/packages/comments/src/components/CommentDeleteButton.tsx
@@ -10,7 +10,7 @@ import { unsetCommentNodesById } from '../utils/index';
 
 export const useCommentDeleteButtonState = () => {
   const activeCommentId = useCommentsSelectors().activeCommentId();
-  const onCommentDelete = useCommentsSelectors().onCommentDelete();
+  const onCommentDelete = useCommentsSelectors().onCommentDelete()?.fn;
   const id = useCommentSelectors().id();
   const setActiveCommentId = useCommentsActions().activeCommentId();
   const removeComment = useRemoveComment();

--- a/packages/comments/src/components/CommentEditSaveButton.tsx
+++ b/packages/comments/src/components/CommentEditSaveButton.tsx
@@ -12,7 +12,7 @@ import {
 } from '../stores/comments/CommentsProvider';
 
 export const useCommentEditSaveButtonState = () => {
-  const onCommentUpdate = useCommentsSelectors().onCommentUpdate();
+  const onCommentUpdate = useCommentsSelectors().onCommentUpdate()?.fn;
   const editingValue = useCommentSelectors().editingValue();
   const setEditingValue = useCommentActions().editingValue();
   const id = useCommentSelectors().id();

--- a/packages/comments/src/components/CommentNewSubmitButton.tsx
+++ b/packages/comments/src/components/CommentNewSubmitButton.tsx
@@ -12,7 +12,7 @@ import {
 } from '../stores/comments/CommentsProvider';
 
 export const useCommentNewSubmitButtonState = () => {
-  const onCommentAdd = useCommentsSelectors().onCommentAdd();
+  const onCommentAdd = useCommentsSelectors().onCommentAdd()?.fn;
   const activeCommentId = useCommentsSelectors().activeCommentId()!;
   const comment = useComment(SCOPE_ACTIVE_COMMENT)!;
   const newValue = useCommentsSelectors().newValue();

--- a/packages/comments/src/components/CommentResolveButton.tsx
+++ b/packages/comments/src/components/CommentResolveButton.tsx
@@ -8,7 +8,7 @@ import {
 } from '../stores/comments/CommentsProvider';
 
 export const useCommentResolveButton = () => {
-  const onCommentUpdate = useCommentsSelectors().onCommentUpdate();
+  const onCommentUpdate = useCommentsSelectors().onCommentUpdate()?.fn;
   const activeCommentId = useCommentsSelectors().activeCommentId();
   const setActiveCommentId = useCommentsActions().activeCommentId();
   const updateComment = useUpdateComment(activeCommentId);

--- a/packages/comments/src/stores/comments/CommentsProvider.tsx
+++ b/packages/comments/src/stores/comments/CommentsProvider.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   createAtomStore,
   getNodeString,
@@ -35,31 +36,57 @@ export interface CommentsStoreState {
 
   focusTextarea: boolean;
 
-  onCommentAdd: ((value: WithPartial<TComment, 'userId'>) => void) | null;
-  onCommentUpdate:
-    | ((value: Pick<TComment, 'id'> & Partial<Omit<TComment, 'id'>>) => void)
-    | null;
-  onCommentDelete: ((id: string) => void) | null;
+  onCommentAdd: { fn: (value: WithPartial<TComment, 'userId'>) => void } | null;
+  onCommentUpdate: {
+    fn: (value: Pick<TComment, 'id'> & Partial<Omit<TComment, 'id'>>) => void;
+  } | null;
+  onCommentDelete: { fn: (id: string) => void } | null;
 }
 
-export const { commentsStore, useCommentsStore, CommentsProvider } =
-  createAtomStore(
-    {
-      myUserId: null,
-      users: {},
-      comments: {},
-      activeCommentId: null,
-      addingCommentId: null,
-      newValue: [{ type: 'p', children: [{ text: '' }] }],
-      focusTextarea: false,
-      onCommentAdd: null,
-      onCommentUpdate: null,
-      onCommentDelete: null,
-    } as CommentsStoreState,
-    {
-      name: 'comments',
-    }
-  );
+export const {
+  commentsStore,
+  useCommentsStore,
+  CommentsProvider: PrimitiveCommentsProvider,
+} = createAtomStore(
+  {
+    myUserId: null,
+    users: {},
+    comments: {},
+    activeCommentId: null,
+    addingCommentId: null,
+    newValue: [{ type: 'p', children: [{ text: '' }] }],
+    focusTextarea: false,
+    onCommentAdd: null,
+    onCommentUpdate: null,
+    onCommentDelete: null,
+  } as CommentsStoreState,
+  {
+    name: 'comments',
+  }
+);
+
+export const CommentsProvider = ({
+  onCommentAdd,
+  onCommentUpdate,
+  onCommentDelete,
+  ...props
+}: Omit<
+  React.ComponentProps<typeof PrimitiveCommentsProvider>,
+  'onCommentAdd' | 'onCommentUpdate' | 'onCommentDelete'
+> & {
+  onCommentAdd?: (value: WithPartial<TComment, 'userId'>) => void;
+  onCommentUpdate?: (
+    value: Pick<TComment, 'id'> & Partial<Omit<TComment, 'id'>>
+  ) => void;
+  onCommentDelete?: (id: string) => void;
+}) => (
+  <PrimitiveCommentsProvider
+    {...props}
+    onCommentAdd={onCommentAdd ? { fn: onCommentAdd } : null}
+    onCommentUpdate={onCommentUpdate ? { fn: onCommentUpdate } : null}
+    onCommentDelete={onCommentDelete ? { fn: onCommentDelete } : null}
+  />
+);
 
 export const useCommentsStates = () => useCommentsStore().use;
 export const useCommentsSelectors = () => useCommentsStore().get;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6033,11 +6033,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@udecode/plate-alignment@npm:27.0.0, @udecode/plate-alignment@workspace:^, @udecode/plate-alignment@workspace:packages/alignment":
+"@udecode/plate-alignment@npm:27.0.3, @udecode/plate-alignment@workspace:^, @udecode/plate-alignment@workspace:packages/alignment":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-alignment@workspace:packages/alignment"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6048,11 +6048,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-autoformat@npm:27.0.0, @udecode/plate-autoformat@workspace:^, @udecode/plate-autoformat@workspace:packages/autoformat":
+"@udecode/plate-autoformat@npm:27.0.3, @udecode/plate-autoformat@workspace:^, @udecode/plate-autoformat@workspace:packages/autoformat":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-autoformat@workspace:packages/autoformat"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
     lodash: "npm:^4.17.21"
   peerDependencies:
     react: ">=16.8.0"
@@ -6064,15 +6064,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-basic-elements@npm:27.0.0, @udecode/plate-basic-elements@workspace:^, @udecode/plate-basic-elements@workspace:packages/basic-elements":
+"@udecode/plate-basic-elements@npm:27.0.3, @udecode/plate-basic-elements@workspace:^, @udecode/plate-basic-elements@workspace:packages/basic-elements":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-basic-elements@workspace:packages/basic-elements"
   dependencies:
-    "@udecode/plate-block-quote": "npm:27.0.0"
-    "@udecode/plate-code-block": "npm:27.0.0"
-    "@udecode/plate-common": "npm:27.0.0"
-    "@udecode/plate-heading": "npm:27.0.0"
-    "@udecode/plate-paragraph": "npm:27.0.0"
+    "@udecode/plate-block-quote": "npm:27.0.3"
+    "@udecode/plate-code-block": "npm:27.0.3"
+    "@udecode/plate-common": "npm:27.0.3"
+    "@udecode/plate-heading": "npm:27.0.3"
+    "@udecode/plate-paragraph": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6083,11 +6083,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-basic-marks@npm:27.0.0, @udecode/plate-basic-marks@workspace:^, @udecode/plate-basic-marks@workspace:packages/basic-marks":
+"@udecode/plate-basic-marks@npm:27.0.3, @udecode/plate-basic-marks@workspace:^, @udecode/plate-basic-marks@workspace:packages/basic-marks":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-basic-marks@workspace:packages/basic-marks"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6098,11 +6098,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-block-quote@npm:27.0.0, @udecode/plate-block-quote@workspace:^, @udecode/plate-block-quote@workspace:packages/block-quote":
+"@udecode/plate-block-quote@npm:27.0.3, @udecode/plate-block-quote@workspace:^, @udecode/plate-block-quote@workspace:packages/block-quote":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-block-quote@workspace:packages/block-quote"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6113,11 +6113,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-break@npm:27.0.0, @udecode/plate-break@workspace:^, @udecode/plate-break@workspace:packages/break":
+"@udecode/plate-break@npm:27.0.3, @udecode/plate-break@workspace:^, @udecode/plate-break@workspace:packages/break":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-break@workspace:packages/break"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6132,7 +6132,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@udecode/plate-caption@workspace:packages/caption"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
     react-textarea-autosize: "npm:^8.5.2"
   peerDependencies:
     react: ">=16.8.0"
@@ -6149,7 +6149,7 @@ __metadata:
   resolution: "@udecode/plate-cloud@workspace:packages/cloud"
   dependencies:
     "@portive/client": "npm:10.0.3"
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
     delay: "npm:5.0.0"
     p-defer: "npm:^3.0.0"
   peerDependencies:
@@ -6162,11 +6162,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-code-block@npm:27.0.0, @udecode/plate-code-block@workspace:^, @udecode/plate-code-block@workspace:packages/code-block":
+"@udecode/plate-code-block@npm:27.0.3, @udecode/plate-code-block@workspace:^, @udecode/plate-code-block@workspace:packages/code-block":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-code-block@workspace:packages/code-block"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
     prismjs: "npm:^1.29.0"
   peerDependencies:
     react: ">=16.8.0"
@@ -6178,11 +6178,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-combobox@npm:27.0.0, @udecode/plate-combobox@workspace:^, @udecode/plate-combobox@workspace:packages/combobox":
+"@udecode/plate-combobox@npm:27.0.3, @udecode/plate-combobox@workspace:^, @udecode/plate-combobox@workspace:packages/combobox":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-combobox@workspace:packages/combobox"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
     downshift: "npm:^6.1.12"
   peerDependencies:
     react: ">=16.8.0"
@@ -6194,11 +6194,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-comments@npm:27.0.0, @udecode/plate-comments@workspace:^, @udecode/plate-comments@workspace:packages/comments":
+"@udecode/plate-comments@npm:27.0.3, @udecode/plate-comments@workspace:^, @udecode/plate-comments@workspace:packages/comments":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-comments@workspace:packages/comments"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
     lodash: "npm:^4.17.21"
   peerDependencies:
     react: ">=16.8.0"
@@ -6210,12 +6210,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-common@npm:27.0.0, @udecode/plate-common@workspace:^, @udecode/plate-common@workspace:packages/common":
+"@udecode/plate-common@npm:27.0.3, @udecode/plate-common@workspace:^, @udecode/plate-common@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-common@workspace:packages/common"
   dependencies:
-    "@udecode/plate-core": "npm:27.0.0"
-    "@udecode/plate-utils": "npm:27.0.0"
+    "@udecode/plate-core": "npm:27.0.3"
+    "@udecode/plate-utils": "npm:27.0.3"
     "@udecode/slate": "npm:25.0.0"
     "@udecode/slate-react": "npm:25.0.0"
     "@udecode/slate-utils": "npm:25.0.0"
@@ -6230,7 +6230,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-core@npm:27.0.0, @udecode/plate-core@workspace:^, @udecode/plate-core@workspace:packages/core":
+"@udecode/plate-core@npm:27.0.3, @udecode/plate-core@workspace:^, @udecode/plate-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-core@workspace:packages/core"
   dependencies:
@@ -6262,7 +6262,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@udecode/plate-cursor@workspace:packages/cursor"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6277,7 +6277,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@udecode/plate-dnd@workspace:packages/dnd"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
     lodash: "npm:^4.17.21"
     raf: "npm:^3.4.1"
   peerDependencies:
@@ -6297,8 +6297,8 @@ __metadata:
   resolution: "@udecode/plate-emoji@workspace:packages/emoji"
   dependencies:
     "@emoji-mart/data": "npm:^1.1.2"
-    "@udecode/plate-combobox": "npm:27.0.0"
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-combobox": "npm:27.0.3"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6314,7 +6314,7 @@ __metadata:
   resolution: "@udecode/plate-excalidraw@workspace:packages/excalidraw"
   dependencies:
     "@excalidraw/excalidraw": "npm:0.12.0"
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6325,11 +6325,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-find-replace@npm:27.0.0, @udecode/plate-find-replace@workspace:^, @udecode/plate-find-replace@workspace:packages/find-replace":
+"@udecode/plate-find-replace@npm:27.0.3, @udecode/plate-find-replace@workspace:^, @udecode/plate-find-replace@workspace:packages/find-replace":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-find-replace@workspace:packages/find-replace"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6340,13 +6340,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-floating@npm:27.0.0, @udecode/plate-floating@workspace:^, @udecode/plate-floating@workspace:packages/floating":
+"@udecode/plate-floating@npm:27.0.3, @udecode/plate-floating@workspace:^, @udecode/plate-floating@workspace:packages/floating":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-floating@workspace:packages/floating"
   dependencies:
     "@floating-ui/core": "npm:^1.3.1"
     "@floating-ui/react": "npm:^0.22.3"
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6357,11 +6357,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-font@npm:27.0.0, @udecode/plate-font@workspace:^, @udecode/plate-font@workspace:packages/font":
+"@udecode/plate-font@npm:27.0.3, @udecode/plate-font@workspace:^, @udecode/plate-font@workspace:packages/font":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-font@workspace:packages/font"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
     lodash: "npm:^4.17.21"
   peerDependencies:
     react: ">=16.8.0"
@@ -6373,11 +6373,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-heading@npm:27.0.0, @udecode/plate-heading@workspace:^, @udecode/plate-heading@workspace:packages/heading":
+"@udecode/plate-heading@npm:27.0.3, @udecode/plate-heading@workspace:^, @udecode/plate-heading@workspace:packages/heading":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-heading@workspace:packages/heading"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6388,11 +6388,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-highlight@npm:27.0.0, @udecode/plate-highlight@workspace:^, @udecode/plate-highlight@workspace:packages/highlight":
+"@udecode/plate-highlight@npm:27.0.3, @udecode/plate-highlight@workspace:^, @udecode/plate-highlight@workspace:packages/highlight":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-highlight@workspace:packages/highlight"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6403,11 +6403,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-horizontal-rule@npm:27.0.0, @udecode/plate-horizontal-rule@workspace:^, @udecode/plate-horizontal-rule@workspace:packages/horizontal-rule":
+"@udecode/plate-horizontal-rule@npm:27.0.3, @udecode/plate-horizontal-rule@workspace:^, @udecode/plate-horizontal-rule@workspace:packages/horizontal-rule":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-horizontal-rule@workspace:packages/horizontal-rule"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6418,13 +6418,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-indent-list@npm:27.0.0, @udecode/plate-indent-list@workspace:^, @udecode/plate-indent-list@workspace:packages/indent-list":
+"@udecode/plate-indent-list@npm:27.0.3, @udecode/plate-indent-list@workspace:^, @udecode/plate-indent-list@workspace:packages/indent-list":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-indent-list@workspace:packages/indent-list"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
-    "@udecode/plate-indent": "npm:27.0.0"
-    "@udecode/plate-list": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
+    "@udecode/plate-indent": "npm:27.0.3"
+    "@udecode/plate-list": "npm:27.0.3"
     clsx: "npm:^1.2.1"
   peerDependencies:
     react: ">=16.8.0"
@@ -6436,11 +6436,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-indent@npm:27.0.0, @udecode/plate-indent@workspace:^, @udecode/plate-indent@workspace:packages/indent":
+"@udecode/plate-indent@npm:27.0.3, @udecode/plate-indent@workspace:^, @udecode/plate-indent@workspace:packages/indent":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-indent@workspace:packages/indent"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6455,7 +6455,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@udecode/plate-juice@workspace:packages/juice"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
     juice: "npm:^8.1.0"
   peerDependencies:
     react: ">=16.8.0"
@@ -6467,11 +6467,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-kbd@npm:27.0.0, @udecode/plate-kbd@workspace:^, @udecode/plate-kbd@workspace:packages/kbd":
+"@udecode/plate-kbd@npm:27.0.3, @udecode/plate-kbd@workspace:^, @udecode/plate-kbd@workspace:packages/kbd":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-kbd@workspace:packages/kbd"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6482,11 +6482,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-line-height@npm:27.0.0, @udecode/plate-line-height@workspace:^, @udecode/plate-line-height@workspace:packages/line-height":
+"@udecode/plate-line-height@npm:27.0.3, @udecode/plate-line-height@workspace:^, @udecode/plate-line-height@workspace:packages/line-height":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-line-height@workspace:packages/line-height"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6497,13 +6497,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-link@npm:27.0.0, @udecode/plate-link@workspace:^, @udecode/plate-link@workspace:packages/link":
+"@udecode/plate-link@npm:27.0.3, @udecode/plate-link@workspace:^, @udecode/plate-link@workspace:packages/link":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-link@workspace:packages/link"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
-    "@udecode/plate-floating": "npm:27.0.0"
-    "@udecode/plate-normalizers": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
+    "@udecode/plate-floating": "npm:27.0.3"
+    "@udecode/plate-normalizers": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6514,12 +6514,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-list@npm:27.0.0, @udecode/plate-list@workspace:^, @udecode/plate-list@workspace:packages/list":
+"@udecode/plate-list@npm:27.0.3, @udecode/plate-list@workspace:^, @udecode/plate-list@workspace:packages/list":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-list@workspace:packages/list"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
-    "@udecode/plate-reset-node": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
+    "@udecode/plate-reset-node": "npm:27.0.3"
     lodash: "npm:^4.17.21"
   peerDependencies:
     react: ">=16.8.0"
@@ -6531,11 +6531,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-media@npm:27.0.0, @udecode/plate-media@workspace:^, @udecode/plate-media@workspace:packages/media":
+"@udecode/plate-media@npm:27.0.3, @udecode/plate-media@workspace:^, @udecode/plate-media@workspace:packages/media":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-media@workspace:packages/media"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
     js-video-url-parser: "npm:^0.5.1"
   peerDependencies:
     react: ">=16.8.0"
@@ -6547,12 +6547,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-mention@npm:27.0.0, @udecode/plate-mention@workspace:^, @udecode/plate-mention@workspace:packages/mention":
+"@udecode/plate-mention@npm:27.0.3, @udecode/plate-mention@workspace:^, @udecode/plate-mention@workspace:packages/mention":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-mention@workspace:packages/mention"
   dependencies:
-    "@udecode/plate-combobox": "npm:27.0.0"
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-combobox": "npm:27.0.3"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6563,11 +6563,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-node-id@npm:27.0.0, @udecode/plate-node-id@workspace:^, @udecode/plate-node-id@workspace:packages/node-id":
+"@udecode/plate-node-id@npm:27.0.3, @udecode/plate-node-id@workspace:^, @udecode/plate-node-id@workspace:packages/node-id":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-node-id@workspace:packages/node-id"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
     lodash: "npm:^4.17.21"
   peerDependencies:
     react: ">=16.8.0"
@@ -6579,11 +6579,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-normalizers@npm:27.0.0, @udecode/plate-normalizers@workspace:^, @udecode/plate-normalizers@workspace:packages/normalizers":
+"@udecode/plate-normalizers@npm:27.0.3, @udecode/plate-normalizers@workspace:^, @udecode/plate-normalizers@workspace:packages/normalizers":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-normalizers@workspace:packages/normalizers"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
     lodash: "npm:^4.17.21"
   peerDependencies:
     react: ">=16.8.0"
@@ -6595,11 +6595,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-paragraph@npm:27.0.0, @udecode/plate-paragraph@workspace:^, @udecode/plate-paragraph@workspace:packages/paragraph":
+"@udecode/plate-paragraph@npm:27.0.3, @udecode/plate-paragraph@workspace:^, @udecode/plate-paragraph@workspace:packages/paragraph":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-paragraph@workspace:packages/paragraph"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6610,11 +6610,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-reset-node@npm:27.0.0, @udecode/plate-reset-node@workspace:^, @udecode/plate-reset-node@workspace:packages/reset-node":
+"@udecode/plate-reset-node@npm:27.0.3, @udecode/plate-reset-node@workspace:^, @udecode/plate-reset-node@workspace:packages/reset-node":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-reset-node@workspace:packages/reset-node"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6625,11 +6625,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-resizable@npm:27.0.0, @udecode/plate-resizable@workspace:^, @udecode/plate-resizable@workspace:packages/resizable":
+"@udecode/plate-resizable@npm:27.0.3, @udecode/plate-resizable@workspace:^, @udecode/plate-resizable@workspace:packages/resizable":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-resizable@workspace:packages/resizable"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6640,11 +6640,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-select@npm:27.0.0, @udecode/plate-select@workspace:^, @udecode/plate-select@workspace:packages/select":
+"@udecode/plate-select@npm:27.0.3, @udecode/plate-select@workspace:^, @udecode/plate-select@workspace:packages/select":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-select@workspace:packages/select"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6659,7 +6659,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@udecode/plate-selection@workspace:packages/selection"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
     "@viselect/vanilla": "npm:3.2.5"
     copy-to-clipboard: "npm:^3.3.3"
   peerDependencies:
@@ -6672,13 +6672,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-serializer-csv@npm:27.0.2, @udecode/plate-serializer-csv@workspace:^, @udecode/plate-serializer-csv@workspace:packages/serializer-csv":
+"@udecode/plate-serializer-csv@npm:27.0.3, @udecode/plate-serializer-csv@workspace:^, @udecode/plate-serializer-csv@workspace:packages/serializer-csv":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-serializer-csv@workspace:packages/serializer-csv"
   dependencies:
     "@types/papaparse": "npm:^5.3.7"
-    "@udecode/plate-common": "npm:27.0.0"
-    "@udecode/plate-table": "npm:27.0.2"
+    "@udecode/plate-common": "npm:27.0.3"
+    "@udecode/plate-table": "npm:27.0.3"
     papaparse: "npm:^5.4.1"
   peerDependencies:
     react: ">=16.8.0"
@@ -6690,17 +6690,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-serializer-docx@npm:27.0.2, @udecode/plate-serializer-docx@workspace:^, @udecode/plate-serializer-docx@workspace:packages/serializer-docx":
+"@udecode/plate-serializer-docx@npm:27.0.3, @udecode/plate-serializer-docx@workspace:^, @udecode/plate-serializer-docx@workspace:packages/serializer-docx":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-serializer-docx@workspace:packages/serializer-docx"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
-    "@udecode/plate-heading": "npm:27.0.0"
-    "@udecode/plate-indent": "npm:27.0.0"
-    "@udecode/plate-indent-list": "npm:27.0.0"
-    "@udecode/plate-media": "npm:27.0.0"
-    "@udecode/plate-paragraph": "npm:27.0.0"
-    "@udecode/plate-table": "npm:27.0.2"
+    "@udecode/plate-common": "npm:27.0.3"
+    "@udecode/plate-heading": "npm:27.0.3"
+    "@udecode/plate-indent": "npm:27.0.3"
+    "@udecode/plate-indent-list": "npm:27.0.3"
+    "@udecode/plate-media": "npm:27.0.3"
+    "@udecode/plate-paragraph": "npm:27.0.3"
+    "@udecode/plate-table": "npm:27.0.3"
     validator: "npm:^13.9.0"
   peerDependencies:
     react: ">=16.8.0"
@@ -6712,12 +6712,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-serializer-html@npm:27.0.0, @udecode/plate-serializer-html@workspace:^, @udecode/plate-serializer-html@workspace:packages/serializer-html":
+"@udecode/plate-serializer-html@npm:27.0.3, @udecode/plate-serializer-html@workspace:^, @udecode/plate-serializer-html@workspace:packages/serializer-html":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-serializer-html@workspace:packages/serializer-html"
   dependencies:
     "@types/papaparse": "npm:^5.3.7"
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
     html-entities: "npm:^2.4.0"
   peerDependencies:
     react: ">=16.8.0"
@@ -6729,20 +6729,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-serializer-md@npm:27.0.0, @udecode/plate-serializer-md@workspace:^, @udecode/plate-serializer-md@workspace:packages/serializer-md":
+"@udecode/plate-serializer-md@npm:27.0.3, @udecode/plate-serializer-md@workspace:^, @udecode/plate-serializer-md@workspace:packages/serializer-md":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-serializer-md@workspace:packages/serializer-md"
   dependencies:
-    "@udecode/plate-basic-marks": "npm:27.0.0"
-    "@udecode/plate-block-quote": "npm:27.0.0"
-    "@udecode/plate-code-block": "npm:27.0.0"
-    "@udecode/plate-common": "npm:27.0.0"
-    "@udecode/plate-heading": "npm:27.0.0"
-    "@udecode/plate-horizontal-rule": "npm:27.0.0"
-    "@udecode/plate-link": "npm:27.0.0"
-    "@udecode/plate-list": "npm:27.0.0"
-    "@udecode/plate-media": "npm:27.0.0"
-    "@udecode/plate-paragraph": "npm:27.0.0"
+    "@udecode/plate-basic-marks": "npm:27.0.3"
+    "@udecode/plate-block-quote": "npm:27.0.3"
+    "@udecode/plate-code-block": "npm:27.0.3"
+    "@udecode/plate-common": "npm:27.0.3"
+    "@udecode/plate-heading": "npm:27.0.3"
+    "@udecode/plate-horizontal-rule": "npm:27.0.3"
+    "@udecode/plate-link": "npm:27.0.3"
+    "@udecode/plate-list": "npm:27.0.3"
+    "@udecode/plate-media": "npm:27.0.3"
+    "@udecode/plate-paragraph": "npm:27.0.3"
     remark-parse: "npm:^9.0.0"
     unified: "npm:^9.2.2"
   peerDependencies:
@@ -6755,11 +6755,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-suggestion@npm:27.0.0, @udecode/plate-suggestion@workspace:^, @udecode/plate-suggestion@workspace:packages/suggestion":
+"@udecode/plate-suggestion@npm:27.0.3, @udecode/plate-suggestion@workspace:^, @udecode/plate-suggestion@workspace:packages/suggestion":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-suggestion@workspace:packages/suggestion"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6770,11 +6770,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-tabbable@npm:27.0.0, @udecode/plate-tabbable@workspace:^, @udecode/plate-tabbable@workspace:packages/tabbable":
+"@udecode/plate-tabbable@npm:27.0.3, @udecode/plate-tabbable@workspace:^, @udecode/plate-tabbable@workspace:packages/tabbable":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-tabbable@workspace:packages/tabbable"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
     tabbable: "npm:^6.2.0"
   peerDependencies:
     react: ">=16.8.0"
@@ -6786,12 +6786,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-table@npm:27.0.2, @udecode/plate-table@workspace:^, @udecode/plate-table@workspace:packages/table":
+"@udecode/plate-table@npm:27.0.3, @udecode/plate-table@workspace:^, @udecode/plate-table@workspace:packages/table":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-table@workspace:packages/table"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
-    "@udecode/plate-resizable": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
+    "@udecode/plate-resizable": "npm:27.0.3"
     lodash: "npm:^4.17.21"
   peerDependencies:
     react: ">=16.8.0"
@@ -6811,11 +6811,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-trailing-block@npm:27.0.0, @udecode/plate-trailing-block@workspace:^, @udecode/plate-trailing-block@workspace:packages/trailing-block":
+"@udecode/plate-trailing-block@npm:27.0.3, @udecode/plate-trailing-block@workspace:^, @udecode/plate-trailing-block@workspace:packages/trailing-block":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-trailing-block@workspace:packages/trailing-block"
   dependencies:
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -6855,12 +6855,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-utils@npm:27.0.0, @udecode/plate-utils@workspace:^, @udecode/plate-utils@workspace:packages/plate-utils":
+"@udecode/plate-utils@npm:27.0.3, @udecode/plate-utils@workspace:^, @udecode/plate-utils@workspace:packages/plate-utils":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-utils@workspace:packages/plate-utils"
   dependencies:
     "@radix-ui/react-slot": "npm:^1.0.2"
-    "@udecode/plate-core": "npm:27.0.0"
+    "@udecode/plate-core": "npm:27.0.3"
     "@udecode/slate": "npm:25.0.0"
     "@udecode/slate-react": "npm:25.0.0"
     "@udecode/slate-utils": "npm:25.0.0"
@@ -6883,7 +6883,7 @@ __metadata:
   dependencies:
     "@hocuspocus/provider": "npm:^2.2.1"
     "@slate-yjs/core": "npm:^1.0.1"
-    "@udecode/plate-common": "npm:27.0.0"
+    "@udecode/plate-common": "npm:27.0.3"
     yjs: "npm:^13.5.42"
   peerDependencies:
     react: ">=16.8.0"
@@ -6899,44 +6899,44 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@udecode/plate@workspace:packages/plate"
   dependencies:
-    "@udecode/plate-alignment": "npm:27.0.0"
-    "@udecode/plate-autoformat": "npm:27.0.0"
-    "@udecode/plate-basic-elements": "npm:27.0.0"
-    "@udecode/plate-basic-marks": "npm:27.0.0"
-    "@udecode/plate-block-quote": "npm:27.0.0"
-    "@udecode/plate-break": "npm:27.0.0"
-    "@udecode/plate-code-block": "npm:27.0.0"
-    "@udecode/plate-combobox": "npm:27.0.0"
-    "@udecode/plate-comments": "npm:27.0.0"
-    "@udecode/plate-common": "npm:27.0.0"
-    "@udecode/plate-find-replace": "npm:27.0.0"
-    "@udecode/plate-floating": "npm:27.0.0"
-    "@udecode/plate-font": "npm:27.0.0"
-    "@udecode/plate-heading": "npm:27.0.0"
-    "@udecode/plate-highlight": "npm:27.0.0"
-    "@udecode/plate-horizontal-rule": "npm:27.0.0"
-    "@udecode/plate-indent": "npm:27.0.0"
-    "@udecode/plate-indent-list": "npm:27.0.0"
-    "@udecode/plate-kbd": "npm:27.0.0"
-    "@udecode/plate-line-height": "npm:27.0.0"
-    "@udecode/plate-link": "npm:27.0.0"
-    "@udecode/plate-list": "npm:27.0.0"
-    "@udecode/plate-media": "npm:27.0.0"
-    "@udecode/plate-mention": "npm:27.0.0"
-    "@udecode/plate-node-id": "npm:27.0.0"
-    "@udecode/plate-normalizers": "npm:27.0.0"
-    "@udecode/plate-paragraph": "npm:27.0.0"
-    "@udecode/plate-reset-node": "npm:27.0.0"
-    "@udecode/plate-resizable": "npm:27.0.0"
-    "@udecode/plate-select": "npm:27.0.0"
-    "@udecode/plate-serializer-csv": "npm:27.0.2"
-    "@udecode/plate-serializer-docx": "npm:27.0.2"
-    "@udecode/plate-serializer-html": "npm:27.0.0"
-    "@udecode/plate-serializer-md": "npm:27.0.0"
-    "@udecode/plate-suggestion": "npm:27.0.0"
-    "@udecode/plate-tabbable": "npm:27.0.0"
-    "@udecode/plate-table": "npm:27.0.2"
-    "@udecode/plate-trailing-block": "npm:27.0.0"
+    "@udecode/plate-alignment": "npm:27.0.3"
+    "@udecode/plate-autoformat": "npm:27.0.3"
+    "@udecode/plate-basic-elements": "npm:27.0.3"
+    "@udecode/plate-basic-marks": "npm:27.0.3"
+    "@udecode/plate-block-quote": "npm:27.0.3"
+    "@udecode/plate-break": "npm:27.0.3"
+    "@udecode/plate-code-block": "npm:27.0.3"
+    "@udecode/plate-combobox": "npm:27.0.3"
+    "@udecode/plate-comments": "npm:27.0.3"
+    "@udecode/plate-common": "npm:27.0.3"
+    "@udecode/plate-find-replace": "npm:27.0.3"
+    "@udecode/plate-floating": "npm:27.0.3"
+    "@udecode/plate-font": "npm:27.0.3"
+    "@udecode/plate-heading": "npm:27.0.3"
+    "@udecode/plate-highlight": "npm:27.0.3"
+    "@udecode/plate-horizontal-rule": "npm:27.0.3"
+    "@udecode/plate-indent": "npm:27.0.3"
+    "@udecode/plate-indent-list": "npm:27.0.3"
+    "@udecode/plate-kbd": "npm:27.0.3"
+    "@udecode/plate-line-height": "npm:27.0.3"
+    "@udecode/plate-link": "npm:27.0.3"
+    "@udecode/plate-list": "npm:27.0.3"
+    "@udecode/plate-media": "npm:27.0.3"
+    "@udecode/plate-mention": "npm:27.0.3"
+    "@udecode/plate-node-id": "npm:27.0.3"
+    "@udecode/plate-normalizers": "npm:27.0.3"
+    "@udecode/plate-paragraph": "npm:27.0.3"
+    "@udecode/plate-reset-node": "npm:27.0.3"
+    "@udecode/plate-resizable": "npm:27.0.3"
+    "@udecode/plate-select": "npm:27.0.3"
+    "@udecode/plate-serializer-csv": "npm:27.0.3"
+    "@udecode/plate-serializer-docx": "npm:27.0.3"
+    "@udecode/plate-serializer-html": "npm:27.0.3"
+    "@udecode/plate-serializer-md": "npm:27.0.3"
+    "@udecode/plate-suggestion": "npm:27.0.3"
+    "@udecode/plate-tabbable": "npm:27.0.3"
+    "@udecode/plate-table": "npm:27.0.3"
+    "@udecode/plate-trailing-block": "npm:27.0.3"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"


### PR DESCRIPTION
**Description**

See changesets.

The `onCommentAdd`, `onCommentUpdate` and `onCommentDelete` callbacks weren't using the `{ fn: ... }` pattern required by jotai-x. This problem was masked by jotai-x silently wrapping the functions in `{ fn: ... }` anyway but not amending the types.