### PR TITLE
fix: handle callback refs that return functions in useComposedRef

### DIFF
--- a/.changeset/fix-callback-ref-warning.md
+++ b/.changeset/fix-callback-ref-warning.md
@@ -1,7 +1,5 @@
 ---
-"@udecode/react-utils": patch
+'@udecode/react-utils': patch
 ---
 
-Fix React warning "Unexpected return value from a callback ref" in `useComposedRef`
-
-The `composeRefs` function was returning a cleanup function, which violates React's rule that callback refs should not return functions. This fix ensures that `composeRefs` returns `undefined` instead, preventing the warning and potential crashes when callback refs are composed.
+Critical fix for 49.0.13

--- a/.changeset/fix-callback-ref-warning.md
+++ b/.changeset/fix-callback-ref-warning.md
@@ -1,0 +1,7 @@
+---
+"@udecode/react-utils": patch
+---
+
+Fix React warning "Unexpected return value from a callback ref" in `useComposedRef`
+
+The `composeRefs` function was returning a cleanup function, which violates React's rule that callback refs should not return functions. This fix ensures that `composeRefs` returns `undefined` instead, preventing the warning and potential crashes when callback refs are composed.

--- a/packages/udecode/react-utils/src/useComposedRef.spec.ts
+++ b/packages/udecode/react-utils/src/useComposedRef.spec.ts
@@ -1,0 +1,107 @@
+import React from 'react';
+
+import { renderHook } from '@testing-library/react';
+
+import { composeRefs, useComposedRef } from './useComposedRef';
+
+describe('useComposedRef', () => {
+  it('should handle regular refs', () => {
+    const ref1 = React.createRef<HTMLDivElement>();
+    const ref2 = React.createRef<HTMLDivElement>();
+
+    const { result } = renderHook(() => useComposedRef(ref1, ref2));
+
+    const element = document.createElement('div');
+    result.current(element);
+
+    expect(ref1.current).toBe(element);
+    expect(ref2.current).toBe(element);
+  });
+
+  it('should handle callback refs', () => {
+    let captured1: HTMLDivElement | null = null;
+    let captured2: HTMLDivElement | null = null;
+
+    const callbackRef1 = (node: HTMLDivElement | null) => {
+      captured1 = node;
+    };
+
+    const callbackRef2 = (node: HTMLDivElement | null) => {
+      captured2 = node;
+    };
+
+    const { result } = renderHook(() =>
+      useComposedRef(callbackRef1, callbackRef2)
+    );
+
+    const element = document.createElement('div');
+    result.current(element);
+
+    expect(captured1).toBe(element);
+    expect(captured2).toBe(element);
+  });
+
+  it('should handle mixed ref types', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    let captured: HTMLDivElement | null = null;
+
+    const callbackRef = (node: HTMLDivElement | null) => {
+      captured = node;
+    };
+
+    const { result } = renderHook(() => useComposedRef(ref, callbackRef));
+
+    const element = document.createElement('div');
+    result.current(element);
+
+    expect(ref.current).toBe(element);
+    expect(captured).toBe(element);
+  });
+
+  it('should handle undefined refs', () => {
+    const ref = React.createRef<HTMLDivElement>();
+
+    const { result } = renderHook(() => useComposedRef(ref, undefined, null));
+
+    const element = document.createElement('div');
+    expect(() => result.current(element)).not.toThrow();
+    expect(ref.current).toBe(element);
+  });
+
+  it('should not return a function that returns a function (React 18 rule)', () => {
+    // This is the test that should fail with the current implementation
+    const ref = React.createRef<HTMLDivElement>();
+    const callbackRef = jest.fn((node: HTMLDivElement | null) => {
+      // Callback refs should not return anything
+    });
+
+    const composedRef = composeRefs(ref, callbackRef);
+    const element = document.createElement('div');
+
+    const result = composedRef(element);
+
+    // React expects callback refs to not return a function
+    // If this returns a function, React will throw the warning:
+    // "Unexpected return value from a callback ref"
+    expect(typeof result).not.toBe('function');
+  });
+
+  it('should handle callback refs that return functions (edge case)', () => {
+    // This simulates a broken callback ref that returns a function
+    const brokenCallbackRef = jest.fn(() => {
+      // This is incorrect - callback refs should not return functions
+      return () => console.log('cleanup');
+    });
+
+    const normalRef = React.createRef<HTMLDivElement>();
+
+    const composedRef = composeRefs(normalRef, brokenCallbackRef);
+    const element = document.createElement('div');
+
+    const result = composedRef(element);
+
+    // The composed ref should not return a function even if one of the refs does
+    expect(typeof result).not.toBe('function');
+    expect(normalRef.current).toBe(element);
+  });
+});

--- a/packages/udecode/react-utils/src/useComposedRef.ts
+++ b/packages/udecode/react-utils/src/useComposedRef.ts
@@ -8,7 +8,12 @@ type PossibleRef<T> = React.Ref<T> | undefined;
  */
 const setRef = <T>(ref: PossibleRef<T>, value: T) => {
   if (typeof ref === 'function') {
-    return ref(value);
+    const result = ref(value);
+    // Ignore if callback ref returns a function (not allowed by React)
+    if (typeof result === 'function') {
+      return undefined;
+    }
+    return result;
   } else if (ref !== null && ref !== undefined) {
     (ref as React.RefObject<T>).current = value;
   }
@@ -21,9 +26,10 @@ const setRef = <T>(ref: PossibleRef<T>, value: T) => {
 export const composeRefs =
   <T>(...refs: PossibleRef<T>[]) =>
   (node: T) => {
-    const unrefs = refs.map((ref) => setRef(ref, node)).filter(unref => unref !== undefined);
-    return () => unrefs.forEach(unref => unref());
-  }
+    refs.forEach((ref) => setRef(ref, node));
+    // Don't return a function - React doesn't allow callback refs to return functions
+    return undefined;
+  };
 
 /**
  * A custom hook that composes multiple refs Accepts callback refs and


### PR DESCRIPTION
This fixes the React warning "Unexpected return value from a callback ref" by ensuring that composeRefs does not return a function. The issue was that the previous implementation would return a cleanup function, which violates React's expectation that callback refs should not return functions.

Fixes #4432

Co-authored-by: Ziad Beyens <zbeyens@users.noreply.github.com>This PR fixes the React warning "Unexpected return value from a callback ref" that was causing crashes in the Markdown demo.

## Changes
- Modified `composeRefs` to return `undefined` instead of a cleanup function
- Added defensive check in `setRef` to handle callback refs that return functions
- Added comprehensive tests to verify the fix

Fixes #4432

Generated with [Claude Code](https://claude.ai/code)