### PR TITLE
Insert link issue

### DIFF
--- a/.changeset/rich-boats-fix.md
+++ b/.changeset/rich-boats-fix.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-link": patch
+---
+
+Fixed the problem that the LinkFloatingToolbar disappears when clicking anywhere when inserting a link

--- a/packages/link/src/react/components/FloatingLink/useFloatingLinkEdit.ts
+++ b/packages/link/src/react/components/FloatingLink/useFloatingLinkEdit.ts
@@ -122,6 +122,8 @@ export const useFloatingLinkEdit = ({
   useFloatingLinkEscape();
 
   const clickOutsideRef = useOnClickOutside(() => {
+    if (!getOptions().isEditing) return;
+
     api.floatingLink.hide();
   });
 


### PR DESCRIPTION
Fixed the problem that the LinkFloatingToolbar disappears when clicking anywhere when inserting a link

**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)

[video:before](https://github.com/user-attachments/assets/44575852-bc5b-4cc7-81c9-302d5473606d)

[video:after](https://github.com/user-attachments/assets/8bb2e224-008e-4596-9dd6-f5cf2a20d47f)
