### PR TITLE
Normalize cloneDeep import

### DIFF
--- a/.changeset/rotten-foxes-tickle.md
+++ b/.changeset/rotten-foxes-tickle.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-table": patch
+---
+
+Fix lodash import

--- a/packages/table/src/merge/mergeTableCells.ts
+++ b/packages/table/src/merge/mergeTableCells.ts
@@ -9,7 +9,7 @@ import {
   Value,
   withoutNormalizing,
 } from '@udecode/plate-common';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep.js';
 
 import { ELEMENT_TABLE, ELEMENT_TH } from '../createTablePlugin';
 import { getTableGridAbove } from '../queries';


### PR DESCRIPTION

**Description**

See changesets.

Fixes following error by normalizing lodash cloneDeep import to be consistent with other imports in the repo

> SyntaxError: Named export 'cloneDeep' not found. The requested module 'lodash' is a CommonJS module, which may not support all module.exports as named exports.

