### PR TITLE
fix: implement dom to react synthetic event conversion

### DIFF
--- a/.changeset/violet-years-train.md
+++ b/.changeset/violet-years-train.md
@@ -1,5 +1,5 @@
 ---
-"@udecode/plate-core": major
+"@udecode/plate-core": patch
 ---
 
-The problem involved unexpected behavior when users attempted to perform a specific action within the editor. The implemented solution corrects this behavior by adjusting the editor's internal state management, ensuring that the action now produces the expected outcome without causing any side effects.
+Ensure that beforeinput event is handled as a React.SyntheticEvent rather than a native DOM event

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1977,3 +1977,12 @@ To migrate, find and replace all occurrences of:
 ### Patch Changes
 
 - [#658](https://github.com/udecode/slate-plugins/pull/658) [`201a7993`](https://github.com/udecode/slate-plugins/commit/201a799342ff88405e120182d8554e70b726beea) Thanks [@zbeyens](https://github.com/zbeyens)! - test
+
+
+## Unreleased
+
+### Patch Changes
+
+- [#2854](https://github.com/udecode/plate/pull/2854) by [@MarcosPereira1] –
+  - Fix issue [#2794](https://github.com/udecode/plate/issues/2794): The problem involved unexpected behavior when users attempted to perform a specific action within the editor. The implemented solution corrects this behavior by adjusting the editor's internal state management, ensuring that the action now produces the expected outcome without causing any side effects.
+

--- a/packages/core/src/utils/pipeHandler.ts
+++ b/packages/core/src/utils/pipeHandler.ts
@@ -5,7 +5,9 @@ import { PlateEditor } from '../types/PlateEditor';
 import { DOMHandlers, HandlerReturnType } from '../types/plugin/DOMHandlers';
 import { TEditableProps } from '../types/slate-react/TEditableProps';
 
-function convertDomEventToSyntheticEvent(domEvent: Event) {
+export const convertDomEventToSyntheticEvent = (domEvent: Event) => {
+  let propagationStopped = false 
+
   const syntheticEvent = {
     ...domEvent,
     nativeEvent: domEvent,
@@ -19,9 +21,12 @@ function convertDomEventToSyntheticEvent(domEvent: Event) {
     timeStamp: domEvent.timeStamp,
     type: domEvent.type,
     isDefaultPrevented: () => domEvent.defaultPrevented,
-    isPropagationStopped: () => false,
+    isPropagationStopped: () => propagationStopped,
     preventDefault: () => domEvent.preventDefault(),
-    stopPropagation: () => domEvent.stopPropagation(),
+    stopPropagation: () => {
+      propagationStopped = true;
+      domEvent.stopPropagation();
+    },
   };
 
   return syntheticEvent;


### PR DESCRIPTION
Description

This pull request addresses the issue described in [udecode/plate#2794](https://github.com/udecode/plate/issues/2794). The main goal was to resolve the type mismatch issue between DOM events and React's synthetic events, particularly for the onDOMBeforeInput event handler.

After discussing the issue with the community on Discord, two main solutions were proposed. I opted for the second solution, which involves manually creating an object compatible with React's SyntheticEvent interface and passing this object to pipeHandler instead of the native DOM event. This approach was chosen because it allows maintaining the current consumer types in Plate, while also addressing the type mismatch issue.

Here’s a summary of the changes:

Implemented a function convertDomEventToSyntheticEvent that converts a DOM event to a React synthetic event.
Integrated this function into pipeHandler to ensure that all events processed are consistent with the interface expected by React event handlers.
I would greatly appreciate help in testing these changes to ensure that they correctly address the issue without introducing any new ones.