### PR TITLE
Fix bun install command for install docs

### DIFF
--- a/apps/www/src/app/_components/installation-code.tsx
+++ b/apps/www/src/app/_components/installation-code.tsx
@@ -39,7 +39,7 @@ export function InstallationCode({
               __npmCommand__: code,
               __pnpmCommand__: code.replaceAll('npm install', 'pnpm add'),
               __yarnCommand__: code.replaceAll('npm install', 'yarn add'),
-              __bunCommand__: code.replaceAll('npm install', 'yarn add'),
+              __bunCommand__: code.replaceAll('npm install', 'bun add'),
             }}
             className={cn('absolute right-4 top-4')}
           />


### PR DESCRIPTION
**Description**
Very very small PR (one word command change!).

See changesets.

<!-- A clear and concise description of what this pull request solves. -->
Copying the install command for bun (provided through `copy-button.tsx`) populates the command with `yarn add` as currently deployed. This command changes that to `bun add` to avoid that small friction/inconsistency with the rest of the commands as the rest are configured as expected.

As far as I can tell this is the only instance of `__bunCommand__` that's not properly updated! I did a big `CMD + F` in VS Code and the install command seems to be the only `bun` command that's affected.
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

