### PR TITLE
fix: zIndex of floating link

### DIFF
--- a/.changeset/plenty-suits-serve.md
+++ b/.changeset/plenty-suits-serve.md
@@ -1,5 +1,0 @@
----
-"@udecode/plate-link": major
----
-
-change the zIndex of useFloatingLinkdEdit prop.style

--- a/.changeset/plenty-suits-serve.md
+++ b/.changeset/plenty-suits-serve.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-link": major
+---
+
+change the zIndex of useFloatingLinkdEdit prop.style

--- a/.changeset/silly-candles-return.md
+++ b/.changeset/silly-candles-return.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-link": major
+---
+
+Fix zIndex of floating link

--- a/.changeset/silly-candles-return.md
+++ b/.changeset/silly-candles-return.md
@@ -1,5 +1,5 @@
 ---
-"@udecode/plate-link": major
+"@udecode/plate-link": patch
 ---
 
 Fix zIndex of floating link

--- a/packages/link/src/components/FloatingLink/useFloatingLinkEdit.ts
+++ b/packages/link/src/components/FloatingLink/useFloatingLinkEdit.ts
@@ -135,7 +135,7 @@ export const useFloatingLinkEdit = ({
     props: {
       style: {
         ...floating.style,
-        zIndex: 1,
+        zIndex: 30,
       },
     },
     ref: floating.refs.setFloating,

--- a/packages/link/src/components/FloatingLink/useFloatingLinkEdit.ts
+++ b/packages/link/src/components/FloatingLink/useFloatingLinkEdit.ts
@@ -135,7 +135,7 @@ export const useFloatingLinkEdit = ({
     props: {
       style: {
         ...floating.style,
-        zIndex: 30,
+        zIndex: 50,
       },
     },
     ref: floating.refs.setFloating,

--- a/packages/link/src/components/FloatingLink/useFloatingLinkInsert.ts
+++ b/packages/link/src/components/FloatingLink/useFloatingLinkInsert.ts
@@ -126,7 +126,7 @@ export const useFloatingLinkInsert = ({
     props: {
       style: {
         ...floating.style,
-        zIndex: 1,
+        zIndex: 50,
       },
     },
     ref: useComposedRef<HTMLDivElement>(floating.refs.setFloating, ref),


### PR DESCRIPTION
**Description**

close #3144

I fixed the zIndex of `useFloatingLinkInsert` according to 12joan's comment, but the same problem still exists.
So I resolved this issue by fixing the zIndex of `useFloatingLinkEdit`.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->

It works without any problems.
But I'm not sure if changing the zIndex to 30 is the best way.

https://github.com/udecode/plate/assets/77661228/a1f607dd-c7ed-46bb-820e-faa549fb9343




<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

