### PR TITLE
Enable dnd between editors

### DIFF
--- a/.changeset/swift-moons-fetch.md
+++ b/.changeset/swift-moons-fetch.md
@@ -1,0 +1,5 @@
+---
+'@platejs/dnd': patch
+---
+
+Enable dnd between editors

--- a/packages/dnd/src/transforms/onDropNode.spec.ts
+++ b/packages/dnd/src/transforms/onDropNode.spec.ts
@@ -19,7 +19,11 @@ describe('onDropNode', () => {
   const monitor = { canDrop: () => true } as DropTargetMonitor;
   const nodeRef = {};
   const dragElement = { id: 'drag' } as unknown as TElement;
-  const dragItem: DragItemNode = { id: 'drag', element: dragElement };
+  const dragItem: DragItemNode = {
+    id: 'drag',
+    editorId: editor.id,
+    element: dragElement,
+  };
 
   const hoverElement = { id: 'hover' } as unknown as TElement;
 

--- a/packages/dnd/src/transforms/onDropNode.ts
+++ b/packages/dnd/src/transforms/onDropNode.ts
@@ -123,30 +123,34 @@ export const onDropNode = (
 
   const { dragPath, to } = result;
 
-  // Check if we're dragging multiple nodes
-  const draggedIds = Array.isArray(dragItem.id) ? dragItem.id : [dragItem.id];
+  if (dragItem.editorId === editor.id) {
+    // Check if we're dragging multiple nodes
+    const draggedIds = Array.isArray(dragItem.id) ? dragItem.id : [dragItem.id];
 
-  if (draggedIds.length > 1) {
-    // Handle multi-node drop - get elements by their IDs and sort them
-    const elements: TElement[] = [];
+    if (draggedIds.length > 1) {
+      // Handle multi-node drop - get elements by their IDs and sort them
+      const elements: TElement[] = [];
 
-    draggedIds.forEach((id) => {
-      const entry = editor.api.node<TElement>({ id, at: [] });
-      if (entry) {
-        elements.push(entry[0]);
-      }
-    });
+      draggedIds.forEach((id) => {
+        const entry = editor.api.node<TElement>({ id, at: [] });
+        if (entry) {
+          elements.push(entry[0]);
+        }
+      });
 
-    editor.tf.moveNodes({
-      at: [],
-      to,
-      match: (n) => elements.some((element) => element.id === n.id),
-    });
+      editor.tf.moveNodes({
+        at: [],
+        to,
+        match: (n) => elements.some((element) => element.id === n.id),
+      });
+    } else {
+      // Single node drop
+      editor.tf.moveNodes({
+        at: dragPath,
+        to,
+      });
+    }
   } else {
-    // Single node drop
-    editor.tf.moveNodes({
-      at: dragPath,
-      to,
-    });
+    editor.tf.insertNodes(dragItem.element, { at: to });
   }
 };

--- a/packages/dnd/src/transforms/onHoverNode.spec.ts
+++ b/packages/dnd/src/transforms/onHoverNode.spec.ts
@@ -40,7 +40,11 @@ describe('onHoverNode', () => {
   const monitor = {} as DropTargetMonitor;
   const nodeRef = {};
   const dragElement = { id: 'drag' } as unknown as TElement;
-  const dragItem: DragItemNode = { id: 'drag', element: dragElement };
+  const dragItem: DragItemNode = {
+    id: 'drag',
+    editorId: editor.id,
+    element: dragElement,
+  };
 
   const hoverElement = { id: 'hover' } as unknown as TElement;
 

--- a/packages/dnd/src/types.ts
+++ b/packages/dnd/src/types.ts
@@ -10,6 +10,7 @@ export interface ElementDragItemNode {
   /** Required to identify the node(s). */
   id: string[] | string;
   [key: string]: unknown;
+  editorId: string;
   element: TElement;
 }
 

--- a/packages/dnd/src/utils/getHoverDirection.spec.ts
+++ b/packages/dnd/src/utils/getHoverDirection.spec.ts
@@ -17,7 +17,11 @@ describe('getHoverDirection', () => {
   } as unknown as DropTargetMonitor;
 
   const dragElement = { id: 'drag' } as unknown as TElement;
-  const dragItem: DragItemNode = { id: 'drag', element: dragElement };
+  const dragItem: DragItemNode = {
+    id: 'drag',
+    editorId: 'editor',
+    element: dragElement,
+  };
 
   const hoverElement = { id: 'hover' } as unknown as TElement;
 


### PR DESCRIPTION
**Checklist**

- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](docs/components/changelog.mdx)

Enabled dnd between different editors. Works only for single element drags so far (no multi selection dnd).

Disclaimer: This might only work if you use the same / one `DndProvider` for your whole app (and not one per plate.js editor). Or in other words: This only works between editors, which share the same `DndProvider`.