### PR TITLE
Fix for mobile safari: pressing return twice on a list, doesn't terminate the list (Fixes #4320)

### DIFF
--- a/.changeset/rare-carrots-obey.md
+++ b/.changeset/rare-carrots-obey.md
@@ -1,0 +1,5 @@
+---
+'@udecode/plate-indent-list': patch
+---
+
+Fix for mobile safari: pressing return twice on a list, doesn't terminate the list

--- a/packages/indent-list/src/react/onKeyDownIndentList.ts
+++ b/packages/indent-list/src/react/onKeyDownIndentList.ts
@@ -1,6 +1,5 @@
+import type { TElement } from '@udecode/plate';
 import type { KeyboardHandler } from '@udecode/plate/react';
-
-import { type TElement, isHotkey } from '@udecode/plate';
 
 import { outdentList } from '../lib';
 import { type IndentListConfig, IndentListPlugin } from './IndentListPlugin';
@@ -22,7 +21,7 @@ export const onKeyDownIndentList: KeyboardHandler<IndentListConfig> = ({
 
   if (!listStyleType) return;
   if (
-    isHotkey('Enter', event) &&
+    event.key === 'Enter' &&
     editor.api.isEmpty(editor.selection, { block: true }) &&
     node.indent
   ) {


### PR DESCRIPTION
<!--

**Checklist**

- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](docs/components/changelog.mdx)

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/src/registry/components/changelog.mdx`.

-->

This fixes #4320

isHotKey was the source of the bug in #4320. I looked into that package, however it seems to be no longer maintained and not reviewing pull requests. So my solution was just to check for the Enter key directly rather than relying on the isHotKey for this case.
