### PR TITLE
fix: add assertion on emoji-mart data for ESM mode

### DIFF
--- a/.changeset/old-numbers-ring.md
+++ b/.changeset/old-numbers-ring.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-emoji": patch
+---
+
+fix: add assertion as JSON on emoji mart data so it can be read in ESM

--- a/packages/emoji/src/utils/EmojiLibrary/EmojiFloatingLibrary.ts
+++ b/packages/emoji/src/utils/EmojiLibrary/EmojiFloatingLibrary.ts
@@ -1,4 +1,4 @@
-import emojiMartData from '@emoji-mart/data';
+import emojiMartData from '@emoji-mart/data' assert { type: 'json' };
 
 import { defaultCategories } from '../../constants';
 import {

--- a/packages/emoji/src/utils/EmojiLibrary/EmojiInlineLibrary.ts
+++ b/packages/emoji/src/utils/EmojiLibrary/EmojiInlineLibrary.ts
@@ -1,4 +1,4 @@
-import emojiMartData from '@emoji-mart/data';
+import emojiMartData from '@emoji-mart/data' assert { type: 'json' };
 
 import {
   Emoji,


### PR DESCRIPTION
**Description**

Allows testing with Vitest in full ESM mode, otherwise we get: 
```
TypeError: Module "file:///[...]/node_modules/.pnpm/@emoji-mart+data@1.1.2/node_modules/@emoji-mart/data/sets/14/native.json" needs an import attribute of type "json"
```


