### PR TITLE
fix: correct setvalue in equation input behavior

### DIFF
--- a/.changeset/pink-pillows-end.md
+++ b/.changeset/pink-pillows-end.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-math": patch
+---
+
+Fixes #3851

--- a/packages/math/src/react/hooks/useEquationInput.ts
+++ b/packages/math/src/react/hooks/useEquationInput.ts
@@ -23,9 +23,11 @@ export const useEquationInput = ({
   const element = useElement<TEquationElement>();
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
-  const [initialExpression, setInitialExpression] = React.useState<
-    string | null
-  >(null);
+  const [expressionInput, setExpressionInput] = React.useState<string>(
+    element.texExpression
+  );
+
+  const initialExpressionRef = useRef<string>(element.texExpression);
 
   useEffect(() => {
     if (open) {
@@ -35,13 +37,20 @@ export const useEquationInput = ({
           inputRef.current.select();
 
           if (isInline) {
-            setInitialExpression(element.texExpression);
+            initialExpressionRef.current = element.texExpression;
           }
         }
       }, 0);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
+
+  useEffect(() => {
+    setNode<TEquationElement>(editor, element, {
+      texExpression: expressionInput || '',
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expressionInput]);
 
   const onSubmit = () => {
     onClose?.();
@@ -50,7 +59,7 @@ export const useEquationInput = ({
   const onDismiss = () => {
     if (isInline) {
       setNode(editor, element, {
-        texExpression: initialExpression ?? '',
+        texExpression: initialExpressionRef.current,
       });
     }
 
@@ -59,11 +68,9 @@ export const useEquationInput = ({
 
   return {
     props: {
-      value: element.texExpression,
+      value: expressionInput,
       onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-        setNode<TEquationElement>(editor, element, {
-          texExpression: e.target.value,
-        });
+        setExpressionInput(e.target.value);
       },
       onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
         if (isHotkey('enter')(e)) {


### PR DESCRIPTION
fix for #3851 
I tried setting the caret position manually through reference of this [fix](https://stackoverflow.com/questions/46000544/react-controlled-input-cursor-jumps), but it seems that input of foreign character (e.g. Chinese) through a virtual keyboard still has the same issue.
It seems that the original logic is just to reset the value to the previous when it closes on dismiss, so i used just store a value in ref on open and set it back on close

**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->
