### PR TITLE
fix: Remove inject.nodeProps from default element to prevent React hooks error

### DIFF
--- a/.changeset/brown-walls-begin.md
+++ b/.changeset/brown-walls-begin.md
@@ -1,0 +1,5 @@
+---
+'@platejs/core': patch
+---
+
+Remove `inject.nodeProps` from default element, preventing `Error: Rendered more hooks than during the previous render.`.

--- a/packages/core/src/react/utils/getRenderNodeProps.ts
+++ b/packages/core/src/react/utils/getRenderNodeProps.ts
@@ -18,6 +18,7 @@ import { getEditorPlugin } from '../plugin';
  */
 export const getRenderNodeProps = ({
   attributes: nodeAttributes,
+  disableInjectNodeProps,
   editor,
   plugin,
   props,
@@ -26,6 +27,7 @@ export const getRenderNodeProps = ({
   editor: PlateEditor;
   props: PlateHTMLProps;
   attributes?: AnyObject;
+  disableInjectNodeProps?: boolean;
   plugin?: AnyEditorPlatePlugin;
   readOnly?: boolean;
 }): PlateHTMLProps => {
@@ -61,12 +63,14 @@ export const getRenderNodeProps = ({
     },
   };
 
-  newProps = pipeInjectNodeProps(
-    editor,
-    newProps,
-    (node) => editor.api.findPath(node)!,
-    readOnly
-  ) as PlateHTMLProps;
+  if (!disableInjectNodeProps) {
+    newProps = pipeInjectNodeProps(
+      editor,
+      newProps,
+      (node) => editor.api.findPath(node)!,
+      readOnly
+    ) as PlateHTMLProps;
+  }
 
   if (
     newProps.attributes?.style &&

--- a/packages/core/src/react/utils/pipeRenderElement.tsx
+++ b/packages/core/src/react/utils/pipeRenderElement.tsx
@@ -39,6 +39,8 @@ export const pipeRenderElement = (
     }
 
     const ctxProps = getRenderNodeProps({
+      // `transformProps` can run hooks, so we need to disable it for default elements.
+      disableInjectNodeProps: true,
       editor,
       props: { ...props, path } as any,
       readOnly,

--- a/packages/core/src/react/utils/pluginRenderElement.tsx
+++ b/packages/core/src/react/utils/pluginRenderElement.tsx
@@ -114,12 +114,7 @@ export const pluginRenderElement = (
         path={path}
         scope={plugin.key}
       >
-        <ElementContent
-          key={plugin.key}
-          editor={editor}
-          plugin={plugin}
-          {...(props as any)}
-        />
+        <ElementContent editor={editor} plugin={plugin} {...(props as any)} />
       </ElementProvider>
     );
   };


### PR DESCRIPTION
## Summary
Fixes an issue where default elements were causing React hooks errors by removing `inject.nodeProps` functionality.

## Changes
- Added `disableInjectNodeProps` parameter to `getRenderNodeProps` function
- Disabled `inject.nodeProps` for default elements in `pipeRenderElement` to prevent hooks from being called inconsistently
- Removed unnecessary `key` prop from `ElementContent` component

## Test plan
This change prevents the error: "Rendered more hooks than during the previous render" that could occur when using transformProps with hooks in default elements.

🤖 Generated with [Claude Code](https://claude.ai/code)