### PR TITLE
bugfix: Empty list item Md deserialization error

### DIFF
--- a/packages/serializer-md/src/deserializer/utils/deserializeMd.spec.tsx
+++ b/packages/serializer-md/src/deserializer/utils/deserializeMd.spec.tsx
@@ -397,4 +397,29 @@ describe('deserializeMdIndentList', () => {
 
     expect(deserializeMd(editor, input)).toEqual(output);
   });
+
+  it('should deserialize an empty list item', () => {
+    const input = '* Line 1\n*';
+
+    const output = [
+      {
+        type: 'p',
+        listStyleType: 'disc',
+        indent: 1,
+        children: [
+          {
+            text: 'Line 1',
+          },
+        ],
+      },
+      {
+        type: 'p',
+        listStyleType: 'disc',
+        indent: 1,
+        children: [],
+      },
+    ];
+
+    expect(deserializeMd(editor, input)).toEqual(output);
+  });
 });

--- a/packages/serializer-md/src/remark-slate/remarkDefaultElementRules.ts
+++ b/packages/serializer-md/src/remark-slate/remarkDefaultElementRules.ts
@@ -68,7 +68,10 @@ export const remarkDefaultElementRules: RemarkElementRules<Value> = {
               type: getPluginType(options.editor, ELEMENT_PARAGRAPH),
               listStyleType,
               indent,
-              children: remarkTransformElementChildren(paragraph, options),
+              children: remarkTransformElementChildren(
+                paragraph || '',
+                options
+              ),
             });
 
             subLists.forEach((subList) => {


### PR DESCRIPTION
Deserializing an empty list item in an indentList raised an error

For no children, this line would result in an `undefined` paragraph

```ts
const [paragraph, ...subLists] = listItem.children!;
```

Causing the subsequent conversion to fail.
 
Example:
```md
- Item 1
- 
```` 

