### PR TITLE
Fix drop target path

### DIFF
--- a/.changeset/odd-spies-carry.md
+++ b/.changeset/odd-spies-carry.md
@@ -1,0 +1,5 @@
+---
+'@platejs/dnd': patch
+---
+
+Fix missing target path onDropFiles

--- a/packages/dnd/src/transforms/onDropNode.ts
+++ b/packages/dnd/src/transforms/onDropNode.ts
@@ -67,12 +67,12 @@ export const getDropPath = (
 
   // Treat 'right' like 'bottom' (after hovered)
   // Treat 'left' like 'top' (before hovered)
-  if (dragPath && (direction === 'bottom' || direction === 'right')) {
+  if (direction === 'bottom' || direction === 'right') {
     // Insert after hovered node
     dropPath = hoveredPath;
 
     // If the dragged node is already right after hovered node, no change
-    if (PathApi.equals(dragPath, PathApi.next(dropPath))) return;
+    if (dragPath && PathApi.equals(dragPath, PathApi.next(dropPath))) return;
   }
   if (direction === 'top' || direction === 'left') {
     // Insert before hovered node


### PR DESCRIPTION
**Checklist**

- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](docs/components/changelog.mdx)

When dropping files into the editor, sometimes the `target` (the path where the drop happened) argument was `undefined`. This PR fixes this problem.