### PR TITLE
adds problematic testcases

### DIFF
--- a/packages/markdown/src/lib/serializer/serializeInlineMd.spec.ts
+++ b/packages/markdown/src/lib/serializer/serializeInlineMd.spec.ts
@@ -63,6 +63,55 @@ describe('serializeInlineMd', () => {
     expect(result).toBe('Hello ***bold and italic*** text\n');
   });
 
+  it('should serialize overlapping formatting correctly', () => {
+    const nodes = [
+      { text: 'Regular ' },
+      { bold: true, text: 'Bold' },
+      { bold: true, italic: true, text: ' Bold&Italic ' },
+      { italic: true, text: 'Italic' },
+      { text: ' Regular' },
+    ];
+    const result = serializeInlineMd(editor, { value: nodes });
+    expect(result).toBe('Regular *Italic* ***Bold&Italic*** **Bold** Regular\n');
+  });
+
+  it('should serialize overlapping formatting correctly without spaces', () => {
+    const nodes = [
+      { text: 'Regular' },
+      { bold: true, text: 'Bold' },
+      { bold: true, italic: true, text: 'Bold&Italic' },
+      { italic: true, text: 'Italic' },
+      { text: 'Regular' },
+    ];
+    const result = serializeInlineMd(editor, { value: nodes });
+    expect(result).toBe('Regular*Italic****Bold&Italic*****Bold**Regular\n');
+  });
+
+  it('should serialize overlapping formatting correctly without spaces', () => {
+    const nodes = [
+      { text: 'Regular' },
+      { italic: true, text: 'Italic' },
+      { bold: true, italic: true, text: 'Bold&Italic' },
+      { bold: true, text: 'Bold' },
+      { text: 'Regular' },
+    ];
+    const result = serializeInlineMd(editor, { value: nodes });
+    expect(result).toBe('Regular**Bold*****Bold&Italic****Italic*Regular\n');
+  });
+
+  
+  it('should serialize overlapping formatting correctly without spaces', () => {
+    const nodes = [
+      { text: 'Regular' },
+      { bold: true, italic: true, text: 'Bold&Italic' },
+      { bold: true, text: 'Bold' },
+      { text: 'Regular' },
+    ];
+    const result = serializeInlineMd(editor, { value: nodes });
+    expect(result).toBe('Regular***Bold&Italic****Italic*Regular\n');
+  });
+
+
   it('should handle empty nodes array', () => {
     const nodes: any[] = [];
     const result = serializeInlineMd(editor, { value: nodes });


### PR DESCRIPTION
This PR should fix the serialization of inline formmating for overlapping inline formattings:

(subset - compare tests in packages/markdown/src/lib/serializer/serializeInlineMd.spec.ts)

<table><tr><td>
```
Regular *Italic* ***Bold&Italic*** **Bold** Regular
```
</td>
<td>

Regular *Italic* ***Bold&Italic*** **Bold** Regular

</td></tr></table>

<table><tr><td>
```
Regular***Bold&Italic****Italic*Regular
```
</td>
<td>

Regular***Bold&Italic****Italic*Regular

</td></tr></table>

**Checklist**
- [ ] `yarn typecheck`
- [ ] `yarn lint:fix`
- [ ] `yarn test`
- [ ] `yarn brl`
- [ ] `yarn changeset`
- [ ] [ui changelog](apps/www/content/docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/content/docs/components/changelog.mdx`.

-->
