### PR TITLE
Toggle > injectToggle.tsx > Make hidden elements overflow hidden to account for inner elements with a vertical margin

### DIFF
--- a/.changeset/witty-vans-lick.md
+++ b/.changeset/witty-vans-lick.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-toggle": patch
+---
+
+`injectToggle`: Make hidden elements overflow hidden to account for inner elements with a vertical margin

--- a/packages/toggle/src/injectToggle.tsx
+++ b/packages/toggle/src/injectToggle.tsx
@@ -17,4 +17,5 @@ const hiddenStyle: React.CSSProperties = {
   visibility: 'hidden',
   height: 0,
   margin: 0,
+  overflow: 'hidden',
 };


### PR DESCRIPTION
An element hidden by a toggle can still take some vertical space if an inner element has a vertical margin. This PR addresses this issue