### PR TITLE
fix: prevent block menu on image preivew mask

### DIFF
--- a/apps/www/content/docs/en/components/changelog.mdx
+++ b/apps/www/content/docs/en/components/changelog.mdx
@@ -10,6 +10,11 @@ Use the [CLI](https://platejs.org/docs/components/cli) to install the latest ver
 
 ## February 2025 #19
 
+### Feburary 21 #19.3
+
+- `image-preview`: prevent block menu on image preivew mask
+- `media-popover`: hide media popover when image preivew is open
+
 ### February 18 #19.2
 
 Plate 45 - new comments & suggestions UI

--- a/apps/www/src/registry/default/plate-ui/image-preview.tsx
+++ b/apps/www/src/registry/default/plate-ui/image-preview.tsx
@@ -48,9 +48,10 @@ export const ImagePreview = () => {
   return (
     <div
       className={cn(
-        'fixed top-0 left-0 z-50 h-screen w-screen',
+        'fixed top-0 left-0 z-50 h-screen w-screen select-none',
         !isOpen && 'hidden'
       )}
+      onContextMenu={(e) => e.stopPropagation()}
       {...maskLayerProps}
     >
       <div className="absolute inset-0 size-full bg-black opacity-30"></div>

--- a/apps/www/src/registry/default/plate-ui/media-popover.tsx
+++ b/apps/www/src/registry/default/plate-ui/media-popover.tsx
@@ -8,8 +8,10 @@ import {
   FloatingMedia as FloatingMediaPrimitive,
   FloatingMediaStore,
   useFloatingMediaValue,
+  useImagePreviewValue,
 } from '@udecode/plate-media/react';
 import {
+  useEditorRef,
   useEditorSelector,
   useElement,
   useReadOnly,
@@ -30,6 +32,7 @@ export interface MediaPopoverProps {
 }
 
 export function MediaPopover({ children, plugin }: MediaPopoverProps) {
+  const editor = useEditorRef();
   const readOnly = useReadOnly();
   const selected = useSelected();
 
@@ -37,7 +40,9 @@ export function MediaPopover({ children, plugin }: MediaPopoverProps) {
     (editor) => !editor.api.isExpanded(),
     []
   );
-  const isOpen = !readOnly && selected && selectionCollapsed;
+  const isImagePreviewOpen = useImagePreviewValue('isOpen', editor.id);
+  const isOpen =
+    !readOnly && selected && selectionCollapsed && !isImagePreviewOpen;
   const isEditing = useFloatingMediaValue('isEditing');
 
   useEffect(() => {

--- a/templates/plate-playground-template/src/components/plate-ui/image-preview.tsx
+++ b/templates/plate-playground-template/src/components/plate-ui/image-preview.tsx
@@ -48,9 +48,10 @@ export const ImagePreview = () => {
   return (
     <div
       className={cn(
-        'fixed top-0 left-0 z-50 h-screen w-screen',
+        'fixed top-0 left-0 z-50 h-screen w-screen select-none',
         !isOpen && 'hidden'
       )}
+      onContextMenu={(e) => e.stopPropagation()}
       {...maskLayerProps}
     >
       <div className="absolute inset-0 size-full bg-black opacity-30"></div>

--- a/templates/plate-playground-template/src/components/plate-ui/media-popover.tsx
+++ b/templates/plate-playground-template/src/components/plate-ui/media-popover.tsx
@@ -8,8 +8,10 @@ import {
   FloatingMedia as FloatingMediaPrimitive,
   FloatingMediaStore,
   useFloatingMediaValue,
+  useImagePreviewValue,
 } from '@udecode/plate-media/react';
 import {
+  useEditorRef,
   useEditorSelector,
   useElement,
   useReadOnly,
@@ -30,6 +32,7 @@ export interface MediaPopoverProps {
 }
 
 export function MediaPopover({ children, plugin }: MediaPopoverProps) {
+  const editor = useEditorRef();
   const readOnly = useReadOnly();
   const selected = useSelected();
 
@@ -37,7 +40,9 @@ export function MediaPopover({ children, plugin }: MediaPopoverProps) {
     (editor) => !editor.api.isExpanded(),
     []
   );
-  const isOpen = !readOnly && selected && selectionCollapsed;
+  const isImagePreviewOpen = useImagePreviewValue('isOpen', editor.id);
+  const isOpen =
+    !readOnly && selected && selectionCollapsed && !isImagePreviewOpen;
   const isEditing = useFloatingMediaValue('isEditing');
 
   useEffect(() => {


### PR DESCRIPTION
Before, when image preview is open, right click on mask will open block menu, but the menu doesn't work. And media popover will be on top of the mask.

![img_v3_02jn_f9a314e4-f816-4456-91af-88e838b4d39g](https://github.com/user-attachments/assets/4190ddb5-45fa-46d5-b781-82f6c523fc02)

Now, right click on mask will open native context menu, and user can direct copy the image. Media popover will hide when image preview is open.

![img_v3_02jn_6b0f7d5e-a527-4812-a747-0010509ca2bg](https://github.com/user-attachments/assets/39a0ce8b-3021-4159-9161-656e784f62a9)

**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)