### PR TITLE
Introducing Plate Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Plate
   <a target="_blank" href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
   <a target="_blank" href="https://discord.gg/mAZRuBzGM3"><img src="https://img.shields.io/badge/chat-on%20discord-7289da.svg?sanitize=true" /></a>
   <a target="_blank" href="https://github.com/udecode/plate/blob/main/LICENSE"><img src="https://badgen.now.sh/badge/license/MIT" /></a>
+  <a target="_blank" href="https://gurubase.io/g/plate"><img src="https://img.shields.io/badge/Gurubase-Ask%20Plate%20Guru-006BFF" alt="Gurubase"></a>
 </div>
 <div align="center">
 <a href="https://console.algora.io/org/Udecode/bounties/new">


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Plate Guru](https://gurubase.io/g/plate) to Gurubase. Plate Guru uses the data from this repo and data from the [docs](https://platejs.org/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "Plate Guru", which highlights that Plate now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Plate Guru in Gurubase, just let me know that's totally fine.
