### PR TITLE
fix: link update error after umounting input

### DIFF
--- a/.changeset/purple-windows-wink.md
+++ b/.changeset/purple-windows-wink.md
@@ -2,4 +2,4 @@
 '@udecode/plate-link': patch
 ---
 
-fix: Uncaught error when dismounting the floating link input
+fix: Potential uncaught error when immediately dismounting the floating link input after update

--- a/.changeset/purple-windows-wink.md
+++ b/.changeset/purple-windows-wink.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-link': patch
+---
+
+fix: Uncaught error when dismounting the floating link input

--- a/packages/core/src/shared/plugins/createDeserializeAstPlugin.ts
+++ b/packages/core/src/shared/plugins/createDeserializeAstPlugin.ts
@@ -1,5 +1,6 @@
-import { createPluginFactory } from '../utils/createPluginFactory';
 import castArray from 'lodash/castArray.js';
+
+import { createPluginFactory } from '../utils/createPluginFactory';
 
 export const KEY_DESERIALIZE_AST = 'deserializeAst';
 

--- a/packages/link/src/components/FloatingLink/FloatingLinkUrlInput.tsx
+++ b/packages/link/src/components/FloatingLink/FloatingLinkUrlInput.tsx
@@ -17,8 +17,12 @@ export const useFloatingLinkUrlInputState = () => {
   React.useEffect(() => {
     if (ref.current && updated) {
       setTimeout(() => {
-        ref.current?.focus();
-        ref.current!.value = floatingLinkSelectors.url()
+        const input = ref.current;
+
+        if (!input) return;
+
+        input.focus();
+        input.value = floatingLinkSelectors.url()
           ? safeDecodeUrl(floatingLinkSelectors.url())
           : '';
       }, 0);


### PR DESCRIPTION
**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [ ] [ui changelog](apps/www/content/docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->

Fixes an error that happens sometimes when unmounting the Link edit input. The error itself is mostly benign as it happens inside `setTimeout` however it interferes with our testing framework and not ideal to have errors in the logs.

The Link edit input appears to work correctly despite the error:




https://github.com/user-attachments/assets/16516370-b5e5-419c-b40d-a07664d98b7c


