### PR TITLE
feat: add transformInput to LinkPlugin

### DIFF
--- a/.changeset/quick-falcons-vanish.md
+++ b/.changeset/quick-falcons-vanish.md
@@ -1,0 +1,6 @@
+---
+'@udecode/plate-link': minor
+---
+
+feat:`LinkPlugin` new option `transformInput: (url: string) => string | undefined;` that optionally transform's the
+submitted URL provided by the user to the URL input before validation.

--- a/apps/www/content/docs/link.mdx
+++ b/apps/www/content/docs/link.mdx
@@ -106,6 +106,9 @@ Callback function to validate a URL.
 <APIItem name="getUrlHref" type="(url: string) => string | undefined" optional>
 Callback function to optionally get the href for a URL. It returns an optional link that is different from the text content. For example, returns `https://google.com` for `google.com`.
 </APIItem>
+<APIItem name="transformInput" type="(url: string | null) => string | undefined" optional>
+Callback function to optionally transform the submitted URL provided by the user to the URL input before validation.
+</APIItem>
 <APIItem name="getLinkUrl" type="(prevUrl: string | null) => Promise<string | null>" optional>
 On keyboard shortcut or toolbar mousedown, this function is called to get the link URL. The default behavior is to use the browser's native `prompt`.
 </APIItem>

--- a/packages/link/src/createLinkPlugin.ts
+++ b/packages/link/src/createLinkPlugin.ts
@@ -77,6 +77,17 @@ export interface LinkPlugin {
   rangeBeforeOptions?: RangeBeforeOptions;
 
   /**
+   * Transform the content of the URL input before validating it. Useful for
+   * adding a protocol to a URL. E.g. `google.com` -> `https://google.com`
+   *
+   * Similar to `getUrlHref` but is used on URL inputs. Whereas that is used on
+   * any entered text.
+   *
+   * @returns The transformed URL.
+   */
+  transformInput?: (url: string) => string | undefined;
+
+  /**
    * Hotkeys to trigger floating link.
    *
    * @default 'meta+k, ctrl+k'

--- a/packages/link/src/transforms/submitFloatingLink.ts
+++ b/packages/link/src/transforms/submitFloatingLink.ts
@@ -20,9 +20,13 @@ import { upsertLink } from './index';
 export const submitFloatingLink = <V extends Value>(editor: PlateEditor<V>) => {
   if (!editor.selection) return;
 
-  const { forceSubmit } = getPluginOptions<LinkPlugin, V>(editor, ELEMENT_LINK);
+  const { forceSubmit, transformInput } = getPluginOptions<LinkPlugin, V>(
+    editor,
+    ELEMENT_LINK
+  );
 
-  const url = floatingLinkSelectors.url();
+  const inputUrl = floatingLinkSelectors.url();
+  const url = transformInput ? transformInput(inputUrl) ?? '' : inputUrl;
 
   if (!forceSubmit && !validateUrl(editor, url)) return;
 


### PR DESCRIPTION
**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [ ] [ui changelog](apps/www/content/docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->


Adds `transformInput` option to `LinkPlugin` which allows transforming the input from the user before validation. There was already a similar function `getUrlHref` which is applied to all spaced text in the editor. I therefore made the two compatible so you can pass the same function.

However there is no existing transform being applied to the URL input which means if you use `getUrlHref` your text editor may make links out of things more permissively than the URL input itself, which is strange behaviour, e.g., if you add protocols (`google.com` => `https://google.com`).

I also made it two separate functions because you may not want to use `getUrlHref` but you may want to have more permissive URLs in the input (my case) or even if you use both `getUrlHref` may require stricter validation on the input to determine if the user intended to add an URL. 
