### PR TITLE
Set "not found" value to -1 instead of 0 for colIndex

### DIFF
--- a/.changeset/fuzzy-beds-tie.md
+++ b/.changeset/fuzzy-beds-tie.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-table": patch
+---
+
+Set "not found" value to -1 instead of 0 for colIndex

--- a/packages/table/src/queries/getTableColumnIndex.ts
+++ b/packages/table/src/queries/getTableColumnIndex.ts
@@ -14,12 +14,12 @@ export const getTableColumnIndex = <V extends Value>(
   cellNode: TElement
 ) => {
   const path = findNodePath(editor, cellNode);
-  if (!path) return 0;
+  if (!path) return -1;
 
   const [trNode] = getParentNode(editor, path) ?? [];
-  if (!trNode) return 0;
+  if (!trNode) return -1;
 
-  let colIndex = 0;
+  let colIndex = -1;
 
   trNode.children.some((item, index) => {
     if (item === cellNode) {


### PR DESCRIPTION
If nothing exists, set colIndex to -1 instead of 0 so that we can discern from a "not found" and an actual index 0 value.

**Description**
For PlateJS tables, we use this code:

```
const { colIndex, rowIndex, readOnly, selected, hovered, hoveredLeft, rowSize, borders, isSelectingCell, colSpan } =
    useTableCellElementState();
```

to grab the colIndex and rowIndex.

However, I'm finding that with the right memoizations, when the editor refreshes, `colIndex` is briefly set to 0 before it's set back to the expected value.

There's no way to discern the "not found" value and the actual index 0 value.
