### PR TITLE
Use correct type for operations key on TPlateEditor

### DIFF
--- a/.changeset/spicy-nails-help.md
+++ b/.changeset/spicy-nails-help.md
@@ -1,0 +1,5 @@
+---
+'@platejs/core': patch
+---
+
+Use custom type for operations on TPlateEditor

--- a/packages/core/src/react/editor/PlateEditor.ts
+++ b/packages/core/src/react/editor/PlateEditor.ts
@@ -1,4 +1,10 @@
-import type { EditorApi, EditorTransforms, Value } from '@platejs/slate';
+import type {
+  DescendantIn,
+  EditorApi,
+  EditorTransforms,
+  Operation,
+  Value,
+} from '@platejs/slate';
 import type { UnionToIntersection } from '@udecode/utils';
 
 import type {
@@ -47,13 +53,14 @@ type FilterKeys<T, K extends keyof T> = {
 export type TPlateEditor<
   V extends Value = Value,
   P extends AnyPluginConfig = PlateCorePlugin,
-> = FilterKeys<PlateEditor, 'children'> & {
+> = FilterKeys<PlateEditor, 'children' | 'operations'> & {
   api: EditorApi<V> & UnionToIntersection<InferApi<P | PlateCorePlugin>>;
   children: V;
   meta: BaseEditor['meta'] & {
     pluginList: P[];
     shortcuts: Shortcuts;
   };
+  operations: Operation<DescendantIn<V>>[];
   plugins: { [K in P['key']]: Extract<P, { key: K }> };
   tf: EditorTransforms<V> &
     UnionToIntersection<InferTransforms<P | PlateCorePlugin>>;


### PR DESCRIPTION
**Checklist**

- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/src/registry/components/changelog.mdx`.

-->
