### PR TITLE
refactor: move out beforeEditable and afterEditable from aboveEditable render

### DIFF
--- a/.changeset/large-maps-smile.md
+++ b/.changeset/large-maps-smile.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate': major
+---
+
+New layout output: components rendered in the beforeEditor and afterEditor areas will now be rendered outside the aboveEditable area

--- a/.changeset/large-maps-smile.md
+++ b/.changeset/large-maps-smile.md
@@ -1,5 +1,5 @@
 ---
-'@udecode/plate-core': minor
+'@udecode/plate-core': patch
 ---
 
 Fix: `PlatePlugin.render.beforeEditable` and `afterEditable` should be siblings to `aboveEditable` instead of children. `aboveSlate` should be used for that scenario.

--- a/.changeset/large-maps-smile.md
+++ b/.changeset/large-maps-smile.md
@@ -1,5 +1,5 @@
 ---
-'@udecode/plate': major
+'@udecode/plate-core': minor
 ---
 
-New layout output: components rendered in the beforeEditor and afterEditor areas will now be rendered outside the aboveEditable area
+Fix: `PlatePlugin.render.beforeEditable` and `afterEditable` should be siblings to `aboveEditable` instead of children. `aboveSlate` should be used for that scenario.

--- a/apps/www/src/registry/default/blocks/slate-to-html/page.tsx
+++ b/apps/www/src/registry/default/blocks/slate-to-html/page.tsx
@@ -340,9 +340,13 @@ export default async function SlateToHtmlBlock() {
         <EditorStatic components={components} editor={editor} />
       </div>
 
-      <div className="p-2 relative">
+      <div className="relative p-2">
         <H3>HTML Iframe</H3>
-        <ExportHtmlButton className='absolute top-10 right-0' html={html} serverTheme={theme} />
+        <ExportHtmlButton
+          className="absolute top-10 right-0"
+          html={html}
+          serverTheme={theme}
+        />
         <HtmlIframe
           className="h-[7500px] w-full"
           html={html}

--- a/apps/www/src/registry/default/components/editor/slate-to-html.tsx
+++ b/apps/www/src/registry/default/components/editor/slate-to-html.tsx
@@ -65,7 +65,7 @@ export function ExportHtmlButton({
       rel="noopener noreferrer"
       role="button"
     >
-      <Button >Export HTML</Button>
+      <Button>Export HTML</Button>
     </a>
   );
 }

--- a/packages/core/src/react/components/PlateContent.tsx
+++ b/packages/core/src/react/components/PlateContent.tsx
@@ -87,8 +87,6 @@ const PlateContent = React.forwardRef(
 
     let aboveEditable: React.ReactNode = (
       <>
-        {beforeEditable}
-
         {renderEditable ? renderEditable(editable) : editable}
 
         <EditorMethodsEffect id={id} />
@@ -96,8 +94,6 @@ const PlateContent = React.forwardRef(
         {/* <EditorStateEffect id={id} /> */}
         <EditorRefEffect id={id} />
         <PlateControllerEffect id={id} />
-
-        {afterEditable}
       </>
     );
 
@@ -121,7 +117,13 @@ const PlateContent = React.forwardRef(
       prevReadOnly.current = readOnly;
     }, [autoFocusOnEditable, editor, readOnly]);
 
-    return <PlateSlate id={id}>{aboveEditable}</PlateSlate>;
+    return (
+      <PlateSlate id={id}>
+        {beforeEditable}
+        {aboveEditable}
+        {afterEditable}
+      </PlateSlate>
+    );
   }
 );
 PlateContent.displayName = 'PlateContent';


### PR DESCRIPTION
As per discussion: https://github.com/udecode/plate/discussions/4181, this PR makes sure the aboveEditable components only wrap the editable area by moving out the beforeEditable and afterEditable components.


**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [ ] `yarn brl`
- [x] `yarn changeset`
- [ ] [ui changelog](apps/www/content/docs/components/changelog.mdx)