### PR TITLE
fix: remove value from ToolbarButton props

### DIFF
--- a/templates/plate-playground-template/src/components/plate-ui/toolbar.tsx
+++ b/templates/plate-playground-template/src/components/plate-ui/toolbar.tsx
@@ -37,8 +37,10 @@ export const ToolbarSeparator = withCn(
 );
 
 export const ToolbarButton = withRef<
-  typeof ToolbarPrimitive.Button,
-  Omit<ComponentPropsWithoutRef<typeof Toggle>, 'type'> & {
+  React.ExoticComponent<
+    Omit<React.ComponentProps<typeof ToolbarPrimitive.Button>, 'value'>
+  >,
+  Omit<ComponentPropsWithoutRef<typeof Toggle>, 'type' | 'value'> & {
     buttonType?: 'button' | 'toggle';
     pressed?: boolean;
     tooltip?: ReactNode;
@@ -53,7 +55,6 @@ export const ToolbarButton = withRef<
       isDropdown,
       children,
       pressed,
-      value,
       tooltip,
       ...props
     },


### PR DESCRIPTION
**Description**

Remove unused value props form ToolbarButton props type.

Fixes https://github.com/udecode/plate/issues/2711
