### PR TITLE
Use node type instead of plugin key for isVoid check

### DIFF
--- a/.changeset/chatty-ads-listen.md
+++ b/.changeset/chatty-ads-listen.md
@@ -1,0 +1,5 @@
+---
+'@platejs/core': patch
+---
+
+Fix editor.api.isVoid function. Use node type instead of plugin key to determine if a node is a void node.

--- a/packages/core/src/lib/plugins/override/OverridePlugin.ts
+++ b/packages/core/src/lib/plugins/override/OverridePlugin.ts
@@ -21,6 +21,7 @@ export const withOverrides: OverrideEditor = ({
   const inlineTypes = editor.meta.pluginCache.node.isInline;
   const markableVoidTypes = editor.meta.pluginCache.node.isMarkableVoid;
   const notSelectableTypes = editor.meta.pluginCache.node.isNotSelectable;
+  const types = editor.meta.pluginCache.node.types;
 
   return {
     api: {
@@ -42,7 +43,7 @@ export const withOverrides: OverrideEditor = ({
           : isSelectable(element);
       },
       isVoid(element) {
-        return voidTypes.includes(element.type as any) ? true : isVoid(element);
+        return voidTypes.includes(types[element.type] as any) ? true : isVoid(element);
       },
       markableVoid(element) {
         return markableVoidTypes.includes(element.type)


### PR DESCRIPTION
**Checklist**

- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/src/registry/components/changelog.mdx`.

-->

Check the linked issue. It's probably not a good idea to merge this fix solely, since the other check functions, like isInline, isSelectable, markableVoid, also use the plugin key instead of the element type. So i guess we have to figure out, in general, if the node type or the plugin key should be used for these functions.
