### PR TITLE
Omit duplicate type definition to avoid wrong union types

### DIFF
--- a/.changeset/blue-mugs-doubt.md
+++ b/.changeset/blue-mugs-doubt.md
@@ -1,0 +1,5 @@
+---
+'@platejs/core': patch
+---
+
+Omit duplicate keys on TPlateEditor to avoid wrong union types

--- a/packages/core/src/react/editor/PlateEditor.ts
+++ b/packages/core/src/react/editor/PlateEditor.ts
@@ -43,7 +43,17 @@ export type PlateEditor = BaseEditor & {
 export type TPlateEditor<
   V extends Value = Value,
   P extends AnyPluginConfig = PlateCorePlugin,
-> = PlateEditor & {
+> = Omit<
+  PlateEditor,
+  | 'api'
+  | 'children'
+  | 'getApi'
+  | 'getTransforms'
+  | 'meta'
+  | 'plugins'
+  | 'tf'
+  | 'transforms'
+> & {
   api: EditorApi<V> & UnionToIntersection<InferApi<P | PlateCorePlugin>>;
   children: V;
   meta: BaseEditor['meta'] & {

--- a/packages/core/src/react/editor/PlateEditor.ts
+++ b/packages/core/src/react/editor/PlateEditor.ts
@@ -40,20 +40,14 @@ export type PlateEditor = BaseEditor & {
   uid?: string;
 };
 
+type FilterKeys<T, K extends keyof T> = {
+  [P in keyof T as Exclude<P, K>]: T[P];
+};
+
 export type TPlateEditor<
   V extends Value = Value,
   P extends AnyPluginConfig = PlateCorePlugin,
-> = Omit<
-  PlateEditor,
-  | 'api'
-  | 'children'
-  | 'getApi'
-  | 'getTransforms'
-  | 'meta'
-  | 'plugins'
-  | 'tf'
-  | 'transforms'
-> & {
+> = FilterKeys<PlateEditor, 'children'> & {
   api: EditorApi<V> & UnionToIntersection<InferApi<P | PlateCorePlugin>>;
   children: V;
   meta: BaseEditor['meta'] & {


### PR DESCRIPTION
**Checklist**

- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/src/registry/components/changelog.mdx`.

-->
