### PR TITLE
only flatten blockquotes, prevent flattening of other element types s…

### DIFF
--- a/packages/markdown/src/lib/remark-slate/remarkDefaultElementRules.ts
+++ b/packages/markdown/src/lib/remark-slate/remarkDefaultElementRules.ts
@@ -23,7 +23,7 @@ export const remarkDefaultElementRules: RemarkElementRules = {
 
       // Flatten nested blockquotes (e.g. >>>)
       const flattenedChildren = children.flatMap((child: any) =>
-        child.type ? child.children : [child]
+        child.type === "blockquote" ? child.children : [child]
       );
 
       return {


### PR DESCRIPTION
Addresses #3689 

Only flatten nested blockquotes rather than flattening all child nodes which might be relevant such as nested links.