### PR TITLE
Fix LinkPlugin having a `target` attribute. #3156

### DIFF
--- a/.changeset/thin-garlics-pump.md
+++ b/.changeset/thin-garlics-pump.md
@@ -1,0 +1,5 @@
+---
+"@udecode/plate-link": patch
+---
+
+Fixes #3156: LinkPlugin having a `target` attribute. 

--- a/packages/link/src/lib/utils/getLinkAttributes.ts
+++ b/packages/link/src/lib/utils/getLinkAttributes.ts
@@ -17,7 +17,7 @@ export const getLinkAttributes = (editor: SlateEditor, link: TLinkElement) => {
   if (href !== undefined) {
     attributes.href = href;
   }
-  if ('target' in link) {
+  if ('target' in link && link.target !== undefined) {
     attributes.target = link.target;
   }
 


### PR DESCRIPTION
I believe this fixes #3156. At the very least it fixes the following case:

```tsx
LinkPlugin.extend({
  options: {
    defaultLinkAttributes: {
      target: '_blank',
    },
  }
});                                                                                                                            
```

Following the documentation startup instructions and using this resulted in anchors that had no `target` attribute. This patch fixed the issue.