### PR TITLE
Fix: React hooks error when updating block type

### DIFF
--- a/.changeset/soft-comics-sleep.md
+++ b/.changeset/soft-comics-sleep.md
@@ -1,0 +1,5 @@
+---
+'@platejs/core': patch
+---
+
+Fix: `Error: Rendered more hooks than during the previous render.` when updating the block type.

--- a/packages/core/src/react/utils/pluginRenderElement.tsx
+++ b/packages/core/src/react/utils/pluginRenderElement.tsx
@@ -114,7 +114,12 @@ export const pluginRenderElement = (
         path={path}
         scope={plugin.key}
       >
-        <ElementContent editor={editor} plugin={plugin} {...(props as any)} />
+        <ElementContent
+          key={plugin.key}
+          editor={editor}
+          plugin={plugin}
+          {...(props as any)}
+        />
       </ElementProvider>
     );
   };


### PR DESCRIPTION
## Summary
- Fixes `Error: Rendered more hooks than during the previous render.` when updating the block type
- Adds `key={plugin.key}` to `ElementContent` component to ensure React properly tracks component instances when the plugin changes

## Test plan
- [ ] Test changing block types in the editor
- [ ] Verify no React hooks errors occur
- [ ] Ensure block type changes work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)