### PR TITLE
Fix/indent list

### DIFF
--- a/.changeset/silly-seas-compare.md
+++ b/.changeset/silly-seas-compare.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-indent-list": patch
+---
+
+Fix the problem that the sequence number does not continue when inserting a line break in the listRestart node.

--- a/packages/indent-list/src/lib/transforms/toggleIndentList.ts
+++ b/packages/indent-list/src/lib/transforms/toggleIndentList.ts
@@ -1,6 +1,6 @@
 import {
-  ElementEntryOf,
-  ElementOf,
+  type ElementEntryOf,
+  type ElementOf,
   type SlateEditor,
   type TElement,
   getBlockAbove,
@@ -13,6 +13,7 @@ import {
 } from '@udecode/plate-common';
 import { BaseIndentPlugin } from '@udecode/plate-indent';
 
+import type { GetSiblingIndentListOptions } from '../queries';
 import type { IndentListOptions } from './indentList';
 
 import {
@@ -24,7 +25,6 @@ import { setIndentListNodes } from './setIndentListNodes';
 import { setIndentListSiblingNodes } from './setIndentListSiblingNodes';
 import { toggleIndentListSet } from './toggleIndentListSet';
 import { toggleIndentListUnset } from './toggleIndentListUnset';
-import { GetSiblingIndentListOptions } from '../queries';
 
 /** Toggle indent list. */
 export const toggleIndentList = <
@@ -52,8 +52,10 @@ export const toggleIndentList = <
     }
 
     setIndentListSiblingNodes(editor, entry as ElementEntryOf<E>, {
-      ..._getSiblingIndentListOptions,
-      ...getSiblingIndentListOptions,
+      getSiblingIndentListOptions: {
+        ..._getSiblingIndentListOptions,
+        ...getSiblingIndentListOptions,
+      } as GetSiblingIndentListOptions<ElementOf<E>, E>,
       listStyleType,
     });
 

--- a/packages/indent-list/src/lib/transforms/toggleIndentList.ts
+++ b/packages/indent-list/src/lib/transforms/toggleIndentList.ts
@@ -1,4 +1,6 @@
 import {
+  ElementEntryOf,
+  ElementOf,
   type SlateEditor,
   type TElement,
   getBlockAbove,
@@ -22,15 +24,20 @@ import { setIndentListNodes } from './setIndentListNodes';
 import { setIndentListSiblingNodes } from './setIndentListSiblingNodes';
 import { toggleIndentListSet } from './toggleIndentListSet';
 import { toggleIndentListUnset } from './toggleIndentListUnset';
+import { GetSiblingIndentListOptions } from '../queries';
 
 /** Toggle indent list. */
-export const toggleIndentList = <E extends SlateEditor>(
+export const toggleIndentList = <
+  N extends ElementOf<E>,
+  E extends SlateEditor = SlateEditor,
+>(
   editor: E,
-  options: IndentListOptions<E>
+  options: IndentListOptions<E>,
+  getSiblingIndentListOptions?: GetSiblingIndentListOptions<N, E>
 ) => {
   const { listStyleType } = options;
 
-  const { getSiblingIndentListOptions } =
+  const { getSiblingIndentListOptions: _getSiblingIndentListOptions } =
     editor.getOptions(BaseIndentListPlugin);
 
   if (isCollapsed(editor.selection)) {
@@ -44,8 +51,9 @@ export const toggleIndentList = <E extends SlateEditor>(
       return;
     }
 
-    setIndentListSiblingNodes(editor, entry, {
-      getSiblingIndentListOptions,
+    setIndentListSiblingNodes(editor, entry as ElementEntryOf<E>, {
+      ..._getSiblingIndentListOptions,
+      ...getSiblingIndentListOptions,
       listStyleType,
     });
 


### PR DESCRIPTION
**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)

The first commit fixes the problem that the sequence number does not continue when inserting a line break in the listRestart node. The rest are some enhancements to the indent list.

[video:before](https://github.com/user-attachments/assets/8f1fb1a8-7d09-4bc3-b8f6-f94dbd4e559e)

[video:after](https://github.com/user-attachments/assets/8020c76b-4207-4c27-baa5-a5d445a326af)
