### PR TITLE
Fix props injection condition check for elements

### DIFF
--- a/.changeset/curly-hornets-judge.md
+++ b/.changeset/curly-hornets-judge.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-core': patch
+---
+
+Fixed props injection match check for elements

--- a/packages/core/src/lib/utils/getInjectMatch.ts
+++ b/packages/core/src/lib/utils/getInjectMatch.ts
@@ -24,7 +24,7 @@ export const getInjectMatch = <E extends SlateEditor>(
 
     const element = ElementApi.isElement(node) ? node : undefined;
 
-    if (_isElement && element) return false;
+    if (_isElement && !element) return false;
     if (_isBlock && (!element || !editor.api.isBlock(element))) return false;
     if (isLeaf && element) return false;
     if (element?.type) {


### PR DESCRIPTION
It should exit if the injection is intended for elements (`isElement`) and if the current node is NOT an element.

**Checklist**
- [x] `yarn typecheck`  &mdash;  **the command does not exist**
- [x] `yarn lint:fix` &mdash;  **the command does not exist**
- [x] `yarn test`
- [x] `yarn brl`  &mdash;   **the command does not exist**
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx) &mdash; no UI changes

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->
