### PR TITLE
Fix: CVE-2023-26140

### DIFF
--- a/.changeset/eighty-monkeys-poke.md
+++ b/.changeset/eighty-monkeys-poke.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-excalidraw": minor
+---
+
+Fix: CVE-2023-26140

--- a/packages/excalidraw/package.json
+++ b/packages/excalidraw/package.json
@@ -39,7 +39,7 @@
     "typecheck": "yarn p:typecheck"
   },
   "dependencies": {
-    "@excalidraw/excalidraw": "0.12.0"
+    "@excalidraw/excalidraw": "0.16.0"
   },
   "devDependencies": {
     "@udecode/plate-common": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2012,15 +2012,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@excalidraw/excalidraw@npm:0.12.0":
-  version: 0.12.0
-  resolution: "@excalidraw/excalidraw@npm:0.12.0"
-  dependencies:
-    dotenv: "npm:10.0.0"
+"@excalidraw/excalidraw@npm:0.16.0":
+  version: 0.16.0
+  resolution: "@excalidraw/excalidraw@npm:0.16.0"
   peerDependencies:
-    react: ^17.0.2
-    react-dom: ^17.0.2
-  checksum: 10c0/d4c456ed97ef64c64467ca1501022e66f34cadddab20809fa2ae860d60d255b9108a0f9ceacac31a04c7bbb319ad399110b1331f8ca895438adb606e985b2dfd
+    react: ^17.0.2 || ^18.2.0
+    react-dom: ^17.0.2 || ^18.2.0
+  checksum: 10c0/59411d5c1b7516eb17b471f8395704df0ec7f4d67337de5bb2dffc785839d26251e86b3078769f6ead4e95c14e79a26e71ddd3369b9808e24bdd469249f1a031
   languageName: node
   linkType: hard
 
@@ -6601,7 +6599,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@udecode/plate-excalidraw@workspace:packages/excalidraw"
   dependencies:
-    "@excalidraw/excalidraw": "npm:0.12.0"
+    "@excalidraw/excalidraw": "npm:0.16.0"
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
     "@udecode/plate-common": ">=31.0.0"
@@ -9944,13 +9942,6 @@ __metadata:
   dependencies:
     is-obj: "npm:^2.0.0"
   checksum: 10c0/30e51ec6408978a6951b21e7bc4938aad01a86f2fdf779efe52330205c6bb8a8ea12f35925c2029d6dc9d1df22f916f32f828ce1e9b259b1371c580541c22b5a
-  languageName: node
-  linkType: hard
-
-"dotenv@npm:10.0.0":
-  version: 10.0.0
-  resolution: "dotenv@npm:10.0.0"
-  checksum: 10c0/2d8d4ba64bfaff7931402aa5e8cbb8eba0acbc99fe9ae442300199af021079eafa7171ce90e150821a5cb3d74f0057721fbe7ec201a6044b68c8a7615f8c123f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Description**

This commit fixes a potential XSS vulnerability in the `@udecode/plate-excalidraw` package by updating the `@excalidraw/excalidraw` dependency to version `0.16.0`.

Security Advisory: https://github.com/advisories/GHSA-v7v8-gjv7-ffmr
Snyk Report: https://security.snyk.io/vuln/SNYK-JS-EXCALIDRAWEXCALIDRAW-5841658

Patches for `@excalidraw/excalidraw` were introduced in version `0.15.3`; however, as advised by the Snyk Report, I've updated it to version `0.16.0`.