### PR TITLE
Fix: zIndicies of the SiteHeader and FixedToolbar #3213

### DIFF
--- a/apps/www/content/docs/components/changelog.mdx
+++ b/apps/www/content/docs/components/changelog.mdx
@@ -37,8 +37,8 @@ Use the [CLI](https://platejs.org/docs/components/cli) to install the latest ver
 
 ### February 5 #8.1
 
-- fix `mention-element`: Mention input removed when clicking mention combobox scrollbar
-  ([#2919](https://github.com/udecode/plate/issues/2919))
+- fix `mention-element`:  Mention input removed when clicking mention combobox scrollbar
+([#2919](https://github.com/udecode/plate/issues/2919))
 
 ## January 2024 #7
 
@@ -55,7 +55,7 @@ Use the [CLI](https://platejs.org/docs/components/cli) to install the latest ver
 ### January 9 #7.3
 
 - `toolbar`
-  - `Toolbar`: replace `items-stretch` with `items-center`
+  - `Toolbar`: replace `items-stretch` with `items-center` 
   - use `toolbarButtonVariants` instead of `toggleVariants`
   - fix `value` prop type bug
   - uses now `withTooltip`, so replace `[data-state=on]` with `aria-checked` to avoid conflicts
@@ -68,11 +68,9 @@ Use the [CLI](https://platejs.org/docs/components/cli) to install the latest ver
 
 ```tsx
 // Before
-export const TableElement = withRef<typeof PlateElement>(
-  ({ className, children, ...props }, ref) => {
-    // ...
-  }
-);
+export const TableElement = withRef<typeof PlateElement>(({ className, children, ...props }, ref) => {
+  // ...
+});
 
 // After
 export const TableElement = withHOC(
@@ -94,12 +92,9 @@ export const TableElement = withHOC(
 - remove `clsx` from dependency: `class-variance-utility` already exports it as `cx`
 - new dependency: `@udecode/cn`
 - remove `@/lib/utils.ts` in favor of `cn` from `@udecode/cn`. Replace all imports from `@/lib/utils` with `@udecode/cn`
-- import `withProps` from `@udecode/cn` instead of `@udecode/plate-common
-
-  `
-
+- import `withProps` from `@udecode/cn` instead of `@udecode/plate-common`
 - all components using `forwardRef` are now using `withRef`. `withProps`, `withCn` and `withVariants` are also used to reduce boilerplate.
-- add `withCn` to ESLint `settings.tailwindcss.callees` and `classAttributes` in your IDE settings
+- add `withCn` to ESLint `settings.tailwindcss.callees` and `classAttributes` in your IDE settings 
 
 ```tsx
 // before
@@ -126,6 +121,7 @@ export const Avatar = withCn(
   'relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full'
 );
 ```
+
 
 ### December 25 #6.2
 
@@ -166,7 +162,7 @@ export const Avatar = withCn(
 ### 18 Sept #4.4
 
 - `editor`: New component 🎉 See [Editor](https://platejs.org/docs/components/editor)
-- `fixed-toolbar-buttons`, `floating-toolbar-buttons`, `mode-dropdown-menu`:
+- `fixed-toolbar-buttons`, `floating-toolbar-buttons`, `mode-dropdown-menu`: 
   - plate 24: rename `usePlateReadOnly` to `useEditorReadOnly`
 - `code-block-element`: changes in `code-block-element.css`
 

--- a/apps/www/content/docs/components/changelog.mdx
+++ b/apps/www/content/docs/components/changelog.mdx
@@ -8,6 +8,13 @@ Since Plate UI is not a component library, a changelog is maintained here.
 
 Use the [CLI](https://platejs.org/docs/components/cli) to install the latest version of the components.
 
+## May 2024 #10
+
+### May 24 #10.1
+
+- fix `site-header`: change zIndex to 60
+- fix `fixed-toolbar`: change zIndex to 60
+
 ## April 2024 #9
 
 ### April 30 #9.3
@@ -30,8 +37,8 @@ Use the [CLI](https://platejs.org/docs/components/cli) to install the latest ver
 
 ### February 5 #8.1
 
-- fix `mention-element`:  Mention input removed when clicking mention combobox scrollbar
-([#2919](https://github.com/udecode/plate/issues/2919))
+- fix `mention-element`: Mention input removed when clicking mention combobox scrollbar
+  ([#2919](https://github.com/udecode/plate/issues/2919))
 
 ## January 2024 #7
 
@@ -48,7 +55,7 @@ Use the [CLI](https://platejs.org/docs/components/cli) to install the latest ver
 ### January 9 #7.3
 
 - `toolbar`
-  - `Toolbar`: replace `items-stretch` with `items-center` 
+  - `Toolbar`: replace `items-stretch` with `items-center`
   - use `toolbarButtonVariants` instead of `toggleVariants`
   - fix `value` prop type bug
   - uses now `withTooltip`, so replace `[data-state=on]` with `aria-checked` to avoid conflicts
@@ -61,9 +68,11 @@ Use the [CLI](https://platejs.org/docs/components/cli) to install the latest ver
 
 ```tsx
 // Before
-export const TableElement = withRef<typeof PlateElement>(({ className, children, ...props }, ref) => {
-  // ...
-});
+export const TableElement = withRef<typeof PlateElement>(
+  ({ className, children, ...props }, ref) => {
+    // ...
+  }
+);
 
 // After
 export const TableElement = withHOC(
@@ -85,9 +94,12 @@ export const TableElement = withHOC(
 - remove `clsx` from dependency: `class-variance-utility` already exports it as `cx`
 - new dependency: `@udecode/cn`
 - remove `@/lib/utils.ts` in favor of `cn` from `@udecode/cn`. Replace all imports from `@/lib/utils` with `@udecode/cn`
-- import `withProps` from `@udecode/cn` instead of `@udecode/plate-common`
+- import `withProps` from `@udecode/cn` instead of `@udecode/plate-common
+
+  `
+
 - all components using `forwardRef` are now using `withRef`. `withProps`, `withCn` and `withVariants` are also used to reduce boilerplate.
-- add `withCn` to ESLint `settings.tailwindcss.callees` and `classAttributes` in your IDE settings 
+- add `withCn` to ESLint `settings.tailwindcss.callees` and `classAttributes` in your IDE settings
 
 ```tsx
 // before
@@ -114,7 +126,6 @@ export const Avatar = withCn(
   'relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full'
 );
 ```
-
 
 ### December 25 #6.2
 
@@ -155,7 +166,7 @@ export const Avatar = withCn(
 ### 18 Sept #4.4
 
 - `editor`: New component 🎉 See [Editor](https://platejs.org/docs/components/editor)
-- `fixed-toolbar-buttons`, `floating-toolbar-buttons`, `mode-dropdown-menu`: 
+- `fixed-toolbar-buttons`, `floating-toolbar-buttons`, `mode-dropdown-menu`:
   - plate 24: rename `usePlateReadOnly` to `useEditorReadOnly`
 - `code-block-element`: changes in `code-block-element.css`
 

--- a/apps/www/src/components/site-header.tsx
+++ b/apps/www/src/components/site-header.tsx
@@ -31,7 +31,7 @@ export async function SiteHeader() {
     .catch(() => ({ stargazers_count: 0 }));
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <header className="sticky top-0 z-[60] w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-14 max-w-screen-2xl items-center justify-between">
         <MainNav />
         <MobileNav />

--- a/apps/www/src/registry/default/plate-ui/fixed-toolbar.tsx
+++ b/apps/www/src/registry/default/plate-ui/fixed-toolbar.tsx
@@ -4,5 +4,5 @@ import { Toolbar } from './toolbar';
 
 export const FixedToolbar = withCn(
   Toolbar,
-  'supports-backdrop-blur:bg-background/60 sticky left-0 top-[57px] z-50 w-full justify-between overflow-x-auto rounded-t-lg border-b border-b-border bg-background/95 backdrop-blur'
+  'supports-backdrop-blur:bg-background/60 sticky left-0 top-[57px] z-[60] w-full justify-between overflow-x-auto rounded-t-lg border-b border-b-border bg-background/95 backdrop-blur'
 );


### PR DESCRIPTION
**Description**

close  #3213


<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

zIndex of FloatingToolbar is 50

I change the zIndicies of SiteHeader and FixedToolbar to 60


https://github.com/udecode/plate/assets/77661228/95e46e78-e8ad-416f-95aa-c5d66331c65c




