### PR TITLE
fix: Doc missing 'options' for autoFormatPlugin

### DIFF
--- a/apps/www/content/docs/autoformat.mdx
+++ b/apps/www/content/docs/autoformat.mdx
@@ -47,8 +47,10 @@ import { createAutoformatPlugin } from '@udecode/plate-autoformat';
 const plugins = [
   // ...otherPlugins,
   createAutoformatPlugin({
-    rules: autoformatRules,
-    enableUndoOnDelete: true,
+    options : {
+      rules: autoformatRules,
+      enableUndoOnDelete: true,
+    },
   }),
 ];
 ```

--- a/apps/www/content/docs/autoformat.mdx
+++ b/apps/www/content/docs/autoformat.mdx
@@ -47,7 +47,7 @@ import { createAutoformatPlugin } from '@udecode/plate-autoformat';
 const plugins = [
   // ...otherPlugins,
   createAutoformatPlugin({
-    options : {
+    options: {
       rules: autoformatRules,
       enableUndoOnDelete: true,
     },


### PR DESCRIPTION
**Description**

See changesets.

Adding options to the autoFormatPlugin

Problems: 
![image](https://github.com/udecode/plate/assets/125646707/de07e63e-e066-4fec-8df8-a487e10c0987)
 
Real implementation will have typescript error saying `Object literal may only specify known properties, ...`

Fixed by adding: 

## Usage

```tsx
import { createAutoformatPlugin } from '@udecode/plate-autoformat';

const plugins = [
  // ...otherPlugins,
  createAutoformatPlugin({
    options: {
      rules: autoformatRules,
      enableUndoOnDelete: true,
    },
  }),
];
```

<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

