### PR TITLE
[SerializerHtml] Remove `renderToStaticMarkup` from client code

### DIFF
--- a/.changeset/purple-pens-share.md
+++ b/.changeset/purple-pens-share.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-serializer-html": patch
+---
+
+`serialzieHtml`: remove `renderToStaticMarkup` from client code

--- a/packages/serializer-html/src/__tests__/serializeHtml/elements.spec.ts
+++ b/packages/serializer-html/src/__tests__/serializeHtml/elements.spec.ts
@@ -248,7 +248,7 @@ it('serialize align style to html', () => {
       ],
     })
   ).toBe(
-    '<div class="slate-p slate-align-center" style="text-align:center">I am centered text!</div>'
+    '<div class="slate-p slate-align-center" style="text-align: center;">I am centered text!</div>'
   );
 });
 
@@ -275,7 +275,7 @@ it('serialize align className to html', () => {
       ],
     })
   ).toBe(
-    '<div class="slate-p slate-align-center" style="text-align:center">I am centered text!</div>'
+    '<div class="slate-p slate-align-center" style="text-align: center;">I am centered text!</div>'
   );
 });
 

--- a/packages/serializer-html/src/__tests__/serializeHtml/with-useEditor.spec.ts
+++ b/packages/serializer-html/src/__tests__/serializeHtml/with-useEditor.spec.ts
@@ -3,6 +3,7 @@ import {
   createTodoListPlugin,
   ELEMENT_LI,
   ELEMENT_LIC,
+  ELEMENT_TODO_LI,
   ELEMENT_UL,
 } from '@udecode/plate-list';
 import { createPlateUIEditor } from 'www/src/lib/plate/create-plate-ui-editor';
@@ -30,7 +31,7 @@ it('serialize elements using useSlateStatic', () => {
   const render = serializeHtml(editor, {
     nodes: [
       {
-        type: 'action_item',
+        type: ELEMENT_TODO_LI,
         checked: true,
         children: [{ text: 'Slide to the right.' }],
       },
@@ -51,5 +52,5 @@ it('serialize elements using useSlateStatic', () => {
     ],
   });
 
-  expect(render).toContain('input type="checkbox"');
+  expect(render).toContain('type="button" role="checkbox"');
 });

--- a/packages/serializer-html/src/elementToHtml.ts
+++ b/packages/serializer-html/src/elementToHtml.ts
@@ -8,9 +8,9 @@ import {
   Value,
 } from '@udecode/plate-common';
 import { decode } from 'html-entities';
-import { renderToStaticMarkup } from 'react-dom/server';
 
 import { createElementWithSlate } from './utils/createElementWithSlate';
+import { renderToStaticMarkup } from './utils/renderToStaticMarkupClient';
 import { stripClassNames } from './utils/stripClassNames';
 
 export const elementToHtml = <V extends Value>(

--- a/packages/serializer-html/src/leafToHtml.ts
+++ b/packages/serializer-html/src/leafToHtml.ts
@@ -7,9 +7,9 @@ import {
   Value,
 } from '@udecode/plate-common';
 import { decode } from 'html-entities';
-import { renderToStaticMarkup } from 'react-dom/server';
 
 import { createElementWithSlate } from './utils/createElementWithSlate';
+import { renderToStaticMarkup } from './utils/renderToStaticMarkupClient';
 import { stripClassNames } from './utils/stripClassNames';
 
 export const leafToHtml = <V extends Value>(

--- a/packages/serializer-html/src/utils/renderToStaticMarkupClient.ts
+++ b/packages/serializer-html/src/utils/renderToStaticMarkupClient.ts
@@ -1,0 +1,35 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ReactClient from 'react-dom/client';
+
+import { createElementWithSlate } from './createElementWithSlate';
+
+const REACT_API_UPDATE_VERSION = 18;
+
+/**
+ * See https://react.dev/reference/react-dom/server/renderToString#removing-rendertostring-from-the-client-code
+ */
+const renderToStaticNew = (elem: ReturnType<typeof createElementWithSlate>) => {
+  const div = document.createElement('div');
+  const root = ReactClient.createRoot(div);
+  ReactDOM.flushSync(() => {
+    root.render(elem);
+  });
+  return div.innerHTML;
+};
+
+const renderToStaticOld = (elem: ReturnType<typeof createElementWithSlate>) => {
+  const div = document.createElement('div');
+  // eslint-disable-next-line react/no-deprecated
+  ReactDOM.render(elem, div);
+  return div.innerHTML;
+};
+
+const createRenderToStaticMarkup = () => {
+  const reactMajorVersion = +React.version.slice(0, 2);
+  return reactMajorVersion >= REACT_API_UPDATE_VERSION
+    ? renderToStaticNew
+    : renderToStaticOld;
+};
+
+export const renderToStaticMarkup = createRenderToStaticMarkup();

--- a/packages/serializer-html/src/utils/renderToStaticMarkupClient.ts
+++ b/packages/serializer-html/src/utils/renderToStaticMarkupClient.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import ReactClient from 'react-dom/client';
+import ReactDOMClient from 'react-dom/client';
+import ReactDOMServer from 'react-dom/server';
 
 import { createElementWithSlate } from './createElementWithSlate';
 
@@ -11,7 +12,7 @@ const REACT_API_UPDATE_VERSION = 18;
  */
 const renderToStaticNew = (elem: ReturnType<typeof createElementWithSlate>) => {
   const div = document.createElement('div');
-  const root = ReactClient.createRoot(div);
+  const root = ReactDOMClient.createRoot(div);
   ReactDOM.flushSync(() => {
     root.render(elem);
   });
@@ -25,11 +26,14 @@ const renderToStaticOld = (elem: ReturnType<typeof createElementWithSlate>) => {
   return div.innerHTML;
 };
 
-const createRenderToStaticMarkup = () => {
+const createRenderToStaticMarkupClient = () => {
   const reactMajorVersion = +React.version.slice(0, 2);
   return reactMajorVersion >= REACT_API_UPDATE_VERSION
     ? renderToStaticNew
     : renderToStaticOld;
 };
 
-export const renderToStaticMarkup = createRenderToStaticMarkup();
+export const renderToStaticMarkup =
+  typeof window === 'undefined'
+    ? ReactDOMServer.renderToStaticMarkup
+    : createRenderToStaticMarkupClient();


### PR DESCRIPTION
## Summary

Fixes #1123
Fixes #1047

Related issue on slate https://github.com/ianstormtaylor/slate/issues/5012
See [react APIs update](https://react.dev/reference/react-dom/server/renderToString#removing-rendertostring-from-the-client-code) for more details

- Removes `renderToStaticMarkup` from client code
- Now, the lack of `react-dom/server` import will reduce bundle size
- Since serialize will render client react apis, unwanted warnings wont ashore the console