### PR TITLE
fix(link): prevent markdown headings from being converted to links

### DIFF
--- a/.changeset/fix-markdown-heading-link.md
+++ b/.changeset/fix-markdown-heading-link.md
@@ -1,0 +1,7 @@
+---
+"@platejs/link": patch
+---
+
+Fix markdown headings being incorrectly converted to links
+
+The LinkPlugin's `validateUrl` function now properly distinguishes between markdown headings and anchor links. Previously, any string starting with `#` was treated as a valid link, causing markdown headings like `# heading1` to be converted to links when pasted. Now, the function checks for the markdown heading pattern (hash symbols followed by a space) and correctly rejects these as invalid URLs while still allowing valid anchor links like `#section-name`.

--- a/packages/link/src/lib/utils/validateUrl.spec.ts
+++ b/packages/link/src/lib/utils/validateUrl.spec.ts
@@ -1,0 +1,97 @@
+import { createSlateEditor } from 'platejs';
+
+import { BaseLinkPlugin } from '../BaseLinkPlugin';
+import { validateUrl } from './validateUrl';
+
+describe('validateUrl', () => {
+  const createTestEditor = (options?: BaseLinkPlugin['_spec']['options']) =>
+    createSlateEditor({
+      plugins: [BaseLinkPlugin.configure({ options })],
+    });
+
+  describe('internal links', () => {
+    it('should validate paths starting with /', () => {
+      const editor = createTestEditor();
+      expect(validateUrl(editor, '/internal/path')).toBe(true);
+    });
+
+    it('should validate anchor links starting with #', () => {
+      const editor = createTestEditor();
+      expect(validateUrl(editor, '#section-name')).toBe(true);
+      expect(validateUrl(editor, '#top')).toBe(true);
+    });
+  });
+
+  describe('markdown headings', () => {
+    it('should NOT validate markdown heading level 1', () => {
+      const editor = createTestEditor();
+      expect(validateUrl(editor, '# heading1')).toBe(false);
+    });
+
+    it('should NOT validate markdown heading level 2', () => {
+      const editor = createTestEditor();
+      expect(validateUrl(editor, '## heading2')).toBe(false);
+    });
+
+    it('should NOT validate markdown heading level 3', () => {
+      const editor = createTestEditor();
+      expect(validateUrl(editor, '### heading3')).toBe(false);
+    });
+
+    it('should NOT validate markdown heading level 4', () => {
+      const editor = createTestEditor();
+      expect(validateUrl(editor, '#### heading4')).toBe(false);
+    });
+
+    it('should NOT validate markdown heading level 5', () => {
+      const editor = createTestEditor();
+      expect(validateUrl(editor, '##### heading5')).toBe(false);
+    });
+
+    it('should NOT validate markdown heading level 6', () => {
+      const editor = createTestEditor();
+      expect(validateUrl(editor, '###### heading6')).toBe(false);
+    });
+
+    it('should NOT validate markdown headings with various content', () => {
+      const editor = createTestEditor();
+      expect(validateUrl(editor, '# My Title')).toBe(false);
+      expect(validateUrl(editor, '## 2.3 Section')).toBe(false);
+      expect(validateUrl(editor, '### Hello World!')).toBe(false);
+    });
+  });
+
+  describe('external links', () => {
+    it('should validate http URLs', () => {
+      const editor = createTestEditor();
+      expect(validateUrl(editor, 'http://example.com')).toBe(true);
+    });
+
+    it('should validate https URLs', () => {
+      const editor = createTestEditor();
+      expect(validateUrl(editor, 'https://example.com')).toBe(true);
+    });
+
+    it('should validate URLs with custom isUrl function', () => {
+      const editor = createTestEditor({
+        isUrl: (url) => url.startsWith('custom://'),
+      });
+      expect(validateUrl(editor, 'custom://example')).toBe(true);
+      expect(validateUrl(editor, 'http://example.com')).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should still validate anchor links without content after #', () => {
+      const editor = createTestEditor();
+      expect(validateUrl(editor, '#')).toBe(true);
+    });
+
+    it('should validate anchor links that look like markdown but are not', () => {
+      const editor = createTestEditor();
+      // These are valid anchor links, not markdown headings (no space after #)
+      expect(validateUrl(editor, '#heading1')).toBe(true);
+      expect(validateUrl(editor, '##heading2')).toBe(true);
+    });
+  });
+});

--- a/packages/link/src/lib/utils/validateUrl.ts
+++ b/packages/link/src/lib/utils/validateUrl.ts
@@ -6,9 +6,19 @@ export const validateUrl = (editor: SlateEditor, url: string): boolean => {
   const { allowedSchemes, dangerouslySkipSanitization, isUrl } =
     editor.getOptions(BaseLinkPlugin);
 
-  // Allow internal links starting with / or #
-  if (url.startsWith('/') || url.startsWith('#')) {
+  // Allow internal links starting with /
+  if (url.startsWith('/')) {
     return true;
+  }
+
+  // For strings starting with #, check if it's a markdown heading
+  if (url.startsWith('#')) {
+    // Markdown headings have a space after the # symbols
+    const markdownHeadingPattern = /^#{1,6}\s+/;
+    if (markdownHeadingPattern.test(url)) {
+      return false; // This is a markdown heading, not a valid link
+    }
+    return true; // This is an anchor link
   }
 
   if (isUrl && !isUrl(url)) return false;


### PR DESCRIPTION
Fixes #4450

## Summary

The LinkPlugin's `validateUrl` function now properly distinguishes between markdown headings and anchor links. 

Previously, any string starting with `#` was treated as a valid link, causing markdown headings like `# heading1` to be converted to links when pasted.

Now, the function checks for the markdown heading pattern (hash symbols followed by a space) and correctly rejects these as invalid URLs while still allowing valid anchor links like `#section-name`.

## Changes

- Fixed `validateUrl` function to detect markdown heading patterns
- Added comprehensive test coverage for the fix
- Created changeset for patch release

Generated with [Claude Code](https://claude.ai/code)