### PR TITLE
fix: return value of useEditorPlugin changes when rerender

### DIFF
--- a/.changeset/lemon-keys-eat.md
+++ b/.changeset/lemon-keys-eat.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-core': patch
+---
+
+fix: return value of useEditorPlugin changes when rerender

--- a/packages/core/src/react/stores/plate/useEditorPlugin.ts
+++ b/packages/core/src/react/stores/plate/useEditorPlugin.ts
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import type { AnyPluginConfig, WithRequiredKey } from '../../../lib';
 import type { PlateEditor } from '../../editor';
 
@@ -21,8 +23,12 @@ export function useEditorPlugin<
 } {
   const editor = useEditorRef(id);
 
-  return {
-    ...getEditorPlugin(editor, p),
-    store: editor.store,
-  } as any;
+  return React.useMemo(
+    () =>
+      ({
+        ...getEditorPlugin(editor, p),
+        store: editor.store,
+      }) as any,
+    [editor, p]
+  );
 }


### PR DESCRIPTION
Before, if there are two tables in one document, selecting multiple table cells will cause page crash, like #4077. Now it will work normally.

The problem is that `useEditorPlugin` doesn't return a stable value. In `useSelectedCells`, the `setOption` returned by `useEditorPlugin` will change in every re-render. While the `useSelectedCells` called by the first table sets `selectedCells` to a non-null value, the `useSelectedCells` called by the second table will set `selectedCells` back to null, and it repeats infinitely.

```tsx
  // for the second table, `selected = false`, so it will set `selectedCells` to null when `setOption` changes
  React.useEffect(() => {
    if (!selected || readOnly) {
      setOption('selectedCells', null);
      setOption('selectedTables', null);
    }
  }, [selected, editor, readOnly, setOption]);
```

Removing `setOption` from dependency array also fixes this problem, but I'm not sure whether there are similar problems in other functions, so I make the return value of `useEditorPlugin` memorized.

**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)