### PR TITLE
fix: fix incorrect placeholder when both hideOnBlur and composing occurs

### DIFF
--- a/.changeset/twenty-cows-count.md
+++ b/.changeset/twenty-cows-count.md
@@ -1,5 +1,5 @@
 ---
-'@udecode/plate-utils': minor
+'@udecode/plate-utils': patch
 ---
 
 Suppress all placeholders when element is composing

--- a/.changeset/twenty-cows-count.md
+++ b/.changeset/twenty-cows-count.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-utils': minor
+---
+
+Suppress all placeholders when element is composing

--- a/packages/plate-utils/src/react/usePlaceholder.ts
+++ b/packages/plate-utils/src/react/usePlaceholder.ts
@@ -26,17 +26,13 @@ export const usePlaceholderState = ({
   const composing = useComposing();
   const editor = useEditorRef();
 
-  const isEmptyBlock = isElementEmpty(editor, element);
+  const isEmptyBlock = isElementEmpty(editor, element) && !composing;
 
   const enabled =
     isEmptyBlock &&
     (!query || queryNode([element, findNodePath(editor, element)!], query)) &&
     (!hideOnBlur ||
-      (isCollapsed(editor.selection) &&
-        hideOnBlur &&
-        focused &&
-        selected &&
-        !composing));
+      (isCollapsed(editor.selection) && hideOnBlur && focused && selected));
 
   return {
     enabled,


### PR DESCRIPTION
**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [ ] [ui changelog](apps/www/content/docs/components/changelog.mdx)

Modify logic a little bit that makes more sense.
<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->
