### PR TITLE
Hotfix: reset cell entries list when table is overflown

### DIFF
--- a/.changeset/chatty-flowers-move.md
+++ b/.changeset/chatty-flowers-move.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-table": patch
+---
+
+Hotfix: reset cell entries list when table is overflown

--- a/packages/table/src/merge/getTableGridByRange.ts
+++ b/packages/table/src/merge/getTableGridByRange.ts
@@ -106,7 +106,7 @@ export const getTableMergeGridByRange = <T extends FormatType, V extends Value>(
     newCellChildren: [],
   });
 
-  const cellEntries: TElementEntry[] = [];
+  let cellEntries: TElementEntry[] = [];
   let cellsSet = new WeakSet();
 
   let rowIndex = startRowIndex;
@@ -137,6 +137,7 @@ export const getTableMergeGridByRange = <T extends FormatType, V extends Value>(
     ) {
       // reset the cycle if has overflow
       cellsSet = new WeakSet();
+      cellEntries = [];
       startRowIndex = Math.min(startRowIndex, cellRow);
       endRowIndex = Math.max(endRowIndex, cellRowWithSpan);
       startColIndex = Math.min(startColIndex, cellCol);


### PR DESCRIPTION
**Description**

In PR https://github.com/udecode/plate/pull/3029 I forgot to reset `cellEntries` array. It leads to unexpected errors when merging cells in a few corner cases.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

