### PR TITLE
fix: relative 'import' caption in doc

### DIFF
--- a/apps/www/content/docs/caption.mdx
+++ b/apps/www/content/docs/caption.mdx
@@ -25,7 +25,7 @@ npm install @udecode/plate-caption
 ## Usage
 
 ```tsx
-import { createCaptionPlugin } from './createCaptionPlugin';
+import { createCaptionPlugin } from '@udecode/plate-caption';
 
 const plugins = [
   // ...otherPlugins,


### PR DESCRIPTION
**Description**

See changesets.

This is just one line change to the doc of `createCaptionPlugin`, and it does not seem to be much of the problem here. However, IMO, I would like to keep as consistent and should be intuitive .

Change:
```
import { createCaptionPlugin } from './createCaptionPlugin';
```

Modified
```
import { createCaptionPlugin } from '@udecode/plate-caption';
```
