### PR TITLE
fix(registry): include `ListPlugin` in `list-classic-kit`

### DIFF
--- a/apps/www/src/registry/components/editor/plugins/list-classic-kit.tsx
+++ b/apps/www/src/registry/components/editor/plugins/list-classic-kit.tsx
@@ -4,6 +4,7 @@ import {
   BulletedListPlugin,
   ListItemContentPlugin,
   ListItemPlugin,
+  ListPlugin,
   NumberedListPlugin,
   TaskListPlugin,
 } from '@platejs/list-classic/react';
@@ -16,6 +17,7 @@ import {
 } from '@/registry/ui/list-classic-node';
 
 export const ListKit = [
+  ListPlugin,
   ListItemPlugin,
   ListItemContentPlugin,
   BulletedListPlugin.configure({

--- a/docs/components/changelog.mdx
+++ b/docs/components/changelog.mdx
@@ -10,6 +10,9 @@ Use the [CLI](https://platejs.org/docs/components/cli) to install the latest ver
 
 ## July 2025 #24
 
+### July 26 #24.9
+- `list-classic-kit`: Added `ListPlugin` to restore List functionalities (indent with Tab / Shift+Tab, new item when pressing enter, ...).
+
 ### July 25 #24.8
 - `block-draggable`: Added support for automatically selecting list item children when dragging. When dragging a list item, all nested items with bigger indent are now included in the drag operation
 


### PR DESCRIPTION
The missing `listPlugin` broke the behaviour of lists (no indent, no new item added on new line, ...) due to missing editor override and extensions.
