### PR TITLE
Fix: Mention input removed when clicking mention combobox scrollbar

### DIFF
--- a/apps/www/content/docs/components/changelog.mdx
+++ b/apps/www/content/docs/components/changelog.mdx
@@ -8,6 +8,13 @@ Since Plate UI is not a component library, a changelog is maintained here.
 
 Use the [CLI](https://platejs.org/docs/components/cli) to install the latest version of the components.
 
+## February 2025 #8
+
+### February 5 #8.1
+
+- Fix:  Mention input removed when clicking mention combobox scrollbar
+([#2919](https://github.com/udecode/plate/issues/2919))
+
 ## January 2024 #7
 
 ### January 31 #7.5

--- a/apps/www/src/registry/default/plate-ui/mention-combobox.tsx
+++ b/apps/www/src/registry/default/plate-ui/mention-combobox.tsx
@@ -21,14 +21,16 @@ export function MentionCombobox({
   const { trigger } = getPluginOptions<MentionPlugin>(editor, pluginKey);
 
   return (
-    <Combobox
-      id={id}
-      trigger={trigger!}
-      controlled
-      onSelectItem={getMentionOnSelectItem({
-        key: pluginKey,
-      })}
-      {...props}
-    />
+    <div onMouseDown={(e) => e.preventDefault()}>
+      <Combobox
+        id={id}
+        trigger={trigger!}
+        controlled
+        onSelectItem={getMentionOnSelectItem({
+          key: pluginKey,
+        })}
+        {...props}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
**Description**

See changelog.

Fixes #2919.