### PR TITLE
increased z-index to fix overlapping of navbar and editors toolbar

### DIFF
--- a/apps/www/src/components/ui/sheet.tsx
+++ b/apps/www/src/components/ui/sheet.tsx
@@ -11,7 +11,7 @@ const Sheet = SheetPrimitive.Root;
 
 const SheetTrigger = SheetPrimitive.Trigger;
 
-const portalVariants = cva('fixed z-50 flex', {
+const portalVariants = cva('fixed z-100 flex', {
   defaultVariants: { modal: true, position: 'right' },
   variants: {
     modal: {


### PR DESCRIPTION
the sheet (customization sidebar) component was being overlapped by the main navbar and editor's tools.
this PR fixes the issue by increasing the z-index of the sidebar.

![Screenshot 2024-06-22 150014](https://github.com/udecode/plate/assets/108524973/73d2d90e-570e-41c5-a8ad-121dab5c4efd)

this is a very **small** but **impactful** fix that improves the overall UI experience. :)