### PR TITLE
adds explicit spread false to lists to have a less noisy serialization

### DIFF
--- a/.changeset/kind-parrots-impress.md
+++ b/.changeset/kind-parrots-impress.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-markdown": patch
+---
+
+adds explicit spread false to lists to have a less noisy serialization

--- a/packages/markdown/src/lib/rules/defaultRules.ts
+++ b/packages/markdown/src/lib/rules/defaultRules.ts
@@ -430,6 +430,7 @@ export const defaultRules: TRules = {
             }
             currentItem = {
               children: [],
+              spread: false,
               type: 'listItem',
             };
 
@@ -443,6 +444,7 @@ export const defaultRules: TRules = {
                 currentItem.children.push({
                   children: serializeListItems(liChild.children),
                   ordered: liChild.type === 'ol',
+                  spread: false, 
                   type: 'list',
                 });
               }
@@ -460,6 +462,7 @@ export const defaultRules: TRules = {
       return {
         children: serializeListItems(node.children),
         ordered: isOrdered,
+        spread: false,
         type: 'list',
       };
     },

--- a/packages/markdown/src/lib/rules/defaultRules.ts
+++ b/packages/markdown/src/lib/rules/defaultRules.ts
@@ -444,7 +444,7 @@ export const defaultRules: TRules = {
                 currentItem.children.push({
                   children: serializeListItems(liChild.children),
                   ordered: liChild.type === 'ol',
-                  spread: false, 
+                  spread: false,
                   type: 'list',
                 });
               }

--- a/packages/markdown/src/lib/serializer/standardList.spec.tsx
+++ b/packages/markdown/src/lib/serializer/standardList.spec.tsx
@@ -23,7 +23,7 @@ describe('serializeMd list', () => {
       </fragment>
     );
 
-    const expected = '* List item 1\n\n* List item 2\n';
+    const expected = '* List item 1\n* List item 2\n';
 
     expect(serializeMd(editor, { value: input })).toBe(expected);
   });
@@ -42,7 +42,7 @@ describe('serializeMd list', () => {
       </fragment>
     );
 
-    const expected = '1. List item 1\n\n2. List item 2\n';
+    const expected = '1. List item 1\n2. List item 2\n';
 
     expect(serializeMd(editor, { value: input })).toBe(expected);
   });
@@ -63,7 +63,7 @@ describe('serializeMd list', () => {
       </fragment>
     );
 
-    const expected = '* List item 1\n\n  1. List item 1.1\n';
+    const expected = '* List item 1\n  1. List item 1.1\n';
 
     expect(serializeMd(editor, { value: input })).toBe(expected);
   });
@@ -87,7 +87,7 @@ describe('serializeMd list', () => {
     );
 
     const expected =
-      '* Normal text and **bold text**\n\n* *Italic text* and normal text\n';
+      '* Normal text and **bold text**\n* *Italic text* and normal text\n';
 
     expect(serializeMd(editor, { value: input })).toBe(expected);
   });


### PR DESCRIPTION
Currently searialization of list lead to spaces per list entry. this is because the spread property is not set for list during serialization. 

This currently leads to:

```
1. test

3. test

  - test
```

This pr reduces the noise by explicitly setting the spread oparator to false
```
1. test
3. test
  - test
```

**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->
