### PR TITLE
 Fix: Command is invalid, when I install emoji-combobox in platejs.org 

### DIFF
--- a/apps/www/src/app/_components/installation-tab.tsx
+++ b/apps/www/src/app/_components/installation-tab.tsx
@@ -127,7 +127,7 @@ export default function InstallationTab() {
           },
           new Set<string>()
         )
-      ).join(' ')}${isManual && ' tooltip'}`,
+      ).join(' ')}${isManual ? ' tooltip' : ''}`,
       plugins: `npm install ${Array.from(
         plugins.reduce((uniquePackages, { npmPackage }) => {
           if (npmPackage) {


### PR DESCRIPTION
**Description**

issue: #3202 

<!-- A clear and concise description of what this pull request solves. -->



<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->



When `isManual` is false, `installCommands.components` returns unexpected value.
```ts
isManual && ' tooltip' // returns 'false'
```

So, I changed the code as below
```ts
isManual ? ' tooltip' : '' // returns ''
```
<!-- **Example** -->

It's the result!
![image](https://github.com/udecode/plate/assets/77661228/e5645bfa-0d24-4ce7-a617-df99ba906459)






<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

