### PR TITLE
fix: correct documentation for onValueChange

### DIFF
--- a/apps/www/content/docs/api/core/plate.mdx
+++ b/apps/www/content/docs/api/core/plate.mdx
@@ -25,7 +25,7 @@ Controlled callback called when the editor state changes.
 <APIItem name="onSelectionChange" type="(selection: Range | null) => void" optional>
 Callback called when the editor selection changes.
 </APIItem>
-<APIItem name="onValueChange" type="(value: Value) => void" optional>
+<APIItem name="onValueChange" type="({ value, editor }: { value: Value; editor: PlateEditor }) => void" optional>
 Callback called when the editor value changes.
 </APIItem>
 <APIItem name="primary" type="boolean" optional>


### PR DESCRIPTION
I noticed that some of the documentation was outdated for `onValueChange`

**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->
