### PR TITLE
indentList option for MD deserializer

### DIFF
--- a/.changeset/nervous-nails-bathe.md
+++ b/.changeset/nervous-nails-bathe.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-serializer-md": minor
+---
+
+New option in markdown deserializer plugin: `indentList?: boolean`. Set it to true if you're using Indent List plugin instead of the List plugin.

--- a/packages/serializer-md/src/deserializer/createDeserializeMdPlugin.ts
+++ b/packages/serializer-md/src/deserializer/createDeserializeMdPlugin.ts
@@ -36,5 +36,6 @@ export const createDeserializeMdPlugin =
     options: {
       elementRules: remarkDefaultElementRules,
       textRules: remarkDefaultTextRules,
+      indentList: false,
     },
   });

--- a/packages/serializer-md/src/deserializer/types.ts
+++ b/packages/serializer-md/src/deserializer/types.ts
@@ -5,4 +5,5 @@ import { RemarkElementRules, RemarkTextRules } from '../remark-slate/index';
 export interface DeserializeMdPlugin<V extends Value = Value> {
   elementRules?: RemarkElementRules<V>;
   textRules?: RemarkTextRules<V>;
+  indentList?: boolean;
 }

--- a/packages/serializer-md/src/deserializer/utils/deserializeMd.spec.tsx
+++ b/packages/serializer-md/src/deserializer/utils/deserializeMd.spec.tsx
@@ -303,3 +303,98 @@ describe('deserializeMd', () => {
     expect(deserializeMd(editor, input)).toEqual(output);
   });
 });
+
+describe('deserializeMdIndentList', () => {
+  const editor = createPlateEditor({
+    plugins: [
+      createDeserializeMdPlugin({ options: { indentList: true } }) as any,
+    ],
+  });
+
+  it('should deserialize unordered lists', () => {
+    const input = '- List item 1\n- List item 2';
+
+    const output = [
+      {
+        type: 'p',
+        listStyleType: 'disc',
+        indent: 1,
+        children: [
+          {
+            text: 'List item 1',
+          },
+        ],
+      },
+      {
+        type: 'p',
+        listStyleType: 'disc',
+        indent: 1,
+        children: [
+          {
+            text: 'List item 2',
+          },
+        ],
+      },
+    ];
+
+    expect(deserializeMd(editor, input)).toEqual(output);
+  });
+
+  it('should deserialize ordered lists', () => {
+    const input = '1. List item 1\n2. List item 2';
+
+    const output = [
+      {
+        type: "p",
+        listStyleType: "decimal",
+        indent: 1,
+        children: [
+          {
+            text: "List item 1",
+          },
+        ],
+      },
+      {
+        type: "p",
+        listStyleType: "decimal",
+        indent: 1,
+        children: [
+          {
+            text: "List item 2",
+          },
+        ],
+      },
+    ];
+
+    expect(deserializeMd(editor, input)).toEqual(output);
+  });
+
+  it('should deserialize mixed nested lists', () => {
+    const input = '- List item 1\n  1. List item 1.1';
+
+    const output = [
+      {
+        type: "p",
+        listStyleType: "disc",
+        indent: 1,
+        children: [
+          {
+            text: "List item 1",
+          },
+        ],
+      },
+      {
+        type: "p",
+        listStyleType: "disc",
+        indent: 2,
+        children: [
+          {
+            text: "List item 1.1",
+          },
+        ],
+      },
+    ];
+
+    expect(deserializeMd(editor, input)).toEqual(output);
+  });
+});

--- a/packages/serializer-md/src/deserializer/utils/deserializeMd.spec.tsx
+++ b/packages/serializer-md/src/deserializer/utils/deserializeMd.spec.tsx
@@ -345,22 +345,22 @@ describe('deserializeMdIndentList', () => {
 
     const output = [
       {
-        type: "p",
-        listStyleType: "decimal",
+        type: 'p',
+        listStyleType: 'decimal',
         indent: 1,
         children: [
           {
-            text: "List item 1",
+            text: 'List item 1',
           },
         ],
       },
       {
-        type: "p",
-        listStyleType: "decimal",
+        type: 'p',
+        listStyleType: 'decimal',
         indent: 1,
         children: [
           {
-            text: "List item 2",
+            text: 'List item 2',
           },
         ],
       },
@@ -374,22 +374,22 @@ describe('deserializeMdIndentList', () => {
 
     const output = [
       {
-        type: "p",
-        listStyleType: "disc",
+        type: 'p',
+        listStyleType: 'disc',
         indent: 1,
         children: [
           {
-            text: "List item 1",
+            text: 'List item 1',
           },
         ],
       },
       {
-        type: "p",
-        listStyleType: "disc",
+        type: 'p',
+        listStyleType: 'disc',
         indent: 2,
         children: [
           {
-            text: "List item 1.1",
+            text: 'List item 1.1',
           },
         ],
       },

--- a/packages/serializer-md/src/deserializer/utils/deserializeMd.ts
+++ b/packages/serializer-md/src/deserializer/utils/deserializeMd.ts
@@ -14,10 +14,10 @@ export const deserializeMd = <V extends Value>(
   editor: PlateEditor<V>,
   data: string
 ) => {
-  const { elementRules, textRules } = getPluginOptions<DeserializeMdPlugin, V>(
-    editor,
-    KEY_DESERIALIZE_MD
-  );
+  const { elementRules, textRules, indentList } = getPluginOptions<
+    DeserializeMdPlugin,
+    V
+  >(editor, KEY_DESERIALIZE_MD);
 
   const tree: any = unified()
     .use(markdown)
@@ -25,6 +25,7 @@ export const deserializeMd = <V extends Value>(
       editor,
       elementRules,
       textRules,
+      indentList,
     } as unknown as RemarkPluginOptions<V>)
     .processSync(data);
 

--- a/packages/serializer-md/src/remark-slate/types.ts
+++ b/packages/serializer-md/src/remark-slate/types.ts
@@ -62,4 +62,5 @@ export type RemarkPluginOptions<V extends Value> = {
   editor: PlateEditor<V>;
   elementRules: RemarkElementRules<V>;
   textRules: RemarkTextRules<V>;
+  indentList?: boolean;
 };

--- a/packages/utils/src/types/types.ts
+++ b/packages/utils/src/types/types.ts
@@ -38,8 +38,8 @@ export type ModifyDeep<A extends AnyObject, B extends DeepPartialAny<A>> = {
   [K in keyof A]: B[K] extends never
     ? A[K]
     : B[K] extends AnyObject
-    ? ModifyDeep<A[K], B[K]>
-    : B[K];
+      ? ModifyDeep<A[K], B[K]>
+      : B[K];
 } & (A extends AnyObject ? Omit<B, keyof A> : A);
 
 export type PartialPick<T, K extends keyof T> = {


### PR DESCRIPTION
The `indentList` option handles markdown conversion of ordered and unordered lists when the indentList plugin is being used

See changesets.

Fixes MD deserialization compatibility with IndentList plugin

Testing:
- Unit tests added
- Tested on playground (by modifying plugin options locally)

Before

https://github.com/udecode/plate/assets/16997807/a2f9cd79-3622-4f9b-a058-6ca50e23e486


After

https://github.com/udecode/plate/assets/16997807/c16cc7d2-1f32-4843-926b-b0a049b260ef


