### PR TITLE
feat(list): add support for dragging list items with children

### DIFF
--- a/.changeset/list-drag-children.md
+++ b/.changeset/list-drag-children.md
@@ -1,0 +1,6 @@
+---
+'@platejs/list': minor
+---
+
+- Added `expandListItemsWithChildren` to automatically include list item children when selecting blocks for operations like drag-and-drop.
+- Added `getListChildren` to get all child list items (with bigger indent) of a given list item.

--- a/docs/components/changelog.mdx
+++ b/docs/components/changelog.mdx
@@ -10,6 +10,9 @@ Use the [CLI](https://platejs.org/docs/components/cli) to install the latest ver
 
 ## July 2025 #24
 
+### July 25 #24.8
+- `block-draggable`: Added support for automatically selecting list item children when dragging. When dragging a list item, all nested items with bigger indent are now included in the drag operation
+
 ### July 23 #24.7
 - `block-draggable`: Updated to use new `addOnContextMenu` API from BlockSelectionPlugin for cleaner context menu handling
 

--- a/packages/list/src/lib/queries/expandListItemsWithChildren.spec.tsx
+++ b/packages/list/src/lib/queries/expandListItemsWithChildren.spec.tsx
@@ -1,0 +1,296 @@
+/** @jsx jsxt */
+
+import { jsxt } from '@platejs/test-utils';
+import { type Descendant, type SlateEditor, createEditor } from 'platejs';
+
+import { expandListItemsWithChildren } from './expandListItemsWithChildren';
+
+jsxt;
+
+describe('expandListItemsWithChildren', () => {
+  describe('when input contains no list items', () => {
+    it('should return the same blocks unchanged', () => {
+      const input = (
+        <fragment>
+          <hp id="1">
+            paragraph 1<cursor />
+          </hp>
+          <hp id="2">paragraph 2</hp>
+          <hh1 id="3">heading</hh1>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      const entries = [
+        [input[0], [0]],
+        [input[1], [1]],
+        [input[2], [2]],
+      ] as any;
+
+      const result = expandListItemsWithChildren(editor, entries);
+
+      expect(result).toEqual(entries);
+    });
+  });
+
+  describe('when input contains list items without children', () => {
+    it('should return the same list items', () => {
+      const input = (
+        <fragment>
+          <hp id="1" indent={1} listStyleType="disc">
+            item 1
+          </hp>
+          <hp id="2" indent={1} listStyleType="disc">
+            item 2<cursor />
+          </hp>
+          <hp id="3" indent={1} listStyleType="disc">
+            item 3
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      const entries = [
+        [input[0], [0]],
+        [input[1], [1]],
+        [input[2], [2]],
+      ] as any;
+
+      const result = expandListItemsWithChildren(editor, entries);
+
+      expect(result).toEqual(entries);
+    });
+  });
+
+  describe('when input contains list items with children', () => {
+    it('should expand single list item to include its children', () => {
+      const input = (
+        <fragment>
+          <hp id="1" indent={1} listStyleType="disc">
+            parent
+            <cursor />
+          </hp>
+          <hp id="2" indent={2} listStyleType="disc">
+            child 1
+          </hp>
+          <hp id="3" indent={2} listStyleType="disc">
+            child 2
+          </hp>
+          <hp id="4" indent={1} listStyleType="disc">
+            sibling
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      // Only pass the parent item
+      const entries = [[input[0], [0]]] as any;
+
+      const result = expandListItemsWithChildren(editor, entries);
+
+      expect(result).toEqual([
+        [input[0], [0]], // parent
+        [input[1], [1]], // child 1
+        [input[2], [2]], // child 2
+      ]);
+    });
+
+    it('should handle multiple list items with children', () => {
+      const input = (
+        <fragment>
+          <hp id="1" indent={1} listStyleType="disc">
+            parent 1
+          </hp>
+          <hp id="2" indent={2} listStyleType="disc">
+            child 1.1
+          </hp>
+          <hp id="3" indent={1} listStyleType="disc">
+            parent 2<cursor />
+          </hp>
+          <hp id="4" indent={2} listStyleType="disc">
+            child 2.1
+          </hp>
+          <hp id="5" indent={3} listStyleType="disc">
+            grandchild 2.1.1
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      // Pass both parent items
+      const entries = [
+        [input[0], [0]],
+        [input[2], [2]],
+      ] as any;
+
+      const result = expandListItemsWithChildren(editor, entries);
+
+      expect(result).toEqual([
+        [input[0], [0]], // parent 1
+        [input[1], [1]], // child 1.1
+        [input[2], [2]], // parent 2
+        [input[3], [3]], // child 2.1
+        [input[4], [4]], // grandchild 2.1.1
+      ]);
+    });
+
+    it('should avoid duplicates when children are already in input', () => {
+      const input = (
+        <fragment>
+          <hp id="1" indent={1} listStyleType="disc">
+            parent
+          </hp>
+          <hp id="2" indent={2} listStyleType="disc">
+            child 1<cursor />
+          </hp>
+          <hp id="3" indent={2} listStyleType="disc">
+            child 2
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      // Pass parent and one child (child 1)
+      const entries = [
+        [input[0], [0]],
+        [input[1], [1]],
+      ] as any;
+
+      const result = expandListItemsWithChildren(editor, entries);
+
+      // Should not duplicate child 1, but should add child 2
+      expect(result).toEqual([
+        [input[0], [0]], // parent
+        [input[1], [1]], // child 1 (from input)
+        [input[2], [2]], // child 2 (added)
+      ]);
+    });
+  });
+
+  describe('when input contains mixed blocks', () => {
+    it('should expand only list items and keep other blocks as-is', () => {
+      const input = (
+        <fragment>
+          <hp id="1">paragraph before</hp>
+          <hp id="2" indent={1} listStyleType="disc">
+            list parent
+            <cursor />
+          </hp>
+          <hp id="3" indent={2} listStyleType="disc">
+            list child
+          </hp>
+          <hh1 id="4">heading after</hh1>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      const entries = [
+        [input[0], [0]], // paragraph
+        [input[1], [1]], // list parent
+        [input[3], [3]], // heading
+      ] as any;
+
+      const result = expandListItemsWithChildren(editor, entries);
+
+      expect(result).toEqual([
+        [input[0], [0]], // paragraph (unchanged)
+        [input[1], [1]], // list parent
+        [input[2], [2]], // list child (added)
+        [input[3], [3]], // heading (unchanged)
+      ]);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty input', () => {
+      const editor = createEditor((<editor></editor>) as any as SlateEditor);
+
+      const result = expandListItemsWithChildren(editor, []);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle list items at end of document', () => {
+      const input = (
+        <fragment>
+          <hp id="1" indent={1} listStyleType="disc">
+            parent at end
+            <cursor />
+          </hp>
+          <hp id="2" indent={2} listStyleType="disc">
+            child at end
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      const entries = [[input[0], [0]]] as any;
+
+      const result = expandListItemsWithChildren(editor, entries);
+
+      expect(result).toEqual([
+        [input[0], [0]], // parent
+        [input[1], [1]], // child
+      ]);
+    });
+
+    it('should handle deeply nested lists', () => {
+      const input = (
+        <fragment>
+          <hp id="1" indent={1} listStyleType="disc">
+            level 1<cursor />
+          </hp>
+          <hp id="2" indent={2} listStyleType="disc">
+            level 2
+          </hp>
+          <hp id="3" indent={3} listStyleType="disc">
+            level 3
+          </hp>
+          <hp id="4" indent={4} listStyleType="disc">
+            level 4
+          </hp>
+          <hp id="5" indent={5} listStyleType="disc">
+            level 5
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      const entries = [[input[0], [0]]] as any;
+
+      const result = expandListItemsWithChildren(editor, entries);
+
+      expect(result).toEqual([
+        [input[0], [0]], // level 1
+        [input[1], [1]], // level 2
+        [input[2], [2]], // level 3
+        [input[3], [3]], // level 4
+        [input[4], [4]], // level 5
+      ]);
+    });
+  });
+});

--- a/packages/list/src/lib/queries/expandListItemsWithChildren.ts
+++ b/packages/list/src/lib/queries/expandListItemsWithChildren.ts
@@ -1,0 +1,54 @@
+import type { Editor, ElementEntryOf, ElementOf, NodeEntry } from 'platejs';
+
+import { isDefined, KEYS } from 'platejs';
+
+import { getListChildren } from './getListChildren';
+
+/**
+ * Expands a list of blocks to include list item children. For each list item in
+ * the input, adds all its children (items with bigger indent). Non-list blocks
+ * are kept as-is. Requires id to be set on the blocks.
+ *
+ * @returns Array of block entries with list items expanded to include their
+ *   children
+ */
+export const expandListItemsWithChildren = <
+  N extends ElementOf<E>,
+  E extends Editor = Editor,
+>(
+  editor: E,
+  entries: ElementEntryOf<E>[]
+): NodeEntry<N>[] => {
+  const expandedEntries: NodeEntry<N>[] = [];
+  const processedIds = new Set<string>();
+
+  entries.forEach((entry) => {
+    const [node] = entry;
+
+    // Skip if already processed
+    if (processedIds.has(node.id as string)) return;
+
+    expandedEntries.push(entry as NodeEntry<N>);
+    processedIds.add(node.id as string);
+
+    // Check if it's a list item
+    const isListItem =
+      isDefined((node as any)[KEYS.listType]) &&
+      isDefined((node as any)[KEYS.indent]);
+
+    if (isListItem) {
+      // Get all children (items with bigger indent)
+      const children = getListChildren<N, E>(editor, entry);
+
+      // Add children that aren't already in the selection
+      children.forEach((childEntry) => {
+        if (!processedIds.has(childEntry[0].id as string)) {
+          expandedEntries.push(childEntry);
+          processedIds.add(childEntry[0].id as string);
+        }
+      });
+    }
+  });
+
+  return expandedEntries;
+};

--- a/packages/list/src/lib/queries/getListChildren.spec.tsx
+++ b/packages/list/src/lib/queries/getListChildren.spec.tsx
@@ -1,0 +1,415 @@
+/** @jsx jsxt */
+
+import { jsxt } from '@platejs/test-utils';
+import {
+  type Descendant,
+  type SlateEditor,
+  type TElement,
+  createEditor,
+} from 'platejs';
+
+import { getListChildren } from './getListChildren';
+
+jsxt;
+
+describe('getListChildren', () => {
+  describe('when node is not a list item', () => {
+    it('should return empty array when node has no listType', () => {
+      const input = (
+        <fragment>
+          <hp indent={1}>
+            not a list item<cursor />
+          </hp>
+          <hp indent={2} listStyleType="disc">
+            list item
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      const entry = editor.api.block<TElement>();
+      const children = getListChildren(editor, entry!);
+
+      expect(children).toEqual([]);
+    });
+
+    it('should return empty array when node has no indent', () => {
+      const input = (
+        <fragment>
+          <hp listStyleType="disc">
+            no indent<cursor />
+          </hp>
+          <hp indent={1} listStyleType="disc">
+            child
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      const entry = editor.api.block<TElement>();
+      const children = getListChildren(editor, entry!);
+
+      expect(children).toEqual([]);
+    });
+  });
+
+  describe('when node is a list item', () => {
+    it('should get all direct children with bigger indent', () => {
+      const input = (
+        <fragment>
+          <hp indent={1} listStyleType="disc">
+            parent<cursor />
+          </hp>
+          <hp indent={2} listStyleType="disc">
+            child 1
+          </hp>
+          <hp indent={2} listStyleType="disc">
+            child 2
+          </hp>
+          <hp indent={1} listStyleType="disc">
+            sibling
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const output = (
+        <fragment>
+          <hp indent={2} listStyleType="disc">
+            child 1
+          </hp>
+          <hp indent={2} listStyleType="disc">
+            child 2
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      const entry = editor.api.block<TElement>();
+      const children = getListChildren(editor, entry!);
+
+      expect(children).toEqual([
+        [output[0], [1]],
+        [output[1], [2]],
+      ]);
+    });
+
+    it('should get nested children with multiple indent levels', () => {
+      const input = (
+        <fragment>
+          <hp indent={1} listStyleType="disc">
+            parent<cursor />
+          </hp>
+          <hp indent={2} listStyleType="disc">
+            child
+          </hp>
+          <hp indent={3} listStyleType="disc">
+            grandchild
+          </hp>
+          <hp indent={4} listStyleType="disc">
+            great-grandchild
+          </hp>
+          <hp indent={1} listStyleType="disc">
+            sibling
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const output = (
+        <fragment>
+          <hp indent={2} listStyleType="disc">
+            child
+          </hp>
+          <hp indent={3} listStyleType="disc">
+            grandchild
+          </hp>
+          <hp indent={4} listStyleType="disc">
+            great-grandchild
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      const entry = editor.api.block<TElement>();
+      const children = getListChildren(editor, entry!);
+
+      expect(children).toEqual([
+        [output[0], [1]],
+        [output[1], [2]],
+        [output[2], [3]],
+      ]);
+    });
+
+    it('should stop at item with equal indent', () => {
+      const input = (
+        <fragment>
+          <hp indent={2} listStyleType="disc">
+            parent<cursor />
+          </hp>
+          <hp indent={3} listStyleType="disc">
+            child 1
+          </hp>
+          <hp indent={3} listStyleType="disc">
+            child 2
+          </hp>
+          <hp indent={2} listStyleType="disc">
+            sibling (should stop here)
+          </hp>
+          <hp indent={3} listStyleType="disc">
+            not included
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const output = (
+        <fragment>
+          <hp indent={3} listStyleType="disc">
+            child 1
+          </hp>
+          <hp indent={3} listStyleType="disc">
+            child 2
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      const entry = editor.api.block<TElement>();
+      const children = getListChildren(editor, entry!);
+
+      expect(children).toEqual([
+        [output[0], [1]],
+        [output[1], [2]],
+      ]);
+    });
+
+    it('should stop at item with lower indent', () => {
+      const input = (
+        <fragment>
+          <hp indent={3} listStyleType="disc">
+            parent<cursor />
+          </hp>
+          <hp indent={4} listStyleType="disc">
+            child 1
+          </hp>
+          <hp indent={5} listStyleType="disc">
+            grandchild
+          </hp>
+          <hp indent={2} listStyleType="disc">
+            ancestor (should stop here)
+          </hp>
+          <hp indent={4} listStyleType="disc">
+            not included
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const output = (
+        <fragment>
+          <hp indent={4} listStyleType="disc">
+            child 1
+          </hp>
+          <hp indent={5} listStyleType="disc">
+            grandchild
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      const entry = editor.api.block<TElement>();
+      const children = getListChildren(editor, entry!);
+
+      expect(children).toEqual([
+        [output[0], [1]],
+        [output[1], [2]],
+      ]);
+    });
+
+    it('should stop at non-list item', () => {
+      const input = (
+        <fragment>
+          <hp indent={1} listStyleType="disc">
+            parent<cursor />
+          </hp>
+          <hp indent={2} listStyleType="disc">
+            child 1
+          </hp>
+          <hp indent={2}>
+            not a list item (should stop here)
+          </hp>
+          <hp indent={2} listStyleType="disc">
+            not included
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const output = (
+        <fragment>
+          <hp indent={2} listStyleType="disc">
+            child 1
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      const entry = editor.api.block<TElement>();
+      const children = getListChildren(editor, entry!);
+
+      expect(children).toEqual([[output[0], [1]]]);
+    });
+
+    it('should return empty array when no children exist', () => {
+      const input = (
+        <fragment>
+          <hp indent={1} listStyleType="disc">
+            parent<cursor />
+          </hp>
+          <hp indent={1} listStyleType="disc">
+            sibling
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      const entry = editor.api.block<TElement>();
+      const children = getListChildren(editor, entry!);
+
+      expect(children).toEqual([]);
+    });
+
+    it('should return empty array when at last position', () => {
+      const input = (
+        <fragment>
+          <hp indent={1} listStyleType="disc">
+            item 1
+          </hp>
+          <hp indent={2} listStyleType="disc">
+            last item<cursor />
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      const entry = editor.api.block<TElement>();
+      const children = getListChildren(editor, entry!);
+
+      expect(children).toEqual([]);
+    });
+
+    it('should work with mixed list types', () => {
+      const input = (
+        <fragment>
+          <hp indent={1} listStyleType="disc">
+            parent<cursor />
+          </hp>
+          <hp indent={2} listStyleType="decimal">
+            ordered child 1
+          </hp>
+          <hp indent={2} listStyleType="disc">
+            unordered child 2
+          </hp>
+          <hp indent={3} listStyleType="decimal">
+            nested ordered
+          </hp>
+          <hp indent={1} listStyleType="disc">
+            sibling
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const output = (
+        <fragment>
+          <hp indent={2} listStyleType="decimal">
+            ordered child 1
+          </hp>
+          <hp indent={2} listStyleType="disc">
+            unordered child 2
+          </hp>
+          <hp indent={3} listStyleType="decimal">
+            nested ordered
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      const entry = editor.api.block<TElement>();
+      const children = getListChildren(editor, entry!);
+
+      expect(children).toEqual([
+        [output[0], [1]],
+        [output[1], [2]],
+        [output[2], [3]],
+      ]);
+    });
+
+    it('should work with todo lists', () => {
+      const input = (
+        <fragment>
+          <hp indent={1} listStyleType="disc" listChecked={false}>
+            parent todo<cursor />
+          </hp>
+          <hp indent={2} listStyleType="disc" listChecked={true}>
+            checked child
+          </hp>
+          <hp indent={2} listStyleType="disc" listChecked={false}>
+            unchecked child
+          </hp>
+          <hp indent={1} listStyleType="disc">
+            sibling
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const output = (
+        <fragment>
+          <hp indent={2} listStyleType="disc" listChecked={true}>
+            checked child
+          </hp>
+          <hp indent={2} listStyleType="disc" listChecked={false}>
+            unchecked child
+          </hp>
+        </fragment>
+      ) as any as Descendant[];
+
+      const editor = createEditor(
+        (<editor>{input}</editor>) as any as SlateEditor
+      );
+
+      const entry = editor.api.block<TElement>();
+      const children = getListChildren(editor, entry!);
+
+      expect(children).toEqual([
+        [output[0], [1]],
+        [output[1], [2]],
+      ]);
+    });
+  });
+});

--- a/packages/list/src/lib/queries/getListChildren.ts
+++ b/packages/list/src/lib/queries/getListChildren.ts
@@ -1,0 +1,55 @@
+import type { Editor, ElementEntryOf, ElementOf, NodeEntry } from 'platejs';
+
+import { isDefined, KEYS, NodeApi, PathApi } from 'platejs';
+
+/**
+ * Get all list items that are children of the current list item (have bigger
+ * indent). Stops when encountering an item with equal or lower indent.
+ */
+export const getListChildren = <
+  N extends ElementOf<E>,
+  E extends Editor = Editor,
+>(
+  editor: E,
+  entry: ElementEntryOf<E>
+): NodeEntry<N>[] => {
+  const children: NodeEntry<N>[] = [];
+  const [node, path] = entry;
+
+  const parentIndent = (node as any)[KEYS.indent] as number;
+
+  // If no indent or not a list item, return empty
+  if (!isDefined(parentIndent) || !isDefined((node as any)[KEYS.listType])) {
+    return children;
+  }
+
+  let currentPath = path;
+
+  while (true) {
+    const nextPath = PathApi.next(currentPath);
+    if (!nextPath) break;
+
+    const nextNode = NodeApi.get<N>(editor, nextPath);
+    if (!nextNode) break;
+
+    const nextIndent = (nextNode as any)[KEYS.indent] as number;
+
+    // Stop if we hit a non-list item or item with equal/lower indent
+    if (
+      !isDefined(nextIndent) ||
+      !isDefined((nextNode as any)[KEYS.listType])
+    ) {
+      break;
+    }
+
+    if (nextIndent <= parentIndent) {
+      break;
+    }
+
+    // This is a child item (bigger indent)
+    children.push([nextNode, nextPath]);
+    currentPath = nextPath;
+  }
+
+  return children;
+};

--- a/packages/list/src/lib/queries/index.ts
+++ b/packages/list/src/lib/queries/index.ts
@@ -3,7 +3,9 @@
  */
 
 export * from './areEqListStyleType';
+export * from './expandListItemsWithChildren';
 export * from './getListAbove';
+export * from './getListChildren';
 export * from './getListSiblings';
 export * from './getNextList';
 export * from './getPreviousList';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3209,7 +3209,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3221,7 +3221,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3233,7 +3233,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3245,7 +3245,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3258,7 +3258,7 @@ __metadata:
     platejs: "workspace:^"
     react-textarea-autosize: "npm:^8.5.9"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3271,7 +3271,7 @@ __metadata:
     lowlight: "npm:^3.3.0"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3283,7 +3283,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3296,17 +3296,17 @@ __metadata:
     lodash: "npm:^4.17.21"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
   linkType: soft
 
-"@platejs/core@npm:49.1.5, @platejs/core@workspace:packages/core":
+"@platejs/core@npm:49.1.13, @platejs/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@platejs/core@workspace:packages/core"
   dependencies:
-    "@platejs/slate": "npm:49.0.2"
+    "@platejs/slate": "npm:49.1.13"
     "@udecode/react-hotkeys": "npm:37.0.0"
     "@udecode/react-utils": "npm:49.0.15"
     "@udecode/utils": "npm:47.2.7"
@@ -3334,12 +3334,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@platejs/csv@workspace:packages/csv"
   dependencies:
-    "@platejs/table": "npm:49.0.19"
+    "@platejs/table": "npm:49.1.13"
     "@types/papaparse": "npm:^5.3.16"
     papaparse: "npm:^5.5.3"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3351,7 +3351,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3363,7 +3363,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3377,7 +3377,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3391,7 +3391,7 @@ __metadata:
     platejs: "workspace:^"
     raf: "npm:^3.4.1"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dnd: ">=14.0.0"
     react-dnd-html5-backend: ">=14.0.0"
@@ -3406,7 +3406,7 @@ __metadata:
     platejs: "workspace:^"
     validator: "npm:^13.15.15"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3421,7 +3421,7 @@ __metadata:
     platejs: "workspace:^"
   peerDependencies:
     "@emoji-mart/data": ">=1.2.0"
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3434,7 +3434,7 @@ __metadata:
     "@excalidraw/excalidraw": "npm:0.16.4"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3446,7 +3446,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3460,7 +3460,7 @@ __metadata:
     "@floating-ui/react": "npm:^0.27.12"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3472,7 +3472,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3485,7 +3485,7 @@ __metadata:
     juice: "npm:^11.0.1"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3497,7 +3497,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3510,7 +3510,7 @@ __metadata:
     "@platejs/floating": "npm:49.0.0"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3523,7 +3523,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3537,7 +3537,7 @@ __metadata:
     clsx: "npm:^2.1.1"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3559,7 +3559,7 @@ __metadata:
     ts-essentials: "npm:10.1.0"
     unified: "npm:^11.0.5"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3573,7 +3573,7 @@ __metadata:
     katex: "npm:0.16.22"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3586,7 +3586,7 @@ __metadata:
     js-video-url-parser: "npm:^0.5.1"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3599,7 +3599,7 @@ __metadata:
     "@platejs/combobox": "npm:49.0.0"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3612,7 +3612,7 @@ __metadata:
     platejs: "workspace:^"
   peerDependencies:
     "@playwright/test": ">=1.42.1"
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3624,7 +3624,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3637,7 +3637,7 @@ __metadata:
     copy-to-clipboard: "npm:^3.3.3"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3650,13 +3650,13 @@ __metadata:
     "@platejs/combobox": "npm:49.0.0"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
   linkType: soft
 
-"@platejs/slate@npm:49.0.2, @platejs/slate@workspace:packages/slate":
+"@platejs/slate@npm:49.1.13, @platejs/slate@workspace:packages/slate":
   version: 0.0.0-use.local
   resolution: "@platejs/slate@workspace:packages/slate"
   dependencies:
@@ -3676,7 +3676,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3689,13 +3689,13 @@ __metadata:
     platejs: "workspace:^"
     tabbable: "npm:^6.2.0"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
   linkType: soft
 
-"@platejs/table@npm:49.0.19, @platejs/table@workspace:^, @platejs/table@workspace:packages/table":
+"@platejs/table@npm:49.1.13, @platejs/table@workspace:^, @platejs/table@workspace:packages/table":
   version: 0.0.0-use.local
   resolution: "@platejs/table@workspace:packages/table"
   dependencies:
@@ -3703,7 +3703,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3715,7 +3715,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3725,7 +3725,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@platejs/test-utils@workspace:packages/test-utils"
   dependencies:
-    "@platejs/slate": "npm:49.0.2"
+    "@platejs/slate": "npm:49.1.13"
     slate-hyperscript: "npm:0.100.0"
   languageName: unknown
   linkType: soft
@@ -3736,7 +3736,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3750,18 +3750,18 @@ __metadata:
     lodash: "npm:^4.17.21"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
   linkType: soft
 
-"@platejs/utils@npm:49.1.5, @platejs/utils@workspace:packages/utils":
+"@platejs/utils@npm:49.1.13, @platejs/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@platejs/utils@workspace:packages/utils"
   dependencies:
-    "@platejs/core": "npm:49.1.5"
-    "@platejs/slate": "npm:49.0.2"
+    "@platejs/core": "npm:49.1.13"
+    "@platejs/slate": "npm:49.1.13"
     "@udecode/react-utils": "npm:49.0.15"
     "@udecode/utils": "npm:47.2.7"
     clsx: "npm:^2.1.1"
@@ -3781,7 +3781,7 @@ __metadata:
     yjs: "npm:^13.6.27"
   peerDependencies:
     "@hocuspocus/provider": ^2.15.2
-    platejs: ">=49.1.5"
+    platejs: ">=49.1.13"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
     y-webrtc: 10.3.0
@@ -17107,9 +17107,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "platejs@workspace:packages/plate"
   dependencies:
-    "@platejs/core": "npm:49.1.5"
-    "@platejs/slate": "npm:49.0.2"
-    "@platejs/utils": "npm:49.1.5"
+    "@platejs/core": "npm:49.1.13"
+    "@platejs/slate": "npm:49.1.13"
+    "@platejs/utils": "npm:49.1.13"
     "@udecode/react-hotkeys": "npm:37.0.0"
     "@udecode/react-utils": "npm:49.0.15"
     "@udecode/utils": "npm:47.2.7"


### PR DESCRIPTION
## Summary

Adds support for automatically selecting and dragging list item children (nested items with bigger indent) when dragging a parent list item.

## Changes

### New Features
- Added `getListChildren()` function to get all child list items with bigger indent
- Added `expandListItemsWithChildren()` function to expand blocks to include list item children
- Updated `block-draggable` component to automatically include list children when dragging

### Implementation Details
- When dragging a list item, all nested items with bigger indent are now automatically included in the selection
- The implementation uses the existing indent values to determine parent-child relationships
- Non-list blocks are unaffected by this change

## Test plan
- [x] Added comprehensive unit tests for `getListChildren`
- [x] Added comprehensive unit tests for `expandListItemsWithChildren`
- [x] All tests passing

To test manually:
1. Create a nested list structure
2. Drag a parent list item
3. Verify that all child items (with bigger indent) are included in the drag operation
4. Verify that sibling items (same or lower indent) are not included

🤖 Generated with [Claude Code](https://claude.ai/code)