### PR TITLE
fix: caption text area korean ime issue

### DIFF
--- a/.changeset/beige-peaches-divide.md
+++ b/.changeset/beige-peaches-divide.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-caption": patch
+---
+
+fix: caption text area korean ime issue


### PR DESCRIPTION
**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->


hello. When using Caption, there was an issue where each Korean character was cut off when entering Korean characters. A video is attached for explanation.

![화면 기록 2024-11-22 오후 7 36 44](https://github.com/user-attachments/assets/91f3efc2-d971-4fe4-b654-d5019e0cad2a)

I thought it was an IME issue and modified the code.

And the result is as shown in the video below.

![화면 기록 2024-11-22 오후 7 40 16](https://github.com/user-attachments/assets/3fb20238-264c-4550-b4ee-65ea969b6fd3)

I didn't know how to test the plate example within the package, so I brought the source locally, modified it, and checked its operation.

I am willing to continue contributing to your project. It would be good if the contributing guidelines included guidelines on how to test immediately after changing a component or plugin.

If you don't like the source code, you can modify it at will.
