### PR TITLE
Fixes line breaks in paragraphs

### DIFF
--- a/packages/markdown/src/lib/deserializer/deserializeMdParagraphs.spec.tsx
+++ b/packages/markdown/src/lib/deserializer/deserializeMdParagraphs.spec.tsx
@@ -33,7 +33,38 @@ const createTestEditor = (plugins: any[] = []) =>
 const editor = createTestEditor();
 
 describe('deserializeMd - paragraph', () => {
-  it('should deserialize paragraph with one linebreak', () => {
+  it('should deserialize empty paragraph with one soft linebreak', () => {
+    const input = `
+<p><br /></p>`;
+
+    const output = (
+      <fragment>
+        <hp>
+          <htext>{'\n'}</htext>
+        </hp>
+      </fragment>
+    );
+
+    expect(deserializeMd(editor, input)).toEqual(output);
+  });
+  
+  it('should deserialize paragraph with one soft linebreak', () => {
+    const input = `
+Paragaph with one new Line<br />`;
+
+    const output = (
+      <fragment>
+        <hp>
+          <htext>Paragaph with one new Line</htext>
+          <htext>{'\n'}</htext>
+        </hp>
+      </fragment>
+    );
+
+    expect(deserializeMd(editor, input)).toEqual(output);
+  });
+
+  it('should deserialize paragraph with two soft linebreak', () => {
     const input = `
 Paragaph with two new Lines\\
 <br />`;
@@ -43,6 +74,7 @@ Paragaph with two new Lines\\
         <hp>
           <htext>Paragaph with two new Lines</htext>
           <htext>{'\n'}</htext>
+          <htext>{'\n'}</htext>
         </hp>
       </fragment>
     );
@@ -50,7 +82,7 @@ Paragaph with two new Lines\\
     expect(deserializeMd(editor, input)).toEqual(output);
   });
 
-  it('should deserialize paragraph with two leading linebreaks', () => {
+  it('should deserialize paragraph with three soft linebreaks', () => {
     const input = `
 Paragaph with two new Lines\\
 \\
@@ -62,6 +94,7 @@ Paragaph with two new Lines\\
           <htext>Paragaph with two new Lines</htext>
           <htext>{'\n'}</htext>
           <htext>{'\n'}</htext>
+          <htext>{'\n'}</htext>
         </hp>
       </fragment>
     );
@@ -69,7 +102,7 @@ Paragaph with two new Lines\\
     expect(deserializeMd(editor, input)).toEqual(output);
   });
 
-  it('should deserialize paragraph with leading linebreaks in the middle', () => {
+  it('should deserialize paragraph with two soft linebreaks in the middle', () => {
     const input = `
 Paragaph with two new Lines\\
 \\
@@ -89,7 +122,7 @@ followed by text`;
     expect(deserializeMd(editor, input)).toEqual(output);
   });
 
-  it('should deserialize paragraph with leading linebreaks in the middle', () => {
+  it('should deserialize paragraph with soft linebreaks in the middle', () => {
     const input = `
 Paragaph with two new Lines\\
 \\

--- a/packages/markdown/src/lib/deserializer/deserializeMdParagraphs.spec.tsx
+++ b/packages/markdown/src/lib/deserializer/deserializeMdParagraphs.spec.tsx
@@ -47,7 +47,7 @@ describe('deserializeMd - paragraph', () => {
 
     expect(deserializeMd(editor, input)).toEqual(output);
   });
-  
+
   it('should deserialize paragraph with one soft linebreak', () => {
     const input = `
 Paragaph with one new Line<br />`;

--- a/packages/markdown/src/lib/rules/defaultRules.ts
+++ b/packages/markdown/src/lib/rules/defaultRules.ts
@@ -304,7 +304,7 @@ export const defaultRules: TRules = {
         return {
           children: [{ text: '\n' } as TText],
           type: paragraphType,
-        }
+        };
       }
       return {
         text: (mdastNode.value || '').replaceAll('<br />', '\n'),
@@ -631,9 +631,7 @@ export const defaultRules: TRules = {
             }
           });
         } else {
-          
           inlineNodes.push(child);
-          
         }
       });
 
@@ -658,14 +656,15 @@ export const defaultRules: TRules = {
         options
       ) as MdParagraph['children'];
 
-      if (
-        convertedNodes.length === 0 
-      ) {
+      if (convertedNodes.length === 0) {
         return {
           type: 'html',
           value: '<br />',
         } as any;
-      } else if (convertedNodes.length === 1 && enrichedChildren.at(-1)!.type === 'break') {
+      } else if (
+        convertedNodes.length === 1 &&
+        enrichedChildren.at(-1)!.type === 'break'
+      ) {
         return {
           type: 'html',
           value: '<p><br /></p>',
@@ -677,7 +676,6 @@ export const defaultRules: TRules = {
         convertedNodes.at(-1)!.value = '\n<br />';
       }
 
-      
       return {
         children: convertedNodes,
         type: 'paragraph',

--- a/packages/markdown/src/lib/serializer/__snapshots__/serializeMd.spec.ts.snap
+++ b/packages/markdown/src/lib/serializer/__snapshots__/serializeMd.spec.ts.snap
@@ -110,11 +110,20 @@ Text with color and background color
 "
 `;
 
-exports[`serializeMd should serialize paragraphs with only a new line to a <br /> 1`] = `
-"
+exports[`serializeMd should serialize an empty paragraph to a <br /> 1`] = `
+"<br />
+
 <br />
+"
+`;
 
+exports[`serializeMd should serialize paragraphs with only a new line to a <p><br /></p> 1`] = `
+"<p><br /></p>
+"
+`;
 
+exports[`serializeMd should serialize paragraphs with two a new line to a \\\\n<br /> 1`] = `
+"\\ 
 <br />
 "
 `;

--- a/packages/markdown/src/lib/serializer/serializeMd.spec.ts
+++ b/packages/markdown/src/lib/serializer/serializeMd.spec.ts
@@ -229,16 +229,50 @@ describe('serializeMd', () => {
     }
   );
 
+  
+
   it(
-    String.raw`should serialize paragraphs with only a new line to a <br />`,
+    String.raw`should serialize an empty paragraph to a <br />`,
+    () => {
+      const slateNodes = [
+        {
+          children: [{ text: '' }],
+          type: 'p',
+        },
+        {
+          children: [{ text: '' }],
+          type: 'p',
+        },
+      ];
+
+      expect(
+        serializeMd(editor as any, { value: slateNodes })
+      ).toMatchSnapshot();
+    }
+  );
+
+  it(
+    String.raw`should serialize paragraphs with only a new line to a <p><br /></p>`,
     () => {
       const slateNodes = [
         {
           children: [{ text: '\n' }],
           type: 'p',
-        },
+        }
+      ];
+
+      expect(
+        serializeMd(editor as any, { value: slateNodes })
+      ).toMatchSnapshot();
+    }
+  );
+
+  it(
+    String.raw`should serialize paragraphs with two a new line to a \\n<br />`,
+    () => {
+      const slateNodes = [
         {
-          children: [{ text: '\n' }],
+          children: [{ text: '\n' }, { text: '\n' }],
           type: 'p',
         },
       ];

--- a/packages/markdown/src/lib/serializer/serializeMd.spec.ts
+++ b/packages/markdown/src/lib/serializer/serializeMd.spec.ts
@@ -229,27 +229,20 @@ describe('serializeMd', () => {
     }
   );
 
-  
+  it(String.raw`should serialize an empty paragraph to a <br />`, () => {
+    const slateNodes = [
+      {
+        children: [{ text: '' }],
+        type: 'p',
+      },
+      {
+        children: [{ text: '' }],
+        type: 'p',
+      },
+    ];
 
-  it(
-    String.raw`should serialize an empty paragraph to a <br />`,
-    () => {
-      const slateNodes = [
-        {
-          children: [{ text: '' }],
-          type: 'p',
-        },
-        {
-          children: [{ text: '' }],
-          type: 'p',
-        },
-      ];
-
-      expect(
-        serializeMd(editor as any, { value: slateNodes })
-      ).toMatchSnapshot();
-    }
-  );
+    expect(serializeMd(editor as any, { value: slateNodes })).toMatchSnapshot();
+  });
 
   it(
     String.raw`should serialize paragraphs with only a new line to a <p><br /></p>`,
@@ -258,7 +251,7 @@ describe('serializeMd', () => {
         {
           children: [{ text: '\n' }],
           type: 'p',
-        }
+        },
       ];
 
       expect(


### PR DESCRIPTION
Markdown whitespace handling is a beast - two `\n` represent a paragraph but following ones get collapsed.

This pr introduces a serailization that allows to at least keep visual represented paragraphs and soft linebreaks from plate in markdown 
<table>
  <tr>
    <td>Mardkown</td>
    <td>Gets rendered as</td>
  </tr>
  <tr>

<td>
  
```md
Hello



new paragraph
```

</td>
<td>

Hello



new paragraph

</td>
</tr>
</table>

<table>
  <tr>
    <td>collapsed lines</td>
    <td>empty paragraph</td>
    <td>paragraph with one softbreak</td>
    <td>paragraph with two softbreak</td>
  </tr>
  <tr>

<td>

Hello

<br />

new paragraph

</td>
<td>

Hello

<p><br /></p>

new paragraph

</td>
<td>

Hello

\
<br />

new paragraph

</td>

</tr>
<tr>

<td>

```md
Hello

<br />

new paragraph
```

</td>

<td>

```md
Hello

<p><br /></p>

new paragraph
```

</td>
<td>

```md
Hello

\
<br />

new paragraph
```

</td>
</tr>
</table>


**Checklist**
- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](apps/www/content/docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->
