### PR TITLE
Accept components with props of type PlateElementProps

### DIFF
--- a/.changeset/strong-walls-invite.md
+++ b/.changeset/strong-walls-invite.md
@@ -1,0 +1,5 @@
+---
+'@platejs/core': patch
+---
+
+Accept components with props of type PlateElementProps

--- a/packages/core/src/react/components/plate-nodes.tsx
+++ b/packages/core/src/react/components/plate-nodes.tsx
@@ -65,11 +65,13 @@ export type PlateNodeProps<C extends AnyPluginConfig = PluginConfig> =
 
 export type PlateHTMLProps<
   C extends AnyPluginConfig = PluginConfig,
-  T extends React.ComponentType | keyof HTMLElementTagNameMap = 'div',
+  T extends
+    | React.ComponentType<PlateElementProps>
+    | keyof HTMLElementTagNameMap = 'div',
 > = PlateNodeProps<C> & {
   /** HTML attributes to pass to the underlying HTML element */
   attributes: React.PropsWithoutRef<
-    T extends React.ComponentType
+    T extends React.ComponentType<PlateElementProps>
       ? React.ComponentProps<T>
       : T extends keyof HTMLElementTagNameMap
         ? React.JSX.IntrinsicElements[T]


### PR DESCRIPTION
**Checklist**

- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](docs/components/changelog.mdx)

Looks like I missed a little something in my first PR: https://github.com/udecode/plate/pull/4531

Fixed it here