### PR TITLE
Fix compatibility of `useHTMLInputCursorState` with Chrome and WebKit

### DIFF
--- a/.changeset/long-rocks-relate.md
+++ b/.changeset/long-rocks-relate.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-combobox": patch
+---
+
+Fix compatibility of `useHTMLInputCursorState` with Chrome and WebKit

--- a/packages/combobox/src/hooks/useHTMLInputCursorState.ts
+++ b/packages/combobox/src/hooks/useHTMLInputCursorState.ts
@@ -1,23 +1,20 @@
-import { type RefObject, useCallback, useEffect, useState } from 'react';
+import { type RefObject, useCallback, useEffect, useState, useMemo } from 'react';
 
 import type { ComboboxInputCursorState } from '../types';
 
 export const useHTMLInputCursorState = (
   ref: RefObject<HTMLInputElement>
 ): ComboboxInputCursorState => {
-  const [cursorState, setCursorState] = useState<ComboboxInputCursorState>({
-    atEnd: false,
-    atStart: false,
-  });
+  const [atStart, setAtStart] = useState(false);
+  const [atEnd, setAtEnd] = useState(false);
 
   const recomputeCursorState = useCallback(() => {
-    if (!ref.current) return;
-
-    const { selectionEnd, selectionStart, value } = ref.current;
-
-    setCursorState({
-      atEnd: selectionEnd === value.length,
-      atStart: selectionStart === 0,
+    // Wait for events to finish processing
+    setTimeout(() => {
+      if (!ref.current) return;
+      const { selectionEnd, selectionStart, value } = ref.current;
+      setAtStart(selectionStart === 0);
+      setAtEnd(selectionEnd === value.length);
     });
   }, [ref]);
 
@@ -31,11 +28,25 @@ export const useHTMLInputCursorState = (
     input.addEventListener('input', recomputeCursorState);
     input.addEventListener('selectionchange', recomputeCursorState);
 
+    /**
+     * Compat: selectionchange is not supported for <input> except in Firefox,
+     * so we add keydown, pointerdown and pointerup as fallbacks (2024-06-14).
+     */
+    input.addEventListener('keydown', recomputeCursorState);
+    input.addEventListener('pointerdown', recomputeCursorState);
+    input.addEventListener('pointerup', recomputeCursorState);
+
     return () => {
       input.removeEventListener('input', recomputeCursorState);
       input.removeEventListener('selectionchange', recomputeCursorState);
+      input.removeEventListener('keydown', recomputeCursorState);
+      input.removeEventListener('pointerdown', recomputeCursorState);
+      input.removeEventListener('pointerup', recomputeCursorState);
     };
   }, [recomputeCursorState, ref]);
 
-  return cursorState;
+  return useMemo(() => ({
+    atStart,
+    atEnd,
+  }), [atStart, atEnd]);
 };


### PR DESCRIPTION
Fixes two issues affecting `useHTMLInputCursorState`:
 - Synchronously triggering a rerender on the `input` event was preventing the `<input>` from receiving keystrokes in Chrome and WebKit.
 - The `selectionchange` event is not currently supported for `<input>` elements outside of Firefox. Added other events as fallbacks.

- [X] added [changesets](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) <!-- Required if `packages/` has been changed -->
- [ ] updated [components changelog](https://github.com/udecode/plate/blob/main/apps/www/content/docs/components/changelog.mdx) <!-- Required if `apps/www/src/registry` has been changed -->
