### PR TITLE
Fix todo list doc path

### DIFF
--- a/apps/www/src/config/customizer-plugins.ts
+++ b/apps/www/src/config/customizer-plugins.ts
@@ -330,7 +330,7 @@ export const customizerPlugins = {
     id: 'todoli',
     label: 'Todo List',
     value: todoListValue,
-    route: '/docs/todo-list',
+    route: '/docs/list',
     plugins: [ELEMENT_TODO_LI],
   },
   toggle: {


### PR DESCRIPTION
`docs/todo-list` gives a 404, the doc for the todo list in under `docs/list`