### PR TITLE
Hide drop line on cancel drag

### DIFF
--- a/.changeset/khaki-insects-remain.md
+++ b/.changeset/khaki-insects-remain.md
@@ -1,0 +1,5 @@
+---
+'@platejs/dnd': patch
+---
+
+Hide drop line when user leaves document or drops (also besides editor)

--- a/packages/dnd/src/DndPlugin.tsx
+++ b/packages/dnd/src/DndPlugin.tsx
@@ -88,6 +88,9 @@ export const DndPlugin = createTPlatePlugin<DndConfig>({
   useHooks: ({ setOption }) => {
     const handleDocumentDragLeave = useCallback(
       (e: DragEvent) => {
+        // This event fires for every element that receives a drag leave event. If `clientX` and `clientY` are both 0,
+        // it means the drag has left the viewport. Needed, if the drag did not start inside the editor, but for example
+        // by dragging a file from the filesystem
         if (!e.clientX && !e.clientY) {
           setOption('dropTarget', undefined);
         }
@@ -95,6 +98,10 @@ export const DndPlugin = createTPlatePlugin<DndConfig>({
       [setOption]
     );
 
+    // We listen for the drop event on the document and not only inside the editor, because we want to
+    // remove the dropTarget, and therefore hide the drop line, also when the drop happened outside of
+    // the editor. Needed, if the drag did not start inside the editor, but for example by dragging a
+    // file from the filesystem
     const handleDocumentDrop = useCallback(() => {
       setOption('_isOver', false);
       setOption('dropTarget', undefined);


### PR DESCRIPTION
**Checklist**

- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](docs/components/changelog.mdx)

This PR will hide the drop line, when leaving the document while dragging or dropping besides a plate editor.

Before the drop line got stuck in those scenarios.