### PR TITLE
fix plate store id with editor prop

### DIFF
--- a/.changeset/six-papayas-tan.md
+++ b/.changeset/six-papayas-tan.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-core": patch
+---
+
+fix plate store id when plate use the editor prop.

--- a/packages/core/src/components/Plate.spec.tsx
+++ b/packages/core/src/components/Plate.spec.tsx
@@ -236,6 +236,21 @@ describe('Plate', () => {
         expect(result.current).toBe('test');
       });
     });
+
+    describe('when Plate has an editor', () => {
+      it('should be editor id', async () => {
+        const editor = createPlateEditor({ id: 'test' });
+
+        const wrapper = ({ children }: any) => (
+          <Plate editor={editor}>{children}</Plate>
+        );
+        const { result } = renderHook(() => usePlateSelectors().id(), {
+          wrapper,
+        });
+
+        expect(result.current).toBe('test');
+      });
+    });
   });
 
   describe('usePlateEditorStore', () => {
@@ -249,14 +264,29 @@ describe('Plate', () => {
       renderHook(() => useEditorRef().isFallback, { wrapper }).result.current;
 
     describe('when Plate exists', () => {
-      it('returns the store', () => {
-        const wrapper = ({ children }: any) => (
-          <Plate id="test">{children}</Plate>
-        );
+      describe('when editor is defined', () => {
+        it('returns the store', async () => {
+          const editor = createPlateEditor({ id: 'test' });
 
-        expect(getStore(wrapper)).toBeDefined();
-        expect(getId(wrapper)).toBe('test');
-        expect(getIsFallback(wrapper)).toBe(false);
+          const wrapper = ({ children }: any) => (
+            <Plate editor={editor}>{children}</Plate>
+          );
+          expect(getStore(wrapper)).toBeDefined();
+          expect(getId(wrapper)).toBe('test');
+          expect(getIsFallback(wrapper)).toBe(false);
+        });
+      });
+
+      describe('when editor is not defined', () => {
+        it('returns the store', () => {
+          const wrapper = ({ children }: any) => (
+            <Plate id="test">{children}</Plate>
+          );
+
+          expect(getStore(wrapper)).toBeDefined();
+          expect(getId(wrapper)).toBe('test');
+          expect(getIsFallback(wrapper)).toBe(false);
+        });
       });
     });
 

--- a/packages/core/src/components/Plate.tsx
+++ b/packages/core/src/components/Plate.tsx
@@ -98,7 +98,7 @@ function PlateInner<
   primary,
   maxLength,
 }: PlateProps<V, E>) {
-  const [id] = React.useState(() => idProp ?? nanoid());
+  const [id] = React.useState(() => editorProp?.id ?? idProp ?? nanoid());
 
   const editor: E = React.useMemo(
     () =>


### PR DESCRIPTION
**Description**

When we use the `editor` prop to instantiate Plate, we have a desynchronization  between the `editor` id and the id in the plate store.

Plugin like `Mention` can't work because we check the `editorId` and the `focusedEditorId`:

```ts
const focusedEditorId = useEventEditorSelectors.focus?.() // undefined
const editorId = usePlateSelectors().id()

if (
  focusedEditorId !== editorId
) {
  return null
}
```

Without this fix, we need to set the editor id and the plate id with the same value:

```tsx
const editor = createPlateEditor({
  id: 'test',
})

return (
  <Plate id="test" editor={editor}>
    // ...
  </Plate>
)
```

<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

