### PR TITLE
fix: parseTwitterUrl logic

### DIFF
--- a/.changeset/clean-cups-sort.md
+++ b/.changeset/clean-cups-sort.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-media": patch
+---
+
+fix: `parseTwitterUrl`

--- a/packages/media/src/lib/media-embed/parseTwitterUrl.ts
+++ b/packages/media/src/lib/media-embed/parseTwitterUrl.ts
@@ -3,10 +3,13 @@ import type { EmbedUrlData } from '../media/parseMediaUrl';
 const twitterRegex =
   /^https?:\/\/(?:twitter|x)\.com\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)/;
 
+const TWITTER_ID_INDEX = 3
+
 export const parseTwitterUrl = (url: string): EmbedUrlData | undefined => {
-  if (twitterRegex.exec(url)) {
+  const match = twitterRegex.exec(url);
+  if (match) {
     return {
-      id: twitterRegex.exec(url)?.groups?.id,
+      id: match[TWITTER_ID_INDEX],
       provider: 'twitter',
       url,
     };


### PR DESCRIPTION
**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->


Currently, the logic for parsing Twitter URLs does not work in x. So I modified the existing logic. 

You can test it through the URL below.

https://x.com/pudgypenguins/status/1789664435079975016

