### PR TITLE
fix(indent-list): fix nextNodeEntry not input getSiblingIndentListOpt…

### DIFF
--- a/.changeset/grumpy-shoes-jam.md
+++ b/.changeset/grumpy-shoes-jam.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-indent-list": patch
+---
+
+fix: missing `getSiblingIndentListOptions`

--- a/packages/indent-list/src/withIndentList.ts
+++ b/packages/indent-list/src/withIndentList.ts
@@ -334,6 +334,7 @@ export const withIndentList = <
             breakOnEqIndentNeqListStyleType: false,
             breakOnLowerIndent: false,
             eqIndent: false,
+            ...getSiblingIndentListOptions,
           }
         );
 
@@ -356,6 +357,7 @@ export const withIndentList = <
           breakOnEqIndentNeqListStyleType: false,
           breakOnLowerIndent: false,
           eqIndent: false,
+          ...getSiblingIndentListOptions,
         });
 
         if (nextNodeEntry) {


### PR DESCRIPTION
fix indent-list get nextNodeEntry without getSiblingIndentListOption

**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->
