### PR TITLE
[Heading Plugin] Customise Heading levels

### DIFF
--- a/.changeset/tame-beans-deliver.md
+++ b/.changeset/tame-beans-deliver.md
@@ -1,0 +1,32 @@
+---
+"@udecode/plate-heading": minor
+---
+
+### Changes
+
+- Modified `createHeadingPlugin` function to allow granular selection of heading levels.
+- Added support for retaining the old behavior of generating plugins for all heading levels up to a maximum level.
+- Type the heading levels props
+
+### Details
+
+- The `createHeadingPlugin` function has been updated to accept an array of specific heading levels to enable, allowing for granular selection of heading levels. This provides more flexibility in choosing which heading levels to support within the editor.
+- The function now supports retaining the old behavior of generating plugins for all heading levels up to a maximum level if desired. This ensures backward compatibility with existing implementations that rely on the previous behavior.
+
+### How to Use
+
+- To use the granular selection feature, pass an array of heading levels to the `createHeadingPlugin` function when initializing it. For example:
+  
+```ts
+const headingPlugin = createHeadingPlugin({
+    levels: [1, 2, 3] // Enable heading levels 1, 2, and 3
+});
+```
+
+And the previous behaviour is still working:
+
+```ts
+const headingPlugin = createHeadingPlugin({
+    levels: 6 // Enable heading levels 1, 2, 3, 4, 5 and 6
+});
+```

--- a/packages/heading/src/createHeadingPlugin.ts
+++ b/packages/heading/src/createHeadingPlugin.ts
@@ -14,12 +14,12 @@ import { HeadingPlugin, HeadingsPlugin } from './types';
 export const createHeadingPlugin = createPluginFactory<HeadingsPlugin>({
   key: 'heading',
   options: {
-    levels: 6,
+    levels: [1, 2, 3, 4, 5, 6],
   },
   then: (editor, { options: { levels } = {} }) => {
     const plugins: PlatePlugin<HeadingPlugin>[] = [];
 
-    for (let level = 1; level <= levels!; level++) {
+    levels!.forEach((level) => {
       const key = KEYS_HEADING[level - 1];
 
       const plugin: PlatePlugin<HeadingPlugin> = {
@@ -43,7 +43,7 @@ export const createHeadingPlugin = createPluginFactory<HeadingsPlugin>({
       }
 
       plugins.push(plugin);
-    }
+    });
 
     return {
       plugins,

--- a/packages/heading/src/createHeadingPlugin.ts
+++ b/packages/heading/src/createHeadingPlugin.ts
@@ -19,11 +19,11 @@ export const createHeadingPlugin = createPluginFactory<HeadingsPlugin>({
   then: (editor, { options: { levels } = {} }) => {
     const plugins: PlatePlugin<HeadingPlugin>[] = [];
 
-    levels = Array.isArray(levels)
+    const headingLevels = Array.isArray(levels)
       ? levels
-      : Array.from({ length: levels }, (_, i) => i + 1);
+      : Array.from({ length: levels || 6 }, (_, i) => i + 1);
 
-    levels!.forEach((level) => {
+    headingLevels.forEach((level) => {
       const key = KEYS_HEADING[level - 1];
 
       const plugin: PlatePlugin<HeadingPlugin> = {

--- a/packages/heading/src/createHeadingPlugin.ts
+++ b/packages/heading/src/createHeadingPlugin.ts
@@ -19,6 +19,10 @@ export const createHeadingPlugin = createPluginFactory<HeadingsPlugin>({
   then: (editor, { options: { levels } = {} }) => {
     const plugins: PlatePlugin<HeadingPlugin>[] = [];
 
+    levels = Array.isArray(levels)
+      ? levels
+      : Array.from({ length: levels }, (_, i) => i + 1);
+
     levels!.forEach((level) => {
       const key = KEYS_HEADING[level - 1];
 

--- a/packages/heading/src/types.ts
+++ b/packages/heading/src/types.ts
@@ -6,5 +6,5 @@ export interface HeadingsPlugin {
   /**
    * Heading levels supported from 1 to `levels`
    */
-  levels?: number;
+  levels?: Array<1 | 2 | 3 | 4 | 5 | 6>;
 }

--- a/packages/heading/src/types.ts
+++ b/packages/heading/src/types.ts
@@ -2,11 +2,11 @@ import { HotkeyPlugin } from '@udecode/plate-common';
 
 export interface HeadingPlugin extends HotkeyPlugin {}
 
-export type HEADING_LEVEL = 1 | 2 | 3 | 4 | 5 | 6;
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 
 export interface HeadingsPlugin {
   /**
    * Heading levels supported from 1 to `levels`
    */
-  levels?: HEADING_LEVEL | HEADING_LEVEL[];
+  levels?: HeadingLevel | HeadingLevel[];
 }

--- a/packages/heading/src/types.ts
+++ b/packages/heading/src/types.ts
@@ -2,9 +2,11 @@ import { HotkeyPlugin } from '@udecode/plate-common';
 
 export interface HeadingPlugin extends HotkeyPlugin {}
 
+export type HEADING_LEVEL = 1 | 2 | 3 | 4 | 5 | 6;
+
 export interface HeadingsPlugin {
   /**
    * Heading levels supported from 1 to `levels`
    */
-  levels?: Array<1 | 2 | 3 | 4 | 5 | 6>;
+  levels?: HEADING_LEVEL | HEADING_LEVEL[];
 }


### PR DESCRIPTION
**Description**

I would like to add the headings nodes to `h3` without the `h1` node.

So I changed the API to make it more customisable.
 
**Example**

Before
```ts
createHeadingPlugin({ options: { levels: 3 } })
// Create headings from 1 to 3
```

After 
```ts
createHeadingPlugin({ options: { levels: [2, 3] } })
// Create headings 2 and 3
```
