### PR TITLE
Update caption UI when element `caption` property changes

### DIFF
--- a/.changeset/fuzzy-dolls-speak.md
+++ b/.changeset/fuzzy-dolls-speak.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-caption": patch
+---
+
+Update caption UI when element `caption` property changes

--- a/apps/www/content/docs/components/changelog.mdx
+++ b/apps/www/content/docs/components/changelog.mdx
@@ -10,6 +10,10 @@ Use the [CLI](https://platejs.org/docs/components/cli) to install the latest ver
 
 ## June 2024 #11
 
+### Pending #11.2
+
+- fix `caption`: update UI when element `caption` property changes
+
 ### June 6 #11.1
 
 - replace `combobox` with `inline-combobox`
@@ -111,6 +115,7 @@ export const TableElement = withHOC(
 - new dependency: `@udecode/cn`
 - remove `@/lib/utils.ts` in favor of `cn` from `@udecode/cn`. Replace all imports from `@/lib/utils` with `@udecode/cn`
 - import `withProps` from `@udecode/cn` instead of `@udecode/plate-common
+
   `
 - all components using `forwardRef` are now using `withRef`. `withProps`, `withCn` and `withVariants` are also used to reduce boilerplate.
 - add `withCn` to ESLint `settings.tailwindcss.callees` and `classAttributes` in your IDE settings

--- a/packages/caption/src/components/CaptionTextarea.tsx
+++ b/packages/caption/src/components/CaptionTextarea.tsx
@@ -47,14 +47,27 @@ export const useCaptionTextareaFocus = (
 
 export const useCaptionTextareaState = () => {
   const element = useElement<TCaptionElement>();
+  const editor = useEditorRef();
 
   const {
     caption: nodeCaption = [{ children: [{ text: '' }] }] as [TElement],
   } = element;
 
-  const [captionValue, setCaptionValue] = React.useState<
-    TextareaAutosizeProps['value']
-  >(getNodeString(nodeCaption[0]));
+  const captionValue: TextareaAutosizeProps['value'] = getNodeString(
+    nodeCaption[0]
+  );
+
+  function setCaptionValue(newValue: TextareaAutosizeProps['value']) {
+    const path = findNodePath(editor, element);
+
+    if (!path) return;
+
+    setNodes<TCaptionElement>(
+      editor,
+      { caption: [{ text: newValue }] },
+      { at: path }
+    );
+  }
 
   const readOnly = useReadOnly();
 
@@ -84,21 +97,9 @@ export const useCaptionTextarea = ({
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       const newValue = e.target.value;
 
-      // local state
       setCaptionValue(newValue);
-
-      const path = findNodePath(editor, element);
-
-      if (!path) return;
-
-      // saved state
-      setNodes<TCaptionElement>(
-        editor,
-        { caption: [{ text: newValue }] },
-        { at: path }
-      );
     },
-    [editor, element, setCaptionValue]
+    [setCaptionValue]
   );
 
   const onKeyDown: TextareaAutosizeProps['onKeyDown'] = (e) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5604,7 +5604,7 @@ __metadata:
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5621,7 +5621,7 @@ __metadata:
     "@udecode/plate-common": "workspace:^"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5631,17 +5631,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-basic-elements@npm:34.0.0, @udecode/plate-basic-elements@workspace:^, @udecode/plate-basic-elements@workspace:packages/basic-elements":
+"@udecode/plate-basic-elements@npm:34.0.7, @udecode/plate-basic-elements@workspace:^, @udecode/plate-basic-elements@workspace:packages/basic-elements":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-basic-elements@workspace:packages/basic-elements"
   dependencies:
     "@udecode/plate-block-quote": "npm:34.0.0"
     "@udecode/plate-code-block": "npm:34.0.0"
     "@udecode/plate-common": "workspace:^"
-    "@udecode/plate-heading": "npm:34.0.0"
+    "@udecode/plate-heading": "npm:34.0.7"
     "@udecode/plate-paragraph": "npm:34.0.0"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5657,7 +5657,7 @@ __metadata:
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5673,7 +5673,7 @@ __metadata:
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5689,7 +5689,7 @@ __metadata:
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5705,7 +5705,7 @@ __metadata:
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5722,7 +5722,7 @@ __metadata:
     "@udecode/plate-common": "workspace:^"
     react-textarea-autosize: "npm:^8.5.3"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5741,7 +5741,7 @@ __metadata:
     delay: "npm:5.0.0"
     p-defer: "npm:^3.0.0"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5758,7 +5758,7 @@ __metadata:
     "@udecode/plate-common": "workspace:^"
     prismjs: "npm:^1.29.0"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5775,7 +5775,7 @@ __metadata:
     "@udecode/plate-common": "workspace:^"
     downshift: "npm:^6.1.12"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5792,7 +5792,7 @@ __metadata:
     "@udecode/plate-common": "workspace:^"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5802,16 +5802,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-common@npm:34.0.2, @udecode/plate-common@workspace:^, @udecode/plate-common@workspace:packages/common":
+"@udecode/plate-common@npm:34.0.5, @udecode/plate-common@workspace:^, @udecode/plate-common@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-common@workspace:packages/common"
   dependencies:
-    "@udecode/plate-core": "npm:34.0.1"
-    "@udecode/plate-utils": "npm:34.0.2"
+    "@udecode/plate-core": "npm:34.0.4"
+    "@udecode/plate-utils": "npm:34.0.5"
     "@udecode/react-utils": "npm:33.0.0"
     "@udecode/slate": "npm:32.0.1"
     "@udecode/slate-react": "npm:33.0.0"
-    "@udecode/slate-utils": "npm:34.0.0"
+    "@udecode/slate-utils": "npm:34.0.4"
     "@udecode/utils": "npm:31.0.0"
   peerDependencies:
     react: ">=16.8.0"
@@ -5823,13 +5823,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-core@npm:34.0.1, @udecode/plate-core@workspace:^, @udecode/plate-core@workspace:packages/core":
+"@udecode/plate-core@npm:34.0.4, @udecode/plate-core@workspace:^, @udecode/plate-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-core@workspace:packages/core"
   dependencies:
     "@udecode/slate": "npm:32.0.1"
     "@udecode/slate-react": "npm:33.0.0"
-    "@udecode/slate-utils": "npm:34.0.0"
+    "@udecode/slate-utils": "npm:34.0.4"
     "@udecode/utils": "npm:31.0.0"
     clsx: "npm:^1.2.1"
     is-hotkey: "npm:^0.2.0"
@@ -5859,7 +5859,7 @@ __metadata:
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5876,7 +5876,7 @@ __metadata:
     "@udecode/plate-common": "workspace:^"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5894,7 +5894,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     raf: "npm:^3.4.1"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dnd: ">=14.0.0"
     react-dnd-html5-backend: ">=14.0.0"
@@ -5914,7 +5914,7 @@ __metadata:
     "@udecode/plate-combobox": "npm:34.0.0"
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5931,7 +5931,7 @@ __metadata:
     "@excalidraw/excalidraw": "npm:0.16.4"
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5947,7 +5947,7 @@ __metadata:
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5957,7 +5957,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-floating@npm:34.0.1, @udecode/plate-floating@workspace:^, @udecode/plate-floating@workspace:packages/floating":
+"@udecode/plate-floating@npm:34.0.6, @udecode/plate-floating@workspace:^, @udecode/plate-floating@workspace:packages/floating":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-floating@workspace:packages/floating"
   dependencies:
@@ -5965,7 +5965,7 @@ __metadata:
     "@floating-ui/react": "npm:^0.22.3"
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5982,7 +5982,7 @@ __metadata:
     "@udecode/plate-common": "workspace:^"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -5992,13 +5992,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-heading@npm:34.0.0, @udecode/plate-heading@workspace:^, @udecode/plate-heading@workspace:packages/heading":
+"@udecode/plate-heading@npm:34.0.7, @udecode/plate-heading@workspace:^, @udecode/plate-heading@workspace:packages/heading":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-heading@workspace:packages/heading"
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6014,7 +6014,7 @@ __metadata:
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6030,7 +6030,7 @@ __metadata:
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6049,7 +6049,7 @@ __metadata:
     "@udecode/plate-list": "npm:34.0.0"
     clsx: "npm:^1.2.1"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6065,7 +6065,7 @@ __metadata:
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6082,7 +6082,7 @@ __metadata:
     "@udecode/plate-common": "workspace:^"
     juice: "npm:^8.1.0"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6098,7 +6098,7 @@ __metadata:
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6114,7 +6114,7 @@ __metadata:
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6130,7 +6130,7 @@ __metadata:
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6140,15 +6140,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-link@npm:34.0.1, @udecode/plate-link@workspace:^, @udecode/plate-link@workspace:packages/link":
+"@udecode/plate-link@npm:34.0.6, @udecode/plate-link@workspace:^, @udecode/plate-link@workspace:packages/link":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-link@workspace:packages/link"
   dependencies:
     "@udecode/plate-common": "workspace:^"
-    "@udecode/plate-floating": "npm:34.0.1"
+    "@udecode/plate-floating": "npm:34.0.6"
     "@udecode/plate-normalizers": "npm:34.0.0"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6166,7 +6166,7 @@ __metadata:
     "@udecode/plate-reset-node": "npm:34.0.0"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6184,7 +6184,7 @@ __metadata:
     "@udecode/plate-common": "workspace:^"
     katex: "npm:0.16.10"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6201,7 +6201,7 @@ __metadata:
     "@udecode/plate-common": "workspace:^"
     js-video-url-parser: "npm:^0.5.1"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6218,7 +6218,7 @@ __metadata:
     "@udecode/plate-combobox": "npm:34.0.0"
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6235,7 +6235,7 @@ __metadata:
     "@udecode/plate-common": "workspace:^"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6252,7 +6252,7 @@ __metadata:
     "@udecode/plate-common": "workspace:^"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6268,7 +6268,7 @@ __metadata:
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6284,7 +6284,7 @@ __metadata:
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6300,7 +6300,7 @@ __metadata:
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6316,7 +6316,7 @@ __metadata:
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6334,7 +6334,7 @@ __metadata:
     "@viselect/vanilla": "npm:3.2.5"
     copy-to-clipboard: "npm:^3.3.3"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6353,7 +6353,7 @@ __metadata:
     "@udecode/plate-table": "npm:34.0.0"
     papaparse: "npm:^5.4.1"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6363,12 +6363,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-serializer-docx@npm:34.0.2, @udecode/plate-serializer-docx@workspace:^, @udecode/plate-serializer-docx@workspace:packages/serializer-docx":
+"@udecode/plate-serializer-docx@npm:34.0.7, @udecode/plate-serializer-docx@workspace:^, @udecode/plate-serializer-docx@workspace:packages/serializer-docx":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-serializer-docx@workspace:packages/serializer-docx"
   dependencies:
     "@udecode/plate-common": "workspace:^"
-    "@udecode/plate-heading": "npm:34.0.0"
+    "@udecode/plate-heading": "npm:34.0.7"
     "@udecode/plate-indent": "npm:34.0.0"
     "@udecode/plate-indent-list": "npm:34.0.0"
     "@udecode/plate-media": "npm:34.0.2"
@@ -6376,7 +6376,7 @@ __metadata:
     "@udecode/plate-table": "npm:34.0.0"
     validator: "npm:^13.11.0"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6394,7 +6394,7 @@ __metadata:
     "@udecode/plate-common": "workspace:^"
     html-entities: "npm:^2.5.2"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6413,7 +6413,7 @@ __metadata:
     remark-parse: "npm:^9.0.0"
     unified: "npm:^9.2.2"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6430,7 +6430,7 @@ __metadata:
     "@udecode/plate-combobox": "npm:34.0.0"
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6448,7 +6448,7 @@ __metadata:
     "@udecode/plate-diff": "npm:34.0.0"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6465,7 +6465,7 @@ __metadata:
     "@udecode/plate-common": "workspace:^"
     tabbable: "npm:^6.2.0"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6483,7 +6483,7 @@ __metadata:
     "@udecode/plate-resizable": "npm:34.0.0"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6510,7 +6510,7 @@ __metadata:
     "@udecode/plate-node-id": "npm:34.0.0"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6526,7 +6526,7 @@ __metadata:
   dependencies:
     "@udecode/plate-common": "workspace:^"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6567,15 +6567,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-utils@npm:34.0.2, @udecode/plate-utils@workspace:^, @udecode/plate-utils@workspace:packages/plate-utils":
+"@udecode/plate-utils@npm:34.0.5, @udecode/plate-utils@workspace:^, @udecode/plate-utils@workspace:packages/plate-utils":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-utils@workspace:packages/plate-utils"
   dependencies:
-    "@udecode/plate-core": "npm:34.0.1"
+    "@udecode/plate-core": "npm:34.0.4"
     "@udecode/react-utils": "npm:33.0.0"
     "@udecode/slate": "npm:32.0.1"
     "@udecode/slate-react": "npm:33.0.0"
-    "@udecode/slate-utils": "npm:34.0.0"
+    "@udecode/slate-utils": "npm:34.0.4"
     "@udecode/utils": "npm:31.0.0"
     clsx: "npm:^1.2.1"
     lodash: "npm:^4.17.21"
@@ -6598,7 +6598,7 @@ __metadata:
     "@udecode/plate-common": "workspace:^"
     yjs: "npm:^13.6.14"
   peerDependencies:
-    "@udecode/plate-common": ">=34.0.2"
+    "@udecode/plate-common": ">=34.0.5"
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
     slate: ">=0.94.0"
@@ -6614,26 +6614,26 @@ __metadata:
   dependencies:
     "@udecode/plate-alignment": "npm:34.0.0"
     "@udecode/plate-autoformat": "npm:34.0.0"
-    "@udecode/plate-basic-elements": "npm:34.0.0"
+    "@udecode/plate-basic-elements": "npm:34.0.7"
     "@udecode/plate-basic-marks": "npm:34.0.0"
     "@udecode/plate-block-quote": "npm:34.0.0"
     "@udecode/plate-break": "npm:34.0.0"
     "@udecode/plate-code-block": "npm:34.0.0"
     "@udecode/plate-combobox": "npm:34.0.0"
     "@udecode/plate-comments": "npm:34.0.0"
-    "@udecode/plate-common": "npm:34.0.2"
+    "@udecode/plate-common": "npm:34.0.5"
     "@udecode/plate-diff": "npm:34.0.0"
     "@udecode/plate-find-replace": "npm:34.0.0"
-    "@udecode/plate-floating": "npm:34.0.1"
+    "@udecode/plate-floating": "npm:34.0.6"
     "@udecode/plate-font": "npm:34.0.0"
-    "@udecode/plate-heading": "npm:34.0.0"
+    "@udecode/plate-heading": "npm:34.0.7"
     "@udecode/plate-highlight": "npm:34.0.0"
     "@udecode/plate-horizontal-rule": "npm:34.0.0"
     "@udecode/plate-indent": "npm:34.0.0"
     "@udecode/plate-indent-list": "npm:34.0.0"
     "@udecode/plate-kbd": "npm:34.0.0"
     "@udecode/plate-line-height": "npm:34.0.0"
-    "@udecode/plate-link": "npm:34.0.1"
+    "@udecode/plate-link": "npm:34.0.6"
     "@udecode/plate-list": "npm:34.0.0"
     "@udecode/plate-media": "npm:34.0.2"
     "@udecode/plate-mention": "npm:34.0.1"
@@ -6644,7 +6644,7 @@ __metadata:
     "@udecode/plate-resizable": "npm:34.0.0"
     "@udecode/plate-select": "npm:34.0.0"
     "@udecode/plate-serializer-csv": "npm:34.0.0"
-    "@udecode/plate-serializer-docx": "npm:34.0.2"
+    "@udecode/plate-serializer-docx": "npm:34.0.7"
     "@udecode/plate-serializer-html": "npm:34.0.0"
     "@udecode/plate-serializer-md": "npm:34.0.0"
     "@udecode/plate-suggestion": "npm:34.0.0"
@@ -6691,7 +6691,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@udecode/slate-utils@npm:34.0.0, @udecode/slate-utils@workspace:^, @udecode/slate-utils@workspace:packages/slate-utils":
+"@udecode/slate-utils@npm:34.0.4, @udecode/slate-utils@workspace:^, @udecode/slate-utils@workspace:packages/slate-utils":
   version: 0.0.0-use.local
   resolution: "@udecode/slate-utils@workspace:packages/slate-utils"
   dependencies:


### PR DESCRIPTION
Currently, the caption plugin is using an internal React state variable as the source of truth for the caption value. While it is updating the Slate element's `caption` property when the caption value changes, it is only reading the element `caption` property to set the _initial_ value of the aforementioned React state. So after the caption mounts, external changes to the element's `caption` property do not get reflected in the caption textarea.

In my app, this bug is most apparent when using undo/redo. After typing some text into a caption textarea, the undo action will revert one character at a time in the `caption` property on the element itself, but the caption textarea will remain unchanged.

This PR removes the internal React state variable and uses the element's `caption` property as the source of truth for the caption value. This change fixes the bug in my own app.

- [x] added [changesets](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) <!-- Required if `packages/` has been changed -->
- [x] updated [components changelog](https://github.com/udecode/plate/blob/main/apps/www/content/docs/components/changelog.mdx) <!-- Required if `apps/www/src/registry` has been changed -->