### PR TITLE
fix: remove value from ToolbarButton props

### DIFF
--- a/templates/plate-playground-template/src/components/plate-ui/toolbar.tsx
+++ b/templates/plate-playground-template/src/components/plate-ui/toolbar.tsx
@@ -37,8 +37,8 @@ export const ToolbarSeparator = withCn(
 );
 
 export const ToolbarButton = withRef<
-  typeof ToolbarPrimitive.Button,
-  Omit<ComponentPropsWithoutRef<typeof Toggle>, 'type'> & {
+  React.ComponentType<Omit<typeof ToolbarPrimitive.Button, 'value'>>,
+  Omit<ComponentPropsWithoutRef<typeof Toggle>, 'type' | 'value'> & {
     buttonType?: 'button' | 'toggle';
     pressed?: boolean;
     tooltip?: ReactNode;
@@ -53,7 +53,6 @@ export const ToolbarButton = withRef<
       isDropdown,
       children,
       pressed,
-      value,
       tooltip,
       ...props
     },


### PR DESCRIPTION
**Description**

Remove unused value props form ToolbarButton props type.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
Fixes #2711
