### PR TITLE
[serialize-html] Fix handling of empty `preserveClassNames` array

### DIFF
--- a/.changeset/beige-kids-suffer.md
+++ b/.changeset/beige-kids-suffer.md
@@ -1,0 +1,8 @@
+---
+"@udecode/plate-serializer-html": patch
+---
+
+- Fix handling of empty `preserveClassNames` array
+  - Previously, would output `<div class="                 ">`
+  - Now, it outputs `<div>`
+- Reduce time complexity of `stripClassNames` function

--- a/packages/serializer-html/src/__tests__/serializeHtml/classNames.spec.ts
+++ b/packages/serializer-html/src/__tests__/serializeHtml/classNames.spec.ts
@@ -24,6 +24,23 @@ it('serialize with slate className', () => {
   ).toBe('<div class="slate-p">I am centered text!</div>');
 });
 
+it('serialize with without modifying content', () => {
+  const editor = createPlateUIEditor({
+    plugins: [createParagraphPlugin()],
+  });
+
+  expect(
+    serializeHtml(editor, {
+      nodes: [
+        {
+          type: ELEMENT_PARAGRAPH,
+          children: [{ text: 'I am class="preserved" text!' }],
+        },
+      ],
+    })
+  ).toBe('<div class="slate-p">I am class=&quot;preserved&quot; text!</div>');
+});
+
 it('serialize with slate classNames: a+slate', () => {
   const editor = createPlateUIEditor({
     plugins: [
@@ -169,6 +186,30 @@ it('serialize with custom preserved classname: a+custom', () => {
       preserveClassNames: ['custom-'],
     })
   ).toBe('<div class="custom-align-center">I am centered text!</div>');
+});
+
+it('serialize without preserving classnames', () => {
+  const editor = createPlateUIEditor({
+    plugins: [
+      createParagraphPlugin({
+        props: {
+          className: 'a custom-align-center slate-test',
+        },
+      }),
+    ],
+  });
+
+  expect(
+    serializeHtml(editor, {
+      nodes: [
+        {
+          type: ELEMENT_PARAGRAPH,
+          children: [{ text: 'I am centered text!' }],
+        },
+      ],
+      preserveClassNames: [],
+    })
+  ).toBe('<div>I am centered text!</div>');
 });
 
 it('serialize nested with custom preserved classname: a+custom', () => {

--- a/packages/serializer-html/src/utils/stripClassNames.ts
+++ b/packages/serializer-html/src/utils/stripClassNames.ts
@@ -1,26 +1,27 @@
+const classAttrRegExp = / class="([^"]*)"/g;
 /**
  * Remove all class names that do not start with one of preserveClassNames (`slate-` by default)
  */
 export const stripClassNames = (
   html: string,
-  { preserveClassNames = ['slate-'] }: { preserveClassNames?: string[] }
+  { preserveClassNames = ['slate-'] }: { preserveClassNames?: string[] },
 ) => {
-  const allClasses = html.split(/(class="[^"]*")/g);
+  if (preserveClassNames.length === 0) {
+    return html.replaceAll(classAttrRegExp, '');
+  }
 
-  let filteredHtml = '';
-  allClasses.forEach((item, index) => {
-    if (index % 2 === 0) {
-      return (filteredHtml += item);
-    }
-    const preserveRegExp = new RegExp(
-      preserveClassNames.map((cn) => `${cn}[^"\\s]*`).join('|'),
-      'g'
-    );
-    const classNames = item.split('"')[1].match(preserveRegExp);
-    if (classNames) {
-      filteredHtml += `class="${classNames.join(' ')}"`;
-    }
-  });
+  const preserveRegExp = new RegExp(
+    preserveClassNames.map((cn) => `^${cn}`).join('|')
+  );
 
-  return filteredHtml;
+  return html.replaceAll(classAttrRegExp, (match: string, className: string) => {
+      const classesToKeep = className
+        .split(/\s+/)
+        .filter((cn) => preserveRegExp.test(cn));
+
+      return classesToKeep.length === 0
+        ? ''
+        : ` class="${classesToKeep.join(' ')}"`;
+    }
+  );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6884,7 +6884,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-suggestion@npm:30.4.1, @udecode/plate-suggestion@workspace:^, @udecode/plate-suggestion@workspace:packages/suggestion":
+"@udecode/plate-suggestion@npm:30.4.3, @udecode/plate-suggestion@workspace:^, @udecode/plate-suggestion@workspace:packages/suggestion":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-suggestion@workspace:packages/suggestion"
   dependencies:
@@ -7083,7 +7083,7 @@ __metadata:
     "@udecode/plate-serializer-docx": "npm:30.1.2"
     "@udecode/plate-serializer-html": "npm:30.1.2"
     "@udecode/plate-serializer-md": "npm:30.2.1"
-    "@udecode/plate-suggestion": "npm:30.4.1"
+    "@udecode/plate-suggestion": "npm:30.4.3"
     "@udecode/plate-tabbable": "npm:30.1.2"
     "@udecode/plate-table": "npm:30.1.2"
     "@udecode/plate-toggle": "npm:30.3.2"


### PR DESCRIPTION
**Description**

See changesets.

- Fix handling of empty `preserveClassNames` array
  - Previously, would output `<div class="                 ">`
  - Now, it outputs `<div>`
- Reduce time complexity of `stripClassNames` function
- Simplify RegEx patterns
- Add a test case to ensure content doesn't get replaced
