### PR TITLE
fix: omit plate properties from createNodeHOC props

### DIFF
--- a/.changeset/lemon-trees-pay.md
+++ b/.changeset/lemon-trees-pay.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-utils": patch
+---
+
+fix: omit plate properties from createNodeHOC props

--- a/packages/plate-utils/src/shared/createNodeHOC.tsx
+++ b/packages/plate-utils/src/shared/createNodeHOC.tsx
@@ -8,7 +8,7 @@ export const createNodeHOC =
   (Component: any, props: Omit<T, keyof PlateRenderElementProps<V>>) =>
     function hoc(childrenProps: PlateRenderElementProps<V>) {
       return (
-        <HOC {...childrenProps} {...props}>
+        <HOC {...({ ...childrenProps, ...props } as T)}>
           <Component {...childrenProps} />
         </HOC>
       );

--- a/packages/plate-utils/src/shared/createNodeHOC.tsx
+++ b/packages/plate-utils/src/shared/createNodeHOC.tsx
@@ -5,7 +5,7 @@ import type { Value } from '@udecode/slate';
 
 export const createNodeHOC =
   <V extends Value, T>(HOC: React.FC<T>) =>
-  (Component: any, props: T) =>
+  (Component: any, props: Omit<T, keyof PlateRenderElementProps<V>>) =>
     function hoc(childrenProps: PlateRenderElementProps<V>) {
       return (
         <HOC {...childrenProps} {...props}>


### PR DESCRIPTION
<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

Adding a changeset using `yarn changeset` is required if you've modified a
source file in `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.

Changes to component files inside `apps/www/src/registry` don't require a
changeset, but please update the component changelog to briefly describe what
you changed. See `apps/www/content/docs/components/changelog.mdx`.

-->

- [x] `yarn test` passes
- [x] `yarn typecheck` passes
- [x] Ran `yarn lint:fix`
- [x] Ran `yarn brl` (if adding, renaming or deleting source files)
- [x] Added a changeset (if required)
- [ ] Updated the component changelog (if required)
