### PR TITLE
Add readOnly state check to disable block context menu in read-only mode

### DIFF
--- a/apps/www/content/docs/en/components/changelog.mdx
+++ b/apps/www/content/docs/en/components/changelog.mdx
@@ -10,6 +10,9 @@ Use the [CLI](https://platejs.org/docs/components/cli) to install the latest ver
 
 ## March 2025 #20
 
+### March 10 #20.3
+- `block-context-menu`: Prevent opening context menu in read-only mode
+
 ### March 2 #20.2
 
 - `block-suggestion`: fix styles

--- a/apps/www/src/registry/default/plate-ui/block-context-menu.tsx
+++ b/apps/www/src/registry/default/plate-ui/block-context-menu.tsx
@@ -11,7 +11,11 @@ import {
   BlockMenuPlugin,
   BlockSelectionPlugin,
 } from '@udecode/plate-selection/react';
-import { ParagraphPlugin, useEditorPlugin } from '@udecode/plate/react';
+import {
+  ParagraphPlugin,
+  useEditorPlugin,
+  usePlateState,
+} from '@udecode/plate/react';
 
 import { useIsTouchDevice } from '@/registry/default/hooks/use-is-touch-device';
 
@@ -32,6 +36,7 @@ export function BlockContextMenu({ children }: { children: React.ReactNode }) {
   const { api, editor } = useEditorPlugin(BlockMenuPlugin);
   const [value, setValue] = useState<Value>(null);
   const isTouch = useIsTouchDevice();
+  const [readOnly] = usePlateState('readOnly');
 
   const handleTurnInto = useCallback(
     (type: string) => {
@@ -81,7 +86,7 @@ export function BlockContextMenu({ children }: { children: React.ReactNode }) {
         onContextMenu={(event) => {
           const dataset = (event.target as HTMLElement).dataset;
 
-          const disabled = dataset?.slateEditor === 'true';
+          const disabled = dataset?.slateEditor === 'true' || readOnly;
 
           if (disabled) return event.preventDefault();
 

--- a/templates/plate-playground-template/src/components/plate-ui/block-context-menu.tsx
+++ b/templates/plate-playground-template/src/components/plate-ui/block-context-menu.tsx
@@ -11,7 +11,7 @@ import {
   BlockMenuPlugin,
   BlockSelectionPlugin,
 } from '@udecode/plate-selection/react';
-import { ParagraphPlugin, useEditorPlugin } from '@udecode/plate/react';
+import { ParagraphPlugin, useEditorPlugin, usePlateState } from '@udecode/plate/react';
 
 import { useIsTouchDevice } from '@/hooks/use-is-touch-device';
 
@@ -32,6 +32,7 @@ export function BlockContextMenu({ children }: { children: React.ReactNode }) {
   const { api, editor } = useEditorPlugin(BlockMenuPlugin);
   const [value, setValue] = useState<Value>(null);
   const isTouch = useIsTouchDevice();
+  const [readOnly] = usePlateState("readOnly");
 
   const handleTurnInto = useCallback(
     (type: string) => {
@@ -81,7 +82,7 @@ export function BlockContextMenu({ children }: { children: React.ReactNode }) {
         onContextMenu={(event) => {
           const dataset = (event.target as HTMLElement).dataset;
 
-          const disabled = dataset?.slateEditor === 'true';
+          const disabled = dataset?.slateEditor === 'true' || readOnly;
 
           if (disabled) return event.preventDefault();
 

--- a/templates/plate-playground-template/src/components/plate-ui/block-context-menu.tsx
+++ b/templates/plate-playground-template/src/components/plate-ui/block-context-menu.tsx
@@ -11,7 +11,11 @@ import {
   BlockMenuPlugin,
   BlockSelectionPlugin,
 } from '@udecode/plate-selection/react';
-import { ParagraphPlugin, useEditorPlugin, usePlateState } from '@udecode/plate/react';
+import {
+  ParagraphPlugin,
+  useEditorPlugin,
+  usePlateState,
+} from '@udecode/plate/react';
 
 import { useIsTouchDevice } from '@/hooks/use-is-touch-device';
 
@@ -32,7 +36,7 @@ export function BlockContextMenu({ children }: { children: React.ReactNode }) {
   const { api, editor } = useEditorPlugin(BlockMenuPlugin);
   const [value, setValue] = useState<Value>(null);
   const isTouch = useIsTouchDevice();
-  const [readOnly] = usePlateState("readOnly");
+  const [readOnly] = usePlateState('readOnly');
 
   const handleTurnInto = useCallback(
     (type: string) => {


### PR DESCRIPTION
This PR introduces a check for the readOnly state to prevent the block context menu from appearing when the editor is in read-only mode. Previously, the context menu would still be triggered even when editing was disabled, which could lead to unintended UI interactions.

**Changes:**
- Introduced usePlateState("readOnly") to track the read-only state.
- Updated the onContextMenu event handler inside <ContextMenuTrigger> to prevent opening the context menu when readOnly is true.

**Why?**
This ensures a better UX by avoiding unnecessary context menu interactions in scenarios where content editing is not allowed.

**Testing:**
- Verified that the context menu does not appear in read-only mode.
- Confirmed that the menu works as expected when editing is enabled.


**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)

