### PR TITLE
UPDATE image-element.tsx: fixed #2574

### DIFF
--- a/apps/www/src/registry/default/plate-ui/image-element.tsx
+++ b/apps/www/src/registry/default/plate-ui/image-element.tsx
@@ -26,40 +26,56 @@ export const ImageElement = withHOC(
             className={cn('py-2.5', className)}
             {...props}
           >
-            <figure className="group relative m-0" contentEditable={false}>
-              <Resizable
-                align={align}
-                options={{
-                  align,
-                  readOnly,
-                }}
-              >
-                <ResizeHandle
-                  options={{ direction: 'left' }}
-                  className={mediaResizeHandleVariants({ direction: 'left' })}
-                />
-                <Image
-                  className={cn(
-                    'block w-full max-w-full cursor-pointer object-cover px-0',
-                    'rounded-sm',
-                    focused && selected && 'ring-2 ring-ring ring-offset-2'
-                  )}
-                  alt=""
-                  {...nodeProps}
-                />
-                <ResizeHandle
-                  options={{ direction: 'right' }}
-                  className={mediaResizeHandleVariants({ direction: 'right' })}
-                />
-              </Resizable>
+            {!readOnly && (
+              <figure className="group relative m-0" contentEditable={false}>
+                <Resizable
+                  align={align}
+                  options={{
+                    align,
+                    readOnly,
+                  }}
+                >
+                  <ResizeHandle
+                    options={{ direction: 'left' }}
+                    className={mediaResizeHandleVariants({ direction: 'left' })}
+                  />
+                  <Image
+                    className={cn(
+                      'block w-full max-w-full cursor-pointer object-cover px-0',
+                      'rounded-sm',
+                      focused && selected && 'ring-2 ring-ring ring-offset-2',
+                    )}
+                    alt=""
+                    {...nodeProps}
+                  />
+                  <ResizeHandle
+                    options={{ direction: 'right' }}
+                    className={mediaResizeHandleVariants({
+                      direction: 'right',
+                    })}
+                  />
+                </Resizable>
 
-              <Caption align={align} style={{ width }}>
-                <CaptionTextarea
-                  placeholder="Write a caption..."
-                  readOnly={readOnly}
-                />
-              </Caption>
-            </figure>
+                <Caption align={align} style={{ width }}>
+                  <CaptionTextarea
+                    placeholder="Write a caption..."
+                    readOnly={readOnly}
+                  />
+                </Caption>
+              </figure>
+            )}
+
+            {readOnly && (
+              <Image
+                className={cn(
+                  'block w-full max-w-full object-cover px-0',
+                  'rounded-sm',
+                  focused && selected && 'ring-2 ring-ring ring-offset-2',
+                )}
+                alt=""
+                {...nodeProps}
+              />
+            )}
 
             {children}
           </PlateElement>


### PR DESCRIPTION
**Description**
Added wrapper for `readOnly`, so the image will not be resizable in preview mode (`readOnly`).

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

