### PR TITLE
Set `TodoListPlugin` typescript types

### DIFF
--- a/.changeset/kind-kiwis-know.md
+++ b/.changeset/kind-kiwis-know.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-list': patch
+---
+
+More specific typescript types for TodoListPlugin

--- a/packages/list/src/react/TodoListPlugin.tsx
+++ b/packages/list/src/react/TodoListPlugin.tsx
@@ -1,9 +1,12 @@
 import { Key, toTPlatePlugin } from '@udecode/plate/react';
 
-import { BaseTodoListPlugin } from '../lib/BaseTodoListPlugin';
+import {
+  type TodoListConfig,
+  BaseTodoListPlugin,
+} from '../lib/BaseTodoListPlugin';
 
 /** Enables support for todo lists with React-specific features. */
-export const TodoListPlugin = toTPlatePlugin(
+export const TodoListPlugin = toTPlatePlugin<TodoListConfig>(
   BaseTodoListPlugin,
   ({ editor, type }) => ({
     shortcuts: {


### PR DESCRIPTION
Hello! I'm using `TodoListPlugin` and noticed that `TodoListPlugin.key` is typed as `any` whereas I think it should be `'action_item'` as string literal. Every other plugin I've checked has a specific string literal type for `key` so I think it's just a little mistake. Thanks :)

**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)

