### PR TITLE
Fixed playground subscript & superscript buttons

### DIFF
--- a/apps/www/src/components/plate-ui/playground-more-dropdown-menu.tsx
+++ b/apps/www/src/components/plate-ui/playground-more-dropdown-menu.tsx
@@ -65,8 +65,8 @@ export function PlaygroundMoreDropdownMenu(props: DropdownMenuProps) {
         <DropdownMenuItem
           onSelect={() => {
             toggleMark(editor, {
-              key: MARK_SUBSCRIPT,
-              clear: MARK_SUPERSCRIPT,
+              key: MARK_SUPERSCRIPT,
+              clear: MARK_SUBSCRIPT,
             });
             focusEditor(editor);
           }}
@@ -78,8 +78,8 @@ export function PlaygroundMoreDropdownMenu(props: DropdownMenuProps) {
         <DropdownMenuItem
           onSelect={() => {
             toggleMark(editor, {
-              key: MARK_SUPERSCRIPT,
-              clear: MARK_SUBSCRIPT,
+              key: MARK_SUBSCRIPT,
+              clear: MARK_SUPERSCRIPT,
             });
             focusEditor(editor);
           }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6884,7 +6884,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-suggestion@npm:30.4.1, @udecode/plate-suggestion@workspace:^, @udecode/plate-suggestion@workspace:packages/suggestion":
+"@udecode/plate-suggestion@npm:30.4.3, @udecode/plate-suggestion@workspace:^, @udecode/plate-suggestion@workspace:packages/suggestion":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-suggestion@workspace:packages/suggestion"
   dependencies:
@@ -7083,7 +7083,7 @@ __metadata:
     "@udecode/plate-serializer-docx": "npm:30.1.2"
     "@udecode/plate-serializer-html": "npm:30.1.2"
     "@udecode/plate-serializer-md": "npm:30.2.1"
-    "@udecode/plate-suggestion": "npm:30.4.1"
+    "@udecode/plate-suggestion": "npm:30.4.3"
     "@udecode/plate-tabbable": "npm:30.1.2"
     "@udecode/plate-table": "npm:30.1.2"
     "@udecode/plate-toggle": "npm:30.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6884,7 +6884,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-suggestion@npm:30.4.3, @udecode/plate-suggestion@workspace:^, @udecode/plate-suggestion@workspace:packages/suggestion":
+"@udecode/plate-suggestion@npm:30.4.1, @udecode/plate-suggestion@workspace:^, @udecode/plate-suggestion@workspace:packages/suggestion":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-suggestion@workspace:packages/suggestion"
   dependencies:
@@ -7083,7 +7083,7 @@ __metadata:
     "@udecode/plate-serializer-docx": "npm:30.1.2"
     "@udecode/plate-serializer-html": "npm:30.1.2"
     "@udecode/plate-serializer-md": "npm:30.2.1"
-    "@udecode/plate-suggestion": "npm:30.4.3"
+    "@udecode/plate-suggestion": "npm:30.4.1"
     "@udecode/plate-tabbable": "npm:30.1.2"
     "@udecode/plate-table": "npm:30.1.2"
     "@udecode/plate-toggle": "npm:30.3.2"


### PR DESCRIPTION
# Fix to Issue 2925

**Description**

Small fix to https://github.com/udecode/plate/issues/2925 where the subscript and superscript buttons were swapped around.


Old:

https://github.com/udecode/plate/assets/55113649/ccdeb4c2-f4bc-43a1-9e2a-3e9a2fdd6224

Fixed:

https://github.com/udecode/plate/assets/55113649/cbe646b3-e32d-43c8-b813-136250130ffd


