### PR TITLE
fix: image edit link button not pressable

### DIFF
--- a/.changeset/blue-taxis-push.md
+++ b/.changeset/blue-taxis-push.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-media': patch
+---
+
+fix: image edit link button not pressable

--- a/packages/media/src/react/media/FloatingMedia/FloatingMediaEditButton.tsx
+++ b/packages/media/src/react/media/FloatingMedia/FloatingMediaEditButton.tsx
@@ -4,7 +4,7 @@ import { createPrimitiveComponent, useElement } from '@udecode/plate/react';
 
 import type { TMediaElement } from '../../../lib/media/types';
 
-import { ImagePreviewStore } from '../../image';
+import { FloatingMediaStore } from './FloatingMediaStore';
 
 export const useFloatingMediaEditButton = () => {
   const element = useElement<TMediaElement>();
@@ -12,12 +12,9 @@ export const useFloatingMediaEditButton = () => {
   return {
     props: {
       onClick: React.useCallback(() => {
-        ImagePreviewStore.set('currentPreview', {
-          id: element.id,
-          url: element.url,
-        });
-        ImagePreviewStore.set('isEditingScale', true);
-      }, [element.id, element.url]),
+        FloatingMediaStore.set('url', element.url);
+        FloatingMediaStore.set('isEditing', true);
+      }, [element.url]),
     },
   };
 };


### PR DESCRIPTION
I encounter the same issue as #4063, the image edit link button don't respond when clicking. This PR resolves the problem by updating `onClick` function, using `FloatingMediaStore` instead of `ImagePreviewStore`.

**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)
