### PR TITLE
Fix cursor regression and performance issue affecting tables

### DIFF
--- a/apps/www/src/registry/ui/table-node.tsx
+++ b/apps/www/src/registry/ui/table-node.tsx
@@ -104,7 +104,6 @@ export const TableElement = withHOC(
       'isSelectionAreaVisible'
     );
     const hasControls = !readOnly && !isSelectionAreaVisible;
-    const selected = useSelected();
     const {
       isSelectingCell,
       marginLeft,
@@ -134,7 +133,7 @@ export const TableElement = withHOC(
       </PlateElement>
     );
 
-    if (readOnly || !selected) {
+    if (readOnly) {
       return content;
     }
 
@@ -147,14 +146,18 @@ function TableFloatingToolbar({
   ...props
 }: React.ComponentProps<typeof PopoverContent>) {
   const { tf } = useEditorPlugin(TablePlugin);
+  const selected = useSelected();
   const element = useElement<TTableElement>();
   const { props: buttonProps } = useRemoveNodeButton({ element });
-  const collapsed = useEditorSelector((editor) => !editor.api.isExpanded(), []);
+  const collapsedInside = useEditorSelector(
+    (editor) => selected && editor.api.isCollapsed(),
+    [selected]
+  );
 
   const { canMerge, canSplit } = useTableMergeState();
 
   return (
-    <Popover open={canMerge || canSplit || collapsed} modal={false}>
+    <Popover open={canMerge || canSplit || collapsedInside} modal={false}>
       <PopoverAnchor asChild>{children}</PopoverAnchor>
       <PopoverContent
         asChild
@@ -201,7 +204,7 @@ function TableFloatingToolbar({
               </DropdownMenuPortal>
             </DropdownMenu>
 
-            {collapsed && (
+            {collapsedInside && (
               <ToolbarGroup>
                 <ToolbarButton tooltip="Delete table" {...buttonProps}>
                   <Trash2Icon />
@@ -210,7 +213,7 @@ function TableFloatingToolbar({
             )}
           </ToolbarGroup>
 
-          {collapsed && (
+          {collapsedInside && (
             <ToolbarGroup>
               <ToolbarButton
                 onClick={() => {
@@ -242,7 +245,7 @@ function TableFloatingToolbar({
             </ToolbarGroup>
           )}
 
-          {collapsed && (
+          {collapsedInside && (
             <ToolbarGroup>
               <ToolbarButton
                 onClick={() => {

--- a/docs/components/changelog.mdx
+++ b/docs/components/changelog.mdx
@@ -10,6 +10,10 @@ Use the [CLI](https://platejs.org/docs/components/cli) to install the latest ver
 
 ## June 2025 #23
 
+### June 18 #23.4
+
+- `table-node`: Fix bug affecting cursor position and improve performance
+
 ### June 16 #23.3
 
 - `block-draggable`: use `getPluginByType` instead of `getContainerTypes`


### PR DESCRIPTION
The table element's content was previously configured to remount inside a Radix popover (for the floating toolbar) when it became selected. Due to [changes to the timing](https://github.com/ianstormtaylor/slate/pull/5871/files#r2111732434) of `slate-react`'s `useSelected` hook, this was causing the cursor to appear in the wrong position in some circumstances (see the recording below). It was also causing severe performance problems when selecting and deselecting the table.

https://github.com/user-attachments/assets/2839bc1e-5bbb-44f5-8bad-292e89c40fab

This PR configures the table element to always render the content inside the popover root regardless of selection state (but not when the editor is read-only). As before, the floating toolbar is only visible when the cursor is collapsed inside the table, or in circumstances where the user can split or merge cells.

**Checklist**

- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](docs/components/changelog.mdx)
