### PR TITLE
Trailing Block plugin fixes

### DIFF
--- a/.changeset/yellow-chairs-smile.md
+++ b/.changeset/yellow-chairs-smile.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-trailing-block": patch
+---
+
+Fixed custom trailing block types

--- a/packages/trailing-block/src/withTrailingBlock.ts
+++ b/packages/trailing-block/src/withTrailingBlock.ts
@@ -39,7 +39,7 @@ export const withTrailingBlock = <
       ) {
         const at = lastChild ? Path.next(lastChild[1]) : [0];
 
-        insertElements(editor, editor.blockFactory({}, at), { at });
+        insertElements(editor, editor.blockFactory({ type }, at), { at });
 
         return;
       }


### PR DESCRIPTION
**Description**

See changesets.

<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

We're in the process of migrating from Slate to Plate and due to us wanting to maintain backward compatibility between the two editor data formats, we have to customize most plugins to use custom element types. We did notice that the trailing block plugin is broken when trying to override the trailing block type which is already supported in the options but isn't working correctly because the trailing block is always defaulting to the default type configured on an editor level which doesn't seem to be intended behavior.

 
<!-- **Example** -->



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

