### PR TITLE
fix: fix type signature

### DIFF
--- a/.changeset/eight-bugs-look.md
+++ b/.changeset/eight-bugs-look.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-core': minor
+---
+
+Fix wrong typescript signature of getOption

--- a/.changeset/eight-bugs-look.md
+++ b/.changeset/eight-bugs-look.md
@@ -1,5 +1,5 @@
 ---
-'@udecode/plate-core': minor
+'@udecode/plate-core': patch
 ---
 
-Fix wrong typescript signature of getOption
+Fix wrong typescript signature of `getOption`

--- a/packages/core/src/lib/editor/SlateEditor.ts
+++ b/packages/core/src/lib/editor/SlateEditor.ts
@@ -38,7 +38,7 @@ export type BaseEditor = TEditor & {
   >(
     plugin: WithRequiredKey<C>,
     optionKey: K,
-    ...args: F extends (...args: infer A) => any ? A : never
+    ...args: F extends (...args: infer A) => any ? A : never[]
   ) => F extends (...args: any[]) => infer R ? R : F;
 
   getOptions: <C extends AnyPluginConfig = PluginConfig>(

--- a/packages/core/src/lib/plugin/BasePlugin.ts
+++ b/packages/core/src/lib/plugin/BasePlugin.ts
@@ -256,7 +256,7 @@ export type ParserOptions = {
 export type BasePluginContext<C extends AnyPluginConfig = PluginConfig> = {
   getOption: <K extends keyof InferOptions<C>, F extends InferOptions<C>[K]>(
     optionKey: K,
-    ...args: F extends (...args: infer A) => any ? A : never
+    ...args: F extends (...args: infer A) => any ? A : never[]
   ) => F extends (...args: any[]) => infer R ? R : F;
   setOption: <K extends keyof InferOptions<C>>(
     optionKey: K,


### PR DESCRIPTION
**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [ ] [ui changelog](apps/www/content/docs/components/changelog.mdx)

getOption signature when the option is not a setter function is wrong. Change to never[] instead of never
<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->
