### PR TITLE
Add option to change the default plugin to use when deserializing html

### DIFF
--- a/.changeset/cool-sloths-protect.md
+++ b/.changeset/cool-sloths-protect.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-core': minor
+---
+
+Add new param to HTML deserializer for changing the default element

--- a/.changeset/cool-sloths-protect.md
+++ b/.changeset/cool-sloths-protect.md
@@ -1,5 +1,5 @@
 ---
-'@udecode/plate-core': minor
+'@udecode/plate-core': patch
 ---
 
 Add new param to HTML deserializer for changing the default element

--- a/packages/core/src/lib/plugins/html/utils/deserializeHtml.ts
+++ b/packages/core/src/lib/plugins/html/utils/deserializeHtml.ts
@@ -1,7 +1,7 @@
 import type { Descendant } from '@udecode/slate';
 
 import type { SlateEditor } from '../../../editor';
-import type { SlatePlugin } from '../../../plugin';
+import type { WithRequiredKey } from '../../../plugin';
 
 import { normalizeDescendantsToDocumentFragment } from '../../../utils/normalizeDescendantsToDocumentFragment';
 import { collapseWhiteSpace } from './collapse-white-space';
@@ -18,7 +18,7 @@ export const deserializeHtml = (
   }: {
     element: HTMLElement | string;
     collapseWhiteSpace?: boolean;
-    defaultElementPlugin?: SlatePlugin;
+    defaultElementPlugin?: WithRequiredKey;
   }
 ): Descendant[] => {
   // for serializer

--- a/packages/core/src/lib/plugins/html/utils/deserializeHtml.ts
+++ b/packages/core/src/lib/plugins/html/utils/deserializeHtml.ts
@@ -1,6 +1,7 @@
 import type { Descendant } from '@udecode/slate';
 
 import type { SlateEditor } from '../../../editor';
+import type { SlatePlugin } from '../../../plugin';
 
 import { normalizeDescendantsToDocumentFragment } from '../../../utils/normalizeDescendantsToDocumentFragment';
 import { collapseWhiteSpace } from './collapse-white-space';
@@ -12,10 +13,12 @@ export const deserializeHtml = (
   editor: SlateEditor,
   {
     collapseWhiteSpace: shouldCollapseWhiteSpace = true,
+    defaultElementPlugin,
     element,
   }: {
     element: HTMLElement | string;
     collapseWhiteSpace?: boolean;
+    defaultElementPlugin?: SlatePlugin;
   }
 ): Descendant[] => {
   // for serializer
@@ -29,6 +32,7 @@ export const deserializeHtml = (
   const fragment = deserializeHtmlElement(editor, element) as Descendant[];
 
   return normalizeDescendantsToDocumentFragment(editor, {
+    defaultElementPlugin,
     descendants: fragment,
   });
 };

--- a/packages/core/src/lib/utils/normalizeDescendantsToDocumentFragment.spec.tsx
+++ b/packages/core/src/lib/utils/normalizeDescendantsToDocumentFragment.spec.tsx
@@ -1,6 +1,9 @@
+import { BaseBlockquotePlugin } from '@udecode/plate-block-quote';
 /** @jsx jsxt */
 import { LinkPlugin } from '@udecode/plate-link/react';
 import { jsxt } from '@udecode/plate-test-utils';
+
+import type { SlatePlugin } from '../plugin';
 
 import { createPlateEditor } from '../../react';
 import { normalizeDescendantsToDocumentFragment } from './index';
@@ -107,6 +110,81 @@ describe('normalizeDescendantsToDocumentFragment()', () => {
       });
 
       const result = normalizeDescendantsToDocumentFragment(editor, {
+        descendants: input,
+      });
+      expect(result).toEqual(output);
+    }
+  );
+
+  it.each([
+    {
+      input: [<htext>text node</htext>, <htext>another text node</htext>],
+      output: [<htext>text node</htext>, <htext>another text node</htext>],
+    },
+    {
+      input: [<ha>inline element</ha>, <htext>text node</htext>],
+      output: [<ha>inline element</ha>, <htext>text node</htext>],
+    },
+    {
+      input: [<hp>block</hp>, <hp>another block</hp>, <htext>text node</htext>],
+      output: [
+        <hp>block</hp>,
+        <hp>another block</hp>,
+        <hblockquote>text node</hblockquote>,
+      ],
+    },
+    {
+      input: [<ha>inline element</ha>, <hp>block</hp>],
+      output: [
+        <hblockquote>
+          <ha>inline element</ha>
+        </hblockquote>,
+        <hp>block</hp>,
+      ],
+    },
+    {
+      input: [
+        <htext>text 1</htext>,
+        <htext>text 2</htext>,
+        <hp>block</hp>,
+        <htext>text 3</htext>,
+        <htext>text 4</htext>,
+      ],
+      output: [
+        <hblockquote>
+          <htext>text 1</htext>
+          <htext>text 2</htext>
+        </hblockquote>,
+        <hp>block</hp>,
+        <hblockquote>
+          <htext>text 3</htext>
+          <htext>text 4</htext>
+        </hblockquote>,
+      ],
+    },
+    {
+      input: [
+        <hp>
+          <htext>text node</htext>
+          <hp>block</hp>
+        </hp>,
+      ],
+      output: [
+        <hp>
+          <hblockquote>text node</hblockquote>
+          <hp>block</hp>
+        </hp>,
+      ],
+    },
+  ])(
+    'should wrap inline blocks and text nodes in case they have a sibling block',
+    ({ input, output }: any) => {
+      const editor = createPlateEditor({
+        plugins: [LinkPlugin],
+      });
+
+      const result = normalizeDescendantsToDocumentFragment(editor, {
+        defaultElementPlugin: BaseBlockquotePlugin as SlatePlugin,
         descendants: input,
       });
       expect(result).toEqual(output);

--- a/packages/core/src/lib/utils/normalizeDescendantsToDocumentFragment.spec.tsx
+++ b/packages/core/src/lib/utils/normalizeDescendantsToDocumentFragment.spec.tsx
@@ -1,11 +1,8 @@
-import { BaseBlockquotePlugin } from '@udecode/plate-block-quote';
 /** @jsx jsxt */
 import { LinkPlugin } from '@udecode/plate-link/react';
 import { jsxt } from '@udecode/plate-test-utils';
 
-import type { SlatePlugin } from '../plugin';
-
-import { createPlateEditor } from '../../react';
+import { createPlateEditor, createPlatePlugin } from '../../react';
 import { normalizeDescendantsToDocumentFragment } from './index';
 
 jsxt;
@@ -179,12 +176,17 @@ describe('normalizeDescendantsToDocumentFragment()', () => {
   ])(
     'should wrap inline blocks and text nodes in case they have a sibling block',
     ({ input, output }: any) => {
+      const BaseBlockquotePlugin = createPlatePlugin({
+        key: 'blockquote',
+        node: { isElement: true },
+      });
+
       const editor = createPlateEditor({
         plugins: [LinkPlugin],
       });
 
       const result = normalizeDescendantsToDocumentFragment(editor, {
-        defaultElementPlugin: BaseBlockquotePlugin as SlatePlugin,
+        defaultElementPlugin: BaseBlockquotePlugin,
         descendants: input,
       });
       expect(result).toEqual(output);

--- a/packages/core/src/lib/utils/normalizeDescendantsToDocumentFragment.ts
+++ b/packages/core/src/lib/utils/normalizeDescendantsToDocumentFragment.ts
@@ -6,7 +6,7 @@ import {
 } from '@udecode/slate';
 
 import type { SlateEditor } from '../editor';
-import type { SlatePlugin } from '../plugin';
+import type { WithRequiredKey } from '../plugin';
 
 import { BaseParagraphPlugin } from '../plugins';
 
@@ -121,7 +121,7 @@ export const normalizeDescendantsToDocumentFragment = (
   {
     defaultElementPlugin = BaseParagraphPlugin,
     descendants,
-  }: { descendants: Descendant[]; defaultElementPlugin?: SlatePlugin }
+  }: { descendants: Descendant[]; defaultElementPlugin?: WithRequiredKey }
 ): Descendant[] => {
   const isInline = isInlineNode(editor);
   const defaultType = editor.getType(defaultElementPlugin);

--- a/packages/core/src/lib/utils/normalizeDescendantsToDocumentFragment.ts
+++ b/packages/core/src/lib/utils/normalizeDescendantsToDocumentFragment.ts
@@ -6,6 +6,7 @@ import {
 } from '@udecode/slate';
 
 import type { SlateEditor } from '../editor';
+import type { SlatePlugin } from '../plugin';
 
 import { BaseParagraphPlugin } from '../plugins';
 
@@ -117,10 +118,13 @@ const normalize = (
 /** Normalize the descendants to a valid document fragment. */
 export const normalizeDescendantsToDocumentFragment = (
   editor: SlateEditor,
-  { descendants }: { descendants: Descendant[] }
+  {
+    defaultElementPlugin = BaseParagraphPlugin,
+    descendants,
+  }: { descendants: Descendant[]; defaultElementPlugin?: SlatePlugin }
 ): Descendant[] => {
   const isInline = isInlineNode(editor);
-  const defaultType = editor.getType(BaseParagraphPlugin);
+  const defaultType = editor.getType(defaultElementPlugin);
   const makeDefaultBlock = makeBlockLazy(defaultType);
 
   return normalize(descendants, isInline, makeDefaultBlock as any);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6226,7 +6226,7 @@ __metadata:
   dependencies:
     "@udecode/plate-combobox": "npm:42.0.0"
     "@udecode/plate-markdown": "npm:42.0.3"
-    "@udecode/plate-selection": "npm:42.0.3"
+    "@udecode/plate-selection": "npm:42.2.0"
     ai: "npm:^3.4.10"
     lodash: "npm:^4.17.21"
   peerDependencies:
@@ -6242,7 +6242,7 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6255,7 +6255,7 @@ __metadata:
     "@udecode/plate": "workspace:^"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6267,10 +6267,10 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
     "@udecode/plate-block-quote": "npm:42.0.0"
-    "@udecode/plate-code-block": "npm:42.0.5"
+    "@udecode/plate-code-block": "npm:42.1.1"
     "@udecode/plate-heading": "npm:42.0.0"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6282,7 +6282,7 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6294,7 +6294,7 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6306,7 +6306,7 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6318,7 +6318,7 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6331,20 +6331,20 @@ __metadata:
     "@udecode/plate": "workspace:^"
     react-textarea-autosize: "npm:^8.5.3"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-code-block@npm:42.0.5, @udecode/plate-code-block@workspace:^, @udecode/plate-code-block@workspace:packages/code-block":
+"@udecode/plate-code-block@npm:42.1.1, @udecode/plate-code-block@workspace:^, @udecode/plate-code-block@workspace:packages/code-block":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-code-block@workspace:packages/code-block"
   dependencies:
     "@udecode/plate": "workspace:^"
     prismjs: "npm:^1.29.0"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6356,7 +6356,7 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6369,13 +6369,13 @@ __metadata:
     "@udecode/plate": "workspace:^"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-core@npm:42.0.6, @udecode/plate-core@workspace:^, @udecode/plate-core@workspace:packages/core":
+"@udecode/plate-core@npm:42.1.2, @udecode/plate-core@workspace:^, @udecode/plate-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-core@workspace:packages/core"
   dependencies:
@@ -6409,10 +6409,10 @@ __metadata:
   dependencies:
     "@types/papaparse": "npm:^5.3.14"
     "@udecode/plate": "workspace:^"
-    "@udecode/plate-table": "npm:42.0.5"
+    "@udecode/plate-table": "npm:42.1.1"
     papaparse: "npm:^5.4.1"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6424,7 +6424,7 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6436,7 +6436,7 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6450,7 +6450,7 @@ __metadata:
     diff-match-patch-ts: "npm:^0.6.0"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6464,7 +6464,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     raf: "npm:^3.4.1"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dnd: ">=14.0.0"
     react-dnd-html5-backend: ">=14.0.0"
@@ -6479,12 +6479,12 @@ __metadata:
     "@udecode/plate": "workspace:^"
     "@udecode/plate-heading": "npm:42.0.0"
     "@udecode/plate-indent": "npm:42.0.0"
-    "@udecode/plate-indent-list": "npm:42.0.5"
-    "@udecode/plate-media": "npm:42.0.5"
-    "@udecode/plate-table": "npm:42.0.5"
+    "@udecode/plate-indent-list": "npm:42.1.1"
+    "@udecode/plate-media": "npm:42.1.1"
+    "@udecode/plate-table": "npm:42.1.1"
     validator: "npm:^13.12.0"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6499,7 +6499,7 @@ __metadata:
     "@udecode/plate-combobox": "npm:42.0.0"
   peerDependencies:
     "@emoji-mart/data": ">=1.2.0"
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6512,7 +6512,7 @@ __metadata:
     "@excalidraw/excalidraw": "npm:0.16.4"
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6524,7 +6524,7 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6538,7 +6538,7 @@ __metadata:
     "@floating-ui/react": "npm:^0.26.23"
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6551,7 +6551,7 @@ __metadata:
     "@udecode/plate": "workspace:^"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6563,7 +6563,7 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6575,7 +6575,7 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6587,13 +6587,13 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-indent-list@npm:42.0.5, @udecode/plate-indent-list@workspace:^, @udecode/plate-indent-list@workspace:packages/indent-list":
+"@udecode/plate-indent-list@npm:42.1.1, @udecode/plate-indent-list@workspace:^, @udecode/plate-indent-list@workspace:packages/indent-list":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-indent-list@workspace:packages/indent-list"
   dependencies:
@@ -6602,7 +6602,7 @@ __metadata:
     "@udecode/plate-list": "npm:42.0.0"
     clsx: "npm:^2.1.1"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6614,7 +6614,7 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6627,7 +6627,7 @@ __metadata:
     "@udecode/plate": "workspace:^"
     juice: "npm:^8.1.0"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6639,7 +6639,7 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6651,7 +6651,7 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6663,7 +6663,7 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6677,7 +6677,7 @@ __metadata:
     "@udecode/plate-floating": "npm:42.0.0"
     "@udecode/plate-normalizers": "npm:42.0.0"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6691,7 +6691,7 @@ __metadata:
     "@udecode/plate-reset-node": "npm:42.0.0"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6708,7 +6708,7 @@ __metadata:
     remark-parse: "npm:^11.0.0"
     unified: "npm:^11.0.5"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6722,20 +6722,20 @@ __metadata:
     "@udecode/plate": "workspace:^"
     katex: "npm:0.16.11"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-media@npm:42.0.5, @udecode/plate-media@workspace:^, @udecode/plate-media@workspace:packages/media":
+"@udecode/plate-media@npm:42.1.1, @udecode/plate-media@workspace:^, @udecode/plate-media@workspace:packages/media":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-media@workspace:packages/media"
   dependencies:
     "@udecode/plate": "workspace:^"
     js-video-url-parser: "npm:^0.5.1"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6748,7 +6748,7 @@ __metadata:
     "@udecode/plate": "workspace:^"
     "@udecode/plate-combobox": "npm:42.0.0"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6761,7 +6761,7 @@ __metadata:
     "@udecode/plate": "workspace:^"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6774,7 +6774,7 @@ __metadata:
     "@udecode/plate": "workspace:^"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6787,7 +6787,7 @@ __metadata:
     "@udecode/plate": "workspace:^"
   peerDependencies:
     "@playwright/test": ">=1.42.1"
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6799,7 +6799,7 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6811,7 +6811,7 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6823,20 +6823,20 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-selection@npm:42.0.3, @udecode/plate-selection@workspace:^, @udecode/plate-selection@workspace:packages/selection":
+"@udecode/plate-selection@npm:42.2.0, @udecode/plate-selection@workspace:^, @udecode/plate-selection@workspace:packages/selection":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-selection@workspace:packages/selection"
   dependencies:
     "@udecode/plate": "workspace:^"
     copy-to-clipboard: "npm:^3.3.3"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6849,7 +6849,7 @@ __metadata:
     "@udecode/plate": "workspace:^"
     "@udecode/plate-combobox": "npm:42.0.0"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6863,7 +6863,7 @@ __metadata:
     "@udecode/plate-diff": "npm:42.0.0"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6876,13 +6876,13 @@ __metadata:
     "@udecode/plate": "workspace:^"
     tabbable: "npm:^6.2.0"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-table@npm:42.0.5, @udecode/plate-table@workspace:^, @udecode/plate-table@workspace:packages/table":
+"@udecode/plate-table@npm:42.1.1, @udecode/plate-table@workspace:^, @udecode/plate-table@workspace:packages/table":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-table@workspace:packages/table"
   dependencies:
@@ -6891,7 +6891,7 @@ __metadata:
     "@udecode/plate-resizable": "npm:42.0.0"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6903,7 +6903,7 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6927,7 +6927,7 @@ __metadata:
     "@udecode/plate-node-id": "npm:42.0.0"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6939,17 +6939,17 @@ __metadata:
   dependencies:
     "@udecode/plate": "workspace:^"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
   linkType: soft
 
-"@udecode/plate-utils@npm:42.0.6, @udecode/plate-utils@workspace:^, @udecode/plate-utils@workspace:packages/plate-utils":
+"@udecode/plate-utils@npm:42.1.2, @udecode/plate-utils@workspace:^, @udecode/plate-utils@workspace:packages/plate-utils":
   version: 0.0.0-use.local
   resolution: "@udecode/plate-utils@workspace:packages/plate-utils"
   dependencies:
-    "@udecode/plate-core": "npm:42.0.6"
+    "@udecode/plate-core": "npm:42.1.2"
     "@udecode/react-utils": "npm:42.0.0"
     "@udecode/slate": "npm:42.0.3"
     "@udecode/utils": "npm:42.0.0"
@@ -6970,7 +6970,7 @@ __metadata:
     "@udecode/plate": "workspace:^"
     yjs: "npm:^13.6.19"
   peerDependencies:
-    "@udecode/plate": ">=42.0.6"
+    "@udecode/plate": ">=42.1.2"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -6980,8 +6980,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@udecode/plate@workspace:packages/plate"
   dependencies:
-    "@udecode/plate-core": "npm:42.0.6"
-    "@udecode/plate-utils": "npm:42.0.6"
+    "@udecode/plate-core": "npm:42.1.2"
+    "@udecode/plate-utils": "npm:42.1.2"
     "@udecode/react-hotkeys": "npm:37.0.0"
     "@udecode/react-utils": "npm:42.0.0"
     "@udecode/slate": "npm:42.0.3"


### PR DESCRIPTION
**Checklist**
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn changeset`

Parametrize the default element used when deserializing HTML

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->
