### PR TITLE
Allow components using `useMediaState` to choose their own default `align`

### DIFF
--- a/.changeset/curvy-ligers-try.md
+++ b/.changeset/curvy-ligers-try.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-media': minor
+---
+
+Remove default `align` from `useMediaState`, allowing components to choose their own default `align`

--- a/packages/media/CHANGELOG.md
+++ b/packages/media/CHANGELOG.md
@@ -26,7 +26,9 @@
 
 ### Minor Changes
 
-- [#3241](https://github.com/udecode/plate/pull/3241) by [@felixfeng33](https://github.com/felixfeng33) – Add plugins: `mediaPlaceholder`, `video`,`audio` and `file`
+- [#3241](https://github.com/udecode/plate/pull/3241) by [@felixfeng33](https://github.com/felixfeng33) –
+  - Add plugins: `mediaPlaceholder`, `video`,`audio` and `file`
+  - Set the default align to 'left' in `useMediaState`
 
 ## 33.0.2
 

--- a/packages/media/src/media/useMediaState.ts
+++ b/packages/media/src/media/useMediaState.ts
@@ -66,7 +66,7 @@ export const useMediaState = ({
   const selected = useSelected();
   const readOnly = useReadOnly();
 
-  const { align = 'left', id, isUpload, name, type, url } = element;
+  const { align, id, isUpload, name, type, url } = element;
 
   const embed = React.useMemo(() => {
     if (!urlParsers || (type !== ELEMENT_VIDEO && type !== ELEMENT_MEDIA_EMBED))


### PR DESCRIPTION
`@udecode/plate-media@34.0.0` included a change to `useMediaState` that set the default `align` to 'left', overriding the defaults of 'center' specified in the image and media embed elements.

**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->
