### PR TITLE
Do not memo `fallbackPlateStore`

### DIFF
--- a/.changeset/honest-files-rest.md
+++ b/.changeset/honest-files-rest.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-core': patch
+---
+
+Fallback Plate store no longer needs to be memorized since `jotai-x@2.3.1` handles this automatically

--- a/packages/core/src/react/stores/plate/createPlateStore.ts
+++ b/packages/core/src/react/stores/plate/createPlateStore.ts
@@ -116,17 +116,11 @@ export const usePlateStore = (id?: string) => {
    * case, return a fallback store until an editor becomes active.
    */
   const plateControllerExists = usePlateControllerExists();
-
-  const fallbackStore = useMemo(createPlateStore, []);
-  const fallbackPlateStore = fallbackStore.usePlateStore();
-  const memorizedFallbackPlateStore = useMemo(
-    () => fallbackPlateStore,
-    [fallbackPlateStore]
-  );
+  const fallbackStore = useMemo(createPlateStore, []).usePlateStore();
 
   if (!store) {
     if (plateControllerExists) {
-      return memorizedFallbackPlateStore;
+      return fallbackStore;
     }
 
     throw new Error(


### PR DESCRIPTION
Fallback Plate store no longer needs to be memorized since `jotai-x@2.3.1` handles this automatically.

**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)