### PR TITLE
fix: focus the editor before opening the floating link toolbar

### DIFF
--- a/.changeset/tidy-jars-poke.md
+++ b/.changeset/tidy-jars-poke.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-link': patch
+---
+
+Editor auto focuses when opening the insert link modal

--- a/packages/link/src/react/components/useLinkToolbarButton.ts
+++ b/packages/link/src/react/components/useLinkToolbarButton.ts
@@ -26,6 +26,7 @@ export const useLinkToolbarButton = (
     props: {
       pressed: state.pressed,
       onClick: () => {
+        editor.tf.focus();
         triggerFloatingLink(editor, { focused: true });
       },
       onMouseDown: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {


### PR DESCRIPTION
**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)

Before, if the user clicked the link button in the toolbar when the editor was not focused, the floating toolbar popup would show up near or off the edge of the editor.

Now, clicking the link button will first auto-focus on the editor before opening up the floating link popup. That way the floating popup always appears in the correct position.

While I am not sure, this fix sounds like it may fix issue #3812. I tried to reproduce the bug described in this issue, however the symptoms I was experiencing were slightly different. I noticed the floating popover was misplaced after the first click of the link button, whereas they reported the issue after the second click. This may fix both issues though.

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->
