### PR TITLE
Fix: Drop line is not visible when hovering white space inside the editor

### DIFF
--- a/.changeset/neat-cooks-turn.md
+++ b/.changeset/neat-cooks-turn.md
@@ -1,0 +1,5 @@
+---
+'@platejs/dnd': patch
+---
+
+Fix: Drop line is not visible when hovering white space inside the editor

--- a/packages/dnd/src/DndPlugin.tsx
+++ b/packages/dnd/src/DndPlugin.tsx
@@ -96,7 +96,10 @@ export const DndPlugin = createTPlatePlugin<DndConfig>({
         if (e.target instanceof Node) {
           const editorDOMNode = editor.api.toDOMNode(editor);
 
-          if (editorDOMNode && !editorDOMNode.contains(e.target)) {
+          if (
+            editorDOMNode &&
+            !(e.target === editorDOMNode || editorDOMNode.contains(e.target))
+          ) {
             setOption('dropTarget', undefined);
           }
         }


### PR DESCRIPTION
**Checklist**

- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](docs/components/changelog.mdx)
