### PR TITLE
fix(block-draggable): it should selected when rightclick

### DIFF
--- a/apps/www/src/registry/ui/block-draggable.tsx
+++ b/apps/www/src/registry/ui/block-draggable.tsx
@@ -247,7 +247,7 @@ const DragHandle = React.memo(function DragHandle({
           onMouseDown={(e) => {
             resetPreview();
 
-            if (e.button !== 0 || e.shiftKey) return;
+            if ((e.button !== 0 && e.button !== 2) || e.shiftKey) return;
 
             const blockSelection = editor
               .getApi(BlockSelectionPlugin)

--- a/templates/plate-playground-template/src/components/ui/block-draggable.tsx
+++ b/templates/plate-playground-template/src/components/ui/block-draggable.tsx
@@ -247,7 +247,7 @@ const DragHandle = React.memo(function DragHandle({
           onMouseDown={(e) => {
             resetPreview();
 
-            if (e.button !== 0 || e.shiftKey) return;
+            if ((e.button !== 0 && e.button !== 2) || e.shiftKey) return;
 
             const blockSelection = editor
               .getApi(BlockSelectionPlugin)


### PR DESCRIPTION
fix https://github.com/udecode/plate/issues/4606

**Checklist**

- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [] `yarn changeset`
- [] [ui changelog](docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/src/registry/components/changelog.mdx`.

-->


### Problem
When users right-click on draggable block elements to trigger the block menu, the block is not selected. This causes all block menu operations (delete, duplicate, format, etc.) to be ineffective because they don't target the intended block, leading to a confusing user experience.

### Root Cause
The mouse event handler in `DragHandle` component only responded to left-click events (`button === 0`), ignoring right-click events (`button === 2`) for block selection.

### Solution
Modified the event handling logic to accept both left-click and right-click for block selection:

```diff
- if (e.button !== 0 || e.shiftKey) return;
+ if ((e.button !== 0 && e.button !== 2) || e.shiftKey) return;
```

### Changes
- **Before**: Only left-click selects blocks → right-click menu operations fail
- **After**: Both left-click and right-click select blocks → right-click menu operations work correctly

### Files Modified
- `apps/www/src/registry/ui/block-draggable.tsx`
- `templates/plate-playground-template/src/components/ui/block-draggable.tsx`


**Type**: 🐛 Bug fix - resolves core interaction issue without breaking changes
