### PR TITLE
fix(docs): correct typo in get started installation page

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -3,7 +3,7 @@ title: Getting Started
 description: Choose your path to integrate the Plate rich-text editor framework into your React project.
 ---
 
-Plate offers multip1le integration paths depending on your project needs and environment. Choose the approach that best matches your requirements.
+Plate offers multiple integration paths depending on your project needs and environment. Choose the approach that best matches your requirements.
 
 ## Client-Side Integration
 


### PR DESCRIPTION
Replacing "multip1le" with "multiple".

**Checklist**

- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](docs/components/changelog.mdx)
