### PR TITLE
fix: changed docs/serializing-markdown route to docs/serializing-md

### DIFF
--- a/apps/www/src/config/customizer-plugins.ts
+++ b/apps/www/src/config/customizer-plugins.ts
@@ -162,7 +162,7 @@ export const customizerPlugins = {
     id: 'deserializemd',
     label: 'Deserialize Markdown',
     value: deserializeMdValue,
-    route: '/docs/serializing-markdown',
+    route: '/docs/serializing-md',
     plugins: [KEY_DESERIALIZE_MD],
   },
   dnd: {


### PR DESCRIPTION
closes https://github.com/udecode/plate/issues/2848

Changed route in builder drawer to docs/serializing-md.

Link now takes user to docs instead of a 404 page.