### PR TITLE
fix: AI Markdown Parsing

### DIFF
--- a/.changeset/young-eggs-taste.md
+++ b/.changeset/young-eggs-taste.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-ai': minor
+---
+
+Fixed a bug with interpreting markdown output from LLMs

--- a/packages/ai/src/lib/transforms/insertAINodes.ts
+++ b/packages/ai/src/lib/transforms/insertAINodes.ts
@@ -11,10 +11,14 @@ export const insertAINodes = (
 ) => {
   if (!target && !editor.selection?.focus.path) return;
 
-  const aiNodes = nodes.map((node) => ({
-    ...node,
-    ai: true,
-  }));
+  const addAINodes = (plainNodes : Descendant[]) => {
+    return plainNodes.map((plainNode: Descendant): Descendant => ({
+      ...plainNode,
+      ...(plainNode.children ? {} : {ai: true }),
+      ...(plainNode.children ? {children: addAINodes(plainNode.children) } : {})
+    }));
+  };
+  const aiNodes = addAINodes(nodes);
 
   editor.tf.withoutNormalizing(() => {
     editor.tf.insertNodes(aiNodes, {

--- a/packages/ai/src/react/ai-chat/useAIChatHook.ts
+++ b/packages/ai/src/react/ai-chat/useAIChatHook.ts
@@ -1,5 +1,5 @@
 import { useEditorPlugin } from '@udecode/plate/react';
-import { deserializeInlineMd } from '@udecode/plate-markdown';
+import { deserializeMd } from '@udecode/plate-markdown';
 
 import type { AIPluginConfig } from '../ai/AIPlugin';
 import type { AIChatPluginConfig } from './AIChatPlugin';
@@ -34,7 +34,7 @@ export const useAIChatHooks = () => {
       editor.undo();
       editor.history.redos.pop();
 
-      const nodes = deserializeInlineMd(editor, content);
+      const nodes = deserializeMd(editor, content);
 
       withAIBatch(
         editor,


### PR DESCRIPTION
**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)

This PR addresses #4040. I have added a new method which better fills in the ai flag and then I now use the full markdown deserializer. 

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->
