### PR TITLE
add vscode data paste handle

### DIFF
--- a/.changeset/few-knives-refuse.md
+++ b/.changeset/few-knives-refuse.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-code-block": patch
+---
+
+add vscode data paste handle

--- a/packages/code-block/src/lib/insertDataCodeBlock.ts
+++ b/packages/code-block/src/lib/insertDataCodeBlock.ts
@@ -1,0 +1,43 @@
+import { type SlateEditor, insertNodes } from '@udecode/plate-common';
+
+import { BaseCodeBlockPlugin, BaseCodeLinePlugin } from './BaseCodeBlockPlugin';
+
+export function insertDataCodeBlock(editor: SlateEditor) {
+  const { insertData } = editor;
+
+  return (data: DataTransfer) => {
+    const text = data.getData('text/plain');
+    const vscodeDataString = data.getData('vscode-editor-data');
+
+    if (vscodeDataString) {
+      try {
+        const vscodeData = JSON.parse(vscodeDataString);
+
+        const lines = text.split('\n');
+        const codeLineType = editor.getType(BaseCodeLinePlugin);
+        const codeBlockType = editor.getType(BaseCodeBlockPlugin);
+
+        const node = {
+          children: lines.map((line) => ({
+            children: [
+              {
+                text: line,
+              },
+            ],
+            type: codeLineType,
+          })),
+          lang: vscodeData?.mode,
+          type: codeBlockType,
+        };
+
+        insertNodes(editor, node, {
+          select: true,
+        });
+
+        return;
+      } catch (error) {}
+    }
+
+    insertData(data);
+  };
+}

--- a/packages/code-block/src/lib/withCodeBlock.ts
+++ b/packages/code-block/src/lib/withCodeBlock.ts
@@ -2,6 +2,7 @@ import type { ExtendEditor } from '@udecode/plate-common';
 
 import type { CodeBlockConfig } from './BaseCodeBlockPlugin';
 
+import { insertDataCodeBlock } from './insertDataCodeBlock';
 import { insertFragmentCodeBlock } from './insertFragmentCodeBlock';
 import { normalizeCodeBlock } from './normalizers/normalizeCodeBlock';
 import { getCodeLineEntry, getIndentDepth } from './queries';
@@ -43,6 +44,8 @@ export const withCodeBlock: ExtendEditor<CodeBlockConfig> = ({ editor }) => {
   editor.insertFragment = insertFragmentCodeBlock(editor);
 
   editor.normalizeNode = normalizeCodeBlock(editor);
+
+  editor.insertData = insertDataCodeBlock(editor);
 
   return editor;
 };


### PR DESCRIPTION
When pasting from vscode, automatically turn it into a code block with the correct language

**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [ ] `yarn changeset`
- [ ] [ui changelog](apps/www/content/docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->
