### PR TITLE
fix(serializer-md): invalid condition for ignoreParagraphNewLine

### DIFF
--- a/.changeset/ten-apes-melt.md
+++ b/.changeset/ten-apes-melt.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-serializer-md": patch
+---
+
+fix(serializer-md): invalid condition for ignoreParagraphNewLine

--- a/packages/serializer-md/src/serializer/serializeMdNode.ts
+++ b/packages/serializer-md/src/serializer/serializeMdNode.ts
@@ -171,7 +171,7 @@ export function serializeMdNode(
          * @example
          *   { type: 'paragraph', children: [   { text: '' },   { type: 'link', children: [{ text: foo.com }]}   { text: '' } ]}
          */
-        if (!isLeafNode(node) && Array.isArray(node.children)) {
+        if (!isLeafNode(c) && Array.isArray(node.children)) {
           ignoreParagraphNewlineProp = true;
         }
 


### PR DESCRIPTION
I believe the if check contains a mistake and it should check whether the child is a leaf and not the node/parent.


**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [ ] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->
