### PR TITLE
fix: close combobox on blur

### DIFF
--- a/apps/www/src/registry/ui/inline-combobox.tsx
+++ b/apps/www/src/registry/ui/inline-combobox.tsx
@@ -124,7 +124,7 @@ const InlineCombobox = ({
   }, [editor, element]);
 
   const { props: inputProps, removeInput } = useComboboxInput({
-    cancelInputOnBlur: false,
+    cancelInputOnBlur: true,
     cursorState,
     ref: inputRef,
     onCancelInput: (cause) => {

--- a/templates/plate-playground-template/src/components/ui/inline-combobox.tsx
+++ b/templates/plate-playground-template/src/components/ui/inline-combobox.tsx
@@ -124,7 +124,7 @@ const InlineCombobox = ({
   }, [editor, element]);
 
   const { props: inputProps, removeInput } = useComboboxInput({
-    cancelInputOnBlur: false,
+    cancelInputOnBlur: true,
     cursorState,
     ref: inputRef,
     onCancelInput: (cause) => {


### PR DESCRIPTION
Fixes #3853

## Description

This PR fixes an issue where the combobox (slash commands, mentions) would not close when clicking outside the editor.

## Changes

- Changed `cancelInputOnBlur` from `false` to `true` in both inline-combobox components
- This ensures the combobox properly closes when it loses focus

## Testing

1. Type `/` or `@` in the editor to open the combobox
2. Click outside the editor
3. The combobox should now close properly

Generated with [Claude Code](https://claude.ai/code)