### PR TITLE
fix: add other methods in createSlatePlugin that copies a plugin to wrap

### DIFF
--- a/.changeset/famous-terms-battle.md
+++ b/.changeset/famous-terms-battle.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-core': minor
+---
+
+patch

--- a/packages/core/src/react/plugin/toPlatePlugin.ts
+++ b/packages/core/src/react/plugin/toPlatePlugin.ts
@@ -40,11 +40,13 @@ const methodsToWrap: (keyof SlatePlugin)[] = [
   'configure',
   'configurePlugin',
   'extendEditorApi',
+  'extendOptions',
   'extendApi',
   'extendEditorTransforms',
+  'extendTransforms',
+  'overrideEditor',
   'extend',
   'extendPlugin',
-  'overrideEditor',
 ];
 
 /**


### PR DESCRIPTION
**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [ ] [ui changelog](apps/www/content/docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->

Adding more methods, currently LinkPlugin.withComponent still do not exist
