### PR TITLE
Fix @udecode/plate-markdown deserializing list with indented block element

### DIFF
--- a/.changeset/few-pans-float.md
+++ b/.changeset/few-pans-float.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-markdown': patch
+---
+
+Fix @udecode/plate-markdown deserializing list with indented block element

--- a/packages/markdown/src/lib/deserializer/utils/deserializeMd.spec.tsx
+++ b/packages/markdown/src/lib/deserializer/utils/deserializeMd.spec.tsx
@@ -420,4 +420,63 @@ describe('deserializeMdIndentList', () => {
 
     expect(deserializeMd(editor, input)).toEqual(output);
   });
+
+  it('should deserialize list with indented block element', () => {
+    const input = `
+- 1
+- 2
+  - 2.1
+  \`\`\`
+  2.2 code
+  \`\`\`
+`.trim();
+    const output = [
+      {
+        children: [
+          {
+            text: '1',
+          },
+        ],
+        indent: 1,
+        listStyleType: 'disc',
+        type: 'p',
+      },
+      {
+        children: [
+          {
+            text: '2',
+          },
+        ],
+        indent: 1,
+        listStyleType: 'disc',
+        type: 'p',
+      },
+      {
+        children: [
+          {
+            text: '2.1',
+          },
+        ],
+        indent: 2,
+        listStyleType: 'disc',
+        type: 'p',
+      },
+      {
+        children: [
+          {
+            children: [
+              {
+                text: '2.2 code',
+              },
+            ],
+            type: 'code_line',
+          },
+        ],
+        indent: 2,
+        type: 'code_block',
+      },
+    ];
+
+    expect(deserializeMd(editor, input)).toEqual(output);
+  });
 });

--- a/packages/markdown/src/lib/remark-slate/remarkDefaultElementRules.ts
+++ b/packages/markdown/src/lib/remark-slate/remarkDefaultElementRules.ts
@@ -3,6 +3,7 @@ import type { TDescendant, TElement, TText } from '@udecode/plate-common';
 import type { MdastNode, RemarkElementRules } from './types';
 
 import { remarkTransformElementChildren } from './remarkTransformElementChildren';
+import { remarkTransformNode } from './remarkTransformNode';
 
 // FIXME: underline, subscript superscript not yet supported by remark-slate
 export const remarkDefaultElementRules: RemarkElementRules = {
@@ -82,7 +83,21 @@ export const remarkDefaultElementRules: RemarkElementRules = {
             });
 
             subLists.forEach((subList) => {
-              parseListItems(subList, listItems, indent + 1);
+              if (subList.type === 'list') {
+                parseListItems(subList, listItems, indent + 1);
+              } else {
+                const result = remarkTransformNode(subList, options) as
+                  | TElement
+                  | TElement[];
+
+                if (Array.isArray(result)) {
+                  listItems.push(
+                    ...result.map((v) => ({ ...v, indent: indent + 1 }))
+                  );
+                } else {
+                  listItems.push({ ...result, indent: indent + 1 });
+                }
+              }
             });
           });
 


### PR DESCRIPTION
## brief

it will throw error when deserializing list with indented block element (eg. code block)  using `@udecode/plate-markdown`

<pre>
- 1
- 2
  - 2.1
  ```
  2.2 code
  ```
</pre>

it expects to render a nested code block element like this rendered by github: 

----

- 1
- 2
  - 2.1
  ```
  2.2 code
  ```

----

while using `@udecode/plate-markdown` to deserializing it will throw runtime errors.


## problem

`@udecode/plate-markdown` will treat every child of `list` as `listItem`. But it's totally legal to put another element into `list`
