### PR TITLE
Implement useNode plugin

### DIFF
--- a/.changeset/happy-schools-battle.md
+++ b/.changeset/happy-schools-battle.md
@@ -1,0 +1,5 @@
+---
+'@platejs/core': patch
+---
+
+Implemented useNode plugin

--- a/packages/core/src/lib/plugins/UseNodePlugin.ts
+++ b/packages/core/src/lib/plugins/UseNodePlugin.ts
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  type Descendant,
+  type NodeEntry,
+  type NodeOperation,
+  type Operation,
+  type Value,
+  NodeApi,
+  OperationApi,
+  PathApi,
+} from 'platejs';
+import {
+  type TPlateEditor,
+  createPlatePlugin,
+  useEditorRef,
+} from 'platejs/react';
+
+type ListenerFn = (op: NodeOperation) => void;
+
+export const UseNodePlugin = createPlatePlugin({
+  key: 'useNode',
+  options: {
+    listeners: [] as ListenerFn[],
+  },
+})
+  .extendApi(({ getOption, setOption }) => ({
+    addListener: (fn: ListenerFn) => {
+      getOption('listeners').push(fn);
+    },
+    removeListener: (fn: ListenerFn) => {
+      setOption(
+        'listeners',
+        getOption('listeners').filter((item) => item !== fn)
+      );
+    },
+  }))
+  .overrideEditor(({ getOption, tf: { apply } }) => ({
+    transforms: {
+      apply: (op) => {
+        apply(op);
+
+        if (OperationApi.isNodeOperation(op)) {
+          getOption('listeners').forEach((fn) => {
+            fn(op);
+          });
+        }
+      },
+    },
+  }));
+
+export const useNode = <T extends Descendant>(id?: string) => {
+  const editor = useEditorRef<TPlateEditor<Value, typeof UseNodePlugin>>();
+  const [nodeEntryFromOperaton, setNodeEntryFromOperation] = useState<
+    NodeEntry<T> | undefined
+  >();
+  const prevId = useRef<typeof id>(undefined);
+  // We use useMemo instead of useState and useEffect, in order to have a value earlier (1 render cycle earlier)
+  const nodeEntry = useMemo<NodeEntry<T> | undefined>(() => {
+    const nextNodeEntry =
+      id === prevId.current
+        ? nodeEntryFromOperaton
+        : editor.api.node<T>({ id, at: [] });
+
+    prevId.current = id;
+
+    return nextNodeEntry;
+  }, [nodeEntryFromOperaton, editor, id]);
+
+  const handleOperation = useCallback(
+    (op: Operation) => {
+      switch (op.type) {
+        case 'insert_node': {
+          if (op.node.id === id) {
+            setNodeEntryFromOperation([op.node, op.path] as NodeEntry<T>);
+          }
+
+          break;
+        }
+
+        case 'merge_node': {
+          const path = PathApi.previous(op.path) ?? op.path;
+          const node = NodeApi.get(editor, path);
+
+          if (node?.id === id) {
+            setNodeEntryFromOperation([node, path] as NodeEntry<T>);
+          }
+
+          break;
+        }
+
+        case 'move_node': {
+          const node = NodeApi.get(editor, op.newPath);
+
+          if (node?.id === id) {
+            setNodeEntryFromOperation([node, op.newPath] as NodeEntry<T>);
+          }
+
+          break;
+        }
+
+        case 'remove_node': {
+          if (op.node.id === id) {
+            setNodeEntryFromOperation(undefined);
+          }
+
+          break;
+        }
+
+        case 'set_node':
+        case 'split_node': {
+          const node = NodeApi.get(editor, op.path);
+
+          if (node?.id === id) {
+            setNodeEntryFromOperation([node, op.path] as NodeEntry<T>);
+          }
+
+          break;
+        }
+      }
+    },
+    [editor, id]
+  );
+
+  useEffect(() => {
+    editor.api[UseNodePlugin.key].addListener(handleOperation);
+
+    return () => {
+      editor.api[UseNodePlugin.key].removeListener(handleOperation);
+    };
+  }, [editor, handleOperation]);
+
+  return nodeEntry;
+};


### PR DESCRIPTION
-**Checklist**

- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/src/registry/components/changelog.mdx`.

-->

The useNode plugin, will re-render, whenever a nodes properties or path have been changed.

We need something like that in our project and i wonder if it would be something of value for the platejs library?

I guess it would need some changes, if you think this could be added to the platejs library. Like:
- Tests
- Docs
- Naming?
- Bettern input args, maybe the same as editor.api.node?