### PR TITLE
fix: make editor div relative to fix DnD

### DIFF
--- a/templates/plate-playground-template/src/components/plate-editor.tsx
+++ b/templates/plate-playground-template/src/components/plate-editor.tsx
@@ -38,6 +38,7 @@ export default function PlateEditor() {
           <div
             ref={containerRef}
             className={cn(
+              'relative',
               // Block selection
               '[&_.slate-start-area-left]:!w-[64px] [&_.slate-start-area-right]:!w-[64px] [&_.slate-start-area-top]:!h-4'
             )}


### PR DESCRIPTION
**Description**
As discussed in issue https://github.com/udecode/plate/issues/2993 and in discord, the editor should be placed in a `relative` div so that DnD adjusts the cursor overlay position accordingly.
<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

