### PR TITLE
fix: subscript and superscript were mixed up

### DIFF
--- a/apps/www/src/components/plate-ui/playground-more-dropdown-menu.tsx
+++ b/apps/www/src/components/plate-ui/playground-more-dropdown-menu.tsx
@@ -67,8 +67,8 @@ export function PlaygroundMoreDropdownMenu(props: DropdownMenuProps) {
         <DropdownMenuItem
           onSelect={() => {
             toggleMark(editor, {
-              clear: MARK_SUBSCRIPT,
-              key: MARK_SUPERSCRIPT,
+              clear: MARK_SUPERSCRIPT,
+              key: MARK_SUBSCRIPT,
             });
             focusEditor(editor);
           }}
@@ -80,8 +80,8 @@ export function PlaygroundMoreDropdownMenu(props: DropdownMenuProps) {
         <DropdownMenuItem
           onSelect={() => {
             toggleMark(editor, {
-              clear: MARK_SUPERSCRIPT,
-              key: MARK_SUBSCRIPT,
+              clear: MARK_SUBSCRIPT,
+              key: MARK_SUPERSCRIPT,
             });
             focusEditor(editor);
           }}

--- a/apps/www/src/registry/default/plate-ui/more-dropdown-menu.tsx
+++ b/apps/www/src/registry/default/plate-ui/more-dropdown-menu.tsx
@@ -35,8 +35,8 @@ export function MoreDropdownMenu(props: DropdownMenuProps) {
         <DropdownMenuItem
           onSelect={() => {
             toggleMark(editor, {
-              clear: MARK_SUPERSCRIPT,
-              key: MARK_SUBSCRIPT,
+              key: MARK_SUPERSCRIPT,
+               clear: [MARK_SUPERSCRIPT, MARK_SUBSCRIPT],
             });
             focusEditor(editor);
           }}
@@ -49,7 +49,7 @@ export function MoreDropdownMenu(props: DropdownMenuProps) {
           onSelect={() => {
             toggleMark(editor, {
               clear: MARK_SUBSCRIPT,
-              key: MARK_SUPERSCRIPT,
+              clear: [MARK_SUPERSCRIPT, MARK_SUBSCRIPT],
             });
             focusEditor(editor);
           }}

--- a/templates/plate-playground-template/src/components/plate-ui/more-dropdown-menu.tsx
+++ b/templates/plate-playground-template/src/components/plate-ui/more-dropdown-menu.tsx
@@ -33,8 +33,8 @@ export function MoreDropdownMenu(props: DropdownMenuProps) {
         <DropdownMenuItem
           onSelect={() => {
             toggleMark(editor, {
-              key: MARK_SUBSCRIPT,
-              clear: MARK_SUPERSCRIPT,
+              key: MARK_SUPERSCRIPT,
+               clear: [MARK_SUPERSCRIPT, MARK_SUBSCRIPT],
             });
             focusEditor(editor);
           }}
@@ -46,8 +46,8 @@ export function MoreDropdownMenu(props: DropdownMenuProps) {
         <DropdownMenuItem
           onSelect={() => {
             toggleMark(editor, {
-              key: MARK_SUPERSCRIPT,
               clear: MARK_SUBSCRIPT,
+              clear: [MARK_SUPERSCRIPT, MARK_SUBSCRIPT],
             });
             focusEditor(editor);
           }}


### PR DESCRIPTION
Dear maintainers,

I noticed following bug in the playground demo and provide a small and straight forward fix to it.

The labels were simply mixed up and the clearing behaviour could not handle changing a subscript to a supscript or vice versa.

With best regards,
Leon Müller