### PR TITLE
updates example code imports to match instructions

### DIFF
--- a/apps/www/content/docs/getting-started.mdx
+++ b/apps/www/content/docs/getting-started.mdx
@@ -40,7 +40,7 @@ npm install @udecode/plate slate slate-react slate-history slate-hyperscript rea
 Let's start with a minimal editor setup.
 
 ```tsx showLineNumbers {1,5-7}
-import { Plate } from '@udecode/plate-common';
+import { Plate, PlateContent } from '@udecode/plate-common';
 
 export default function BasicEditor() {
   return (
@@ -61,6 +61,7 @@ Let's give our editor some styles: [Editor](/docs/components/editor) is a styled
 
 ```tsx showLineNumbers {1,5-7}
 import { Plate } from '@udecode/plate-common';
+import { Editor } from '@/components/plate-ui/editor';
 
 export default function BasicEditor() {
   return (


### PR DESCRIPTION
Without the updated imports, the example code will not run. Including `PlateContent` and the full `Editor` import provides context about which components are belong to Plate and which are custom, helping bring clarity to the next explainer paragraph.

Also, as Plate is a "collection of re-usable components that you can copy and paste into your apps" if feels like a mistake that you cannot copy/paste the getting-started examples.