### PR TITLE
fix: change how aboveNodes/belowNodes are applied

### DIFF
--- a/.changeset/eight-melons-perform.md
+++ b/.changeset/eight-melons-perform.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-core': patch
+---
+
+change `aboveNodes` and `belowNodes` to React component instead of direct function call"

--- a/apps/www/src/registry/default/plate-ui/draggable.tsx
+++ b/apps/www/src/registry/default/plate-ui/draggable.tsx
@@ -85,7 +85,7 @@ export const DraggableAboveNodes: NodeWrapperComponent = (props) => {
 
   if (!enabled) return;
 
-  return (props) => <Draggable {...props} />;
+  return Draggable;
 };
 
 export const Draggable = withRef<'div', PlateRenderElementProps>(

--- a/packages/core/src/lib/static/pluginRenderElementStatic.tsx
+++ b/packages/core/src/lib/static/pluginRenderElementStatic.tsx
@@ -47,10 +47,10 @@ export const pluginRenderElementStatic = (
       }) as any;
 
       belowNodes.forEach((withHOC) => {
-        const hoc = withHOC({ ...nodeProps, key } as any);
+        const HOC = withHOC({ ...nodeProps, key } as any);
 
-        if (hoc) {
-          children = hoc({ ...nodeProps, children } as any);
+        if (HOC) {
+          children = <HOC {...nodeProps}>{children}</HOC>;
         }
       });
 
@@ -59,10 +59,10 @@ export const pluginRenderElementStatic = (
       );
 
       aboveNodes.forEach((withHOC) => {
-        const hoc = withHOC({ ...nodeProps, key } as any);
+        const HOC = withHOC({ ...nodeProps, key } as any);
 
-        if (hoc) {
-          component = hoc({ ...nodeProps, children: component } as any);
+        if (HOC) {
+          component = <HOC {...nodeProps}>{component}</HOC>;
         }
       });
 

--- a/packages/core/src/react/utils/pluginRenderElement.tsx
+++ b/packages/core/src/react/utils/pluginRenderElement.tsx
@@ -50,20 +50,20 @@ function ElementContent({
   let children = _children;
 
   belowNodes.forEach((withHOC) => {
-    const hoc = withHOC({ ...nodeProps, key } as any);
+    const HOC = withHOC({ ...nodeProps, key } as any);
 
-    if (hoc) {
-      children = hoc({ ...nodeProps, children } as any);
+    if (HOC) {
+      children = <HOC {...nodeProps}>{children}</HOC>;
     }
   });
 
   let component: React.ReactNode = <Element {...nodeProps}>{children}</Element>;
 
   aboveNodes.forEach((withHOC) => {
-    const hoc = withHOC({ ...nodeProps, key } as any);
+    const HOC = withHOC({ ...nodeProps, key } as any);
 
-    if (hoc) {
-      component = hoc({ ...nodeProps, children: component } as any);
+    if (HOC) {
+      component = <HOC {...nodeProps}>{component}</HOC>;
     }
   });
 


### PR DESCRIPTION
**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [ ] [ui changelog](apps/www/content/docs/components/changelog.mdx)

Currently `belowNodes` and `aboveNodes` are pure function calls instead of React component. This implementation leads to a problem: Suppose `aboveNodes` conditionally returns different component, where different component has different hooks. If the condition changes, then React would consider that the hook orders have changed. Therefore, the correct implementation should be wrap with component, not direct function call.

I checked utilities like `createNodeHOC` and `aboveEditable`, `aboveSlate`..., they are all component wrappers, except for those two.
<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->
