### PR TITLE
fix

### DIFF
--- a/apps/www/src/registry/default/components/editor/plugins/autoformat-list-plugin.ts
+++ b/apps/www/src/registry/default/components/editor/plugins/autoformat-list-plugin.ts
@@ -199,7 +199,6 @@ export const autoformatBlocks: AutoformatRule[] = [
     match: '```',
     mode: 'block',
     preFormat,
-    triggerAtBlockStart: false,
     type: CodeBlockPlugin.key,
   },
   {

--- a/apps/www/src/registry/default/components/editor/plugins/autoformat-plugin.ts
+++ b/apps/www/src/registry/default/components/editor/plugins/autoformat-plugin.ts
@@ -175,7 +175,6 @@ export const autoformatBlocks: AutoformatRule[] = [
     },
     match: '```',
     mode: 'block',
-    triggerAtBlockStart: false,
     type: CodeBlockPlugin.key,
   },
   {

--- a/templates/plate-playground-template/src/components/editor/plugins/autoformat-plugin.ts
+++ b/templates/plate-playground-template/src/components/editor/plugins/autoformat-plugin.ts
@@ -175,7 +175,6 @@ export const autoformatBlocks: AutoformatRule[] = [
     },
     match: '```',
     mode: 'block',
-    triggerAtBlockStart: false,
     type: CodeBlockPlugin.key,
   },
   {


### PR DESCRIPTION
removes `triggerAtBlockStart` from `autoformatBlocks`

**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->
