### PR TITLE
Update `lodash.last` import in `getLastEntryEnclosedInToggle.ts`

### DIFF
--- a/.changeset/shiny-steaks-whisper.md
+++ b/.changeset/shiny-steaks-whisper.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-toggle": patch
+---
+
+Fix `lodash.last` import

--- a/packages/toggle/src/queries/getLastEntryEnclosedInToggle.ts
+++ b/packages/toggle/src/queries/getLastEntryEnclosedInToggle.ts
@@ -1,5 +1,5 @@
 import { PlateEditor, TNodeEntry, Value } from '@udecode/plate-common';
-import last from 'lodash/last';
+import last from 'lodash/last.js';
 
 import { buildToggleIndex } from '../toggle-controller-store';
 


### PR DESCRIPTION
Error while importing from `@udecode/plate-toggle`

Module not found: Error: Can't resolve 'lodash/last' in '/app/node_modules/@udecode/plate-toggle/dist' Did you mean 'last.js'?
BREAKING CHANGE: The request 'lodash/last' failed to resolve only because it was resolved as fully specified (probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"'). The extension in the request is mandatory for it to be fully specified. Add the extension to the request.
