### PR TITLE
fix: mention component interrupt IME

### DIFF
--- a/apps/www/content/docs/components/changelog.mdx
+++ b/apps/www/content/docs/components/changelog.mdx
@@ -8,10 +8,15 @@ Since Plate UI is not a component library, a changelog is maintained here.
 
 Use the [CLI](https://platejs.org/docs/components/cli) to install the latest version of the components.
 
+## October 2024 #15
+
+### October 1 2024 #15.1
+
+- fix `mention-element`: prevent IME input interruption on MacOS
 
 ## September 2024 #14
 
-### September 29 2024 #15
+### September 29 2024 #14.3
 
 - fix `heading-element`: if the heading is the first block, it should not have a top margin
 

--- a/apps/www/src/registry/default/plate-ui/mention-element.tsx
+++ b/apps/www/src/registry/default/plate-ui/mention-element.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import type { TMentionElement } from '@udecode/plate-mention';
 
 import { cn, withRef } from '@udecode/cn';
 import { getHandler } from '@udecode/plate-common';
 import { PlateElement, useElement } from '@udecode/plate-common/react';
+import { IS_APPLE } from '@udecode/utils';
 import { useFocused, useSelected } from 'slate-react';
 
 export const MentionElement = withRef<
@@ -18,6 +19,12 @@ export const MentionElement = withRef<
   const element = useElement<TMentionElement>();
   const selected = useSelected();
   const focused = useFocused();
+  const [isMacEnv, setIsMacEnv] = React.useState(false);
+
+  useEffect(() => {
+    // Avoid ssr hydration mismatch
+    setIsMacEnv(IS_APPLE);
+  }, []);
 
   return (
     <PlateElement
@@ -35,9 +42,21 @@ export const MentionElement = withRef<
       contentEditable={false}
       {...props}
     >
-      {prefix}
-      {renderLabel ? renderLabel(element) : element.value}
-      {children}
+      {isMacEnv ? (
+        // Mac OS IME https://github.com/ianstormtaylor/slate/issues/3490
+        <React.Fragment>
+          {children}
+          {prefix}
+          {renderLabel ? renderLabel(element) : element.value}
+        </React.Fragment>
+      ) : (
+        // Others like Android https://github.com/ianstormtaylor/slate/pull/5360
+        <React.Fragment>
+          {prefix}
+          {renderLabel ? renderLabel(element) : element.value}
+          {children}
+        </React.Fragment>
+      )}
     </PlateElement>
   );
 });

--- a/apps/www/src/registry/default/plate-ui/mention-element.tsx
+++ b/apps/www/src/registry/default/plate-ui/mention-element.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import type { TMentionElement } from '@udecode/plate-mention';
 
@@ -7,6 +7,8 @@ import { getHandler } from '@udecode/plate-common';
 import { PlateElement, useElement } from '@udecode/plate-common/react';
 import { IS_APPLE } from '@udecode/utils';
 import { useFocused, useSelected } from 'slate-react';
+
+import { useMounted } from '@/hooks/use-mounted';
 
 export const MentionElement = withRef<
   typeof PlateElement,
@@ -19,12 +21,7 @@ export const MentionElement = withRef<
   const element = useElement<TMentionElement>();
   const selected = useSelected();
   const focused = useFocused();
-  const [isMacEnv, setIsMacEnv] = React.useState(false);
-
-  useEffect(() => {
-    // Avoid ssr hydration mismatch
-    setIsMacEnv(IS_APPLE);
-  }, []);
+  const mounted = useMounted();
 
   return (
     <PlateElement
@@ -42,7 +39,7 @@ export const MentionElement = withRef<
       contentEditable={false}
       {...props}
     >
-      {isMacEnv ? (
+      {mounted && IS_APPLE ? (
         // Mac OS IME https://github.com/ianstormtaylor/slate/issues/3490
         <React.Fragment>
           {children}


### PR DESCRIPTION
I'm currently researching plate.js for its editor capabilities, and I came across an issue with the mention component similar to the one in https://github.com/ianstormtaylor/slate/pull/5685.

So I decided to fix this issue. On MacOS browsers, typing in nodes after the spacer tag interrupts the IME. Additionally, pressing the delete key at this point also causes some issues with the selection position.

<img src="https://github.com/user-attachments/assets/5324a726-51e0-4d3b-bd20-1cfbcb2bc35a" width="600px" />

Moving the spacer node forward can fix this issue. However, on Android devices, it still needs to stay in its original position.

<img src="https://github.com/user-attachments/assets/c76dbc20-8796-42b6-8336-21ba9dcfabf8" width="600px" />

**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->
