### PR TITLE
fix(block-context-menu): prevent menu position sticking when triggered multiple times

### DIFF
--- a/apps/www/src/registry/ui/block-context-menu.tsx
+++ b/apps/www/src/registry/ui/block-context-menu.tsx
@@ -9,7 +9,7 @@ import {
   BlockSelectionPlugin,
 } from '@platejs/selection/react';
 import { KEYS } from 'platejs';
-import { useEditorPlugin, usePlateState } from 'platejs/react';
+import { useEditorPlugin, usePlateState, usePluginOption } from 'platejs/react';
 
 import {
   ContextMenu,
@@ -30,6 +30,8 @@ export function BlockContextMenu({ children }: { children: React.ReactNode }) {
   const [value, setValue] = React.useState<Value>(null);
   const isTouch = useIsTouchDevice();
   const [readOnly] = usePlateState('readOnly');
+  const openId = usePluginOption(BlockMenuPlugin, 'openId');
+  const isOpen = openId === BLOCK_CONTEXT_MENU_ID;
 
   const handleTurnInto = React.useCallback(
     (type: string) => {
@@ -85,15 +87,17 @@ export function BlockContextMenu({ children }: { children: React.ReactNode }) {
 
           if (disabled) return event.preventDefault();
 
-          api.blockMenu.show(BLOCK_CONTEXT_MENU_ID, {
-            x: event.clientX,
-            y: event.clientY,
-          });
+         setTimeout(() => {
+            api.blockMenu.show(BLOCK_CONTEXT_MENU_ID, {
+              x: event.clientX,
+              y: event.clientY,
+            });
+         }, 0);
         }}
       >
         <div className="w-full">{children}</div>
       </ContextMenuTrigger>
-      <ContextMenuContent
+      {isOpen && (<ContextMenuContent
         className="w-64"
         onCloseAutoFocus={(e) => {
           e.preventDefault();
@@ -191,7 +195,7 @@ export function BlockContextMenu({ children }: { children: React.ReactNode }) {
             </ContextMenuSubContent>
           </ContextMenuSub>
         </ContextMenuGroup>
-      </ContextMenuContent>
+      </ContextMenuContent>)}
     </ContextMenu>
   );
 }

--- a/apps/www/src/registry/ui/block-context-menu.tsx
+++ b/apps/www/src/registry/ui/block-context-menu.tsx
@@ -87,115 +87,119 @@ export function BlockContextMenu({ children }: { children: React.ReactNode }) {
 
           if (disabled) return event.preventDefault();
 
-         setTimeout(() => {
+          setTimeout(() => {
             api.blockMenu.show(BLOCK_CONTEXT_MENU_ID, {
               x: event.clientX,
               y: event.clientY,
             });
-         }, 0);
+          }, 0);
         }}
       >
         <div className="w-full">{children}</div>
       </ContextMenuTrigger>
-      {isOpen && (<ContextMenuContent
-        className="w-64"
-        onCloseAutoFocus={(e) => {
-          e.preventDefault();
-          editor.getApi(BlockSelectionPlugin).blockSelection.focus();
+      {isOpen && (
+        <ContextMenuContent
+          className="w-64"
+          onCloseAutoFocus={(e) => {
+            e.preventDefault();
+            editor.getApi(BlockSelectionPlugin).blockSelection.focus();
 
-          if (value === 'askAI') {
-            editor.getApi(AIChatPlugin).aiChat.show();
-          }
-
-          setValue(null);
-        }}
-      >
-        <ContextMenuGroup>
-          <ContextMenuItem
-            onClick={() => {
-              setValue('askAI');
-            }}
-          >
-            Ask AI
-          </ContextMenuItem>
-          <ContextMenuItem
-            onClick={() => {
-              editor
-                .getTransforms(BlockSelectionPlugin)
-                .blockSelection.removeNodes();
-              editor.tf.focus();
-            }}
-          >
-            Delete
-          </ContextMenuItem>
-          <ContextMenuItem
-            onClick={() => {
-              editor
-                .getTransforms(BlockSelectionPlugin)
-                .blockSelection.duplicate();
-            }}
-          >
-            Duplicate
-            {/* <ContextMenuShortcut>⌘ + D</ContextMenuShortcut> */}
-          </ContextMenuItem>
-          <ContextMenuSub>
-            <ContextMenuSubTrigger>Turn into</ContextMenuSubTrigger>
-            <ContextMenuSubContent className="w-48">
-              <ContextMenuItem onClick={() => handleTurnInto(KEYS.p)}>
-                Paragraph
-              </ContextMenuItem>
-
-              <ContextMenuItem onClick={() => handleTurnInto(KEYS.h1)}>
-                Heading 1
-              </ContextMenuItem>
-              <ContextMenuItem onClick={() => handleTurnInto(KEYS.h2)}>
-                Heading 2
-              </ContextMenuItem>
-              <ContextMenuItem onClick={() => handleTurnInto(KEYS.h3)}>
-                Heading 3
-              </ContextMenuItem>
-              <ContextMenuItem onClick={() => handleTurnInto(KEYS.blockquote)}>
-                Blockquote
-              </ContextMenuItem>
-            </ContextMenuSubContent>
-          </ContextMenuSub>
-        </ContextMenuGroup>
-
-        <ContextMenuGroup>
-          <ContextMenuItem
-            onClick={() =>
-              editor
-                .getTransforms(BlockSelectionPlugin)
-                .blockSelection.setIndent(1)
+            if (value === 'askAI') {
+              editor.getApi(AIChatPlugin).aiChat.show();
             }
-          >
-            Indent
-          </ContextMenuItem>
-          <ContextMenuItem
-            onClick={() =>
-              editor
-                .getTransforms(BlockSelectionPlugin)
-                .blockSelection.setIndent(-1)
-            }
-          >
-            Outdent
-          </ContextMenuItem>
-          <ContextMenuSub>
-            <ContextMenuSubTrigger>Align</ContextMenuSubTrigger>
-            <ContextMenuSubContent className="w-48">
-              <ContextMenuItem onClick={() => handleAlign('left')}>
-                Left
-              </ContextMenuItem>
-              <ContextMenuItem onClick={() => handleAlign('center')}>
-                Center
-              </ContextMenuItem>
-              <ContextMenuItem onClick={() => handleAlign('right')}>
-                Right
-              </ContextMenuItem>
-            </ContextMenuSubContent>
-          </ContextMenuSub>
-        </ContextMenuGroup>
-      </ContextMenuContent>)}
+
+            setValue(null);
+          }}
+        >
+          <ContextMenuGroup>
+            <ContextMenuItem
+              onClick={() => {
+                setValue('askAI');
+              }}
+            >
+              Ask AI
+            </ContextMenuItem>
+            <ContextMenuItem
+              onClick={() => {
+                editor
+                  .getTransforms(BlockSelectionPlugin)
+                  .blockSelection.removeNodes();
+                editor.tf.focus();
+              }}
+            >
+              Delete
+            </ContextMenuItem>
+            <ContextMenuItem
+              onClick={() => {
+                editor
+                  .getTransforms(BlockSelectionPlugin)
+                  .blockSelection.duplicate();
+              }}
+            >
+              Duplicate
+              {/* <ContextMenuShortcut>⌘ + D</ContextMenuShortcut> */}
+            </ContextMenuItem>
+            <ContextMenuSub>
+              <ContextMenuSubTrigger>Turn into</ContextMenuSubTrigger>
+              <ContextMenuSubContent className="w-48">
+                <ContextMenuItem onClick={() => handleTurnInto(KEYS.p)}>
+                  Paragraph
+                </ContextMenuItem>
+
+                <ContextMenuItem onClick={() => handleTurnInto(KEYS.h1)}>
+                  Heading 1
+                </ContextMenuItem>
+                <ContextMenuItem onClick={() => handleTurnInto(KEYS.h2)}>
+                  Heading 2
+                </ContextMenuItem>
+                <ContextMenuItem onClick={() => handleTurnInto(KEYS.h3)}>
+                  Heading 3
+                </ContextMenuItem>
+                <ContextMenuItem
+                  onClick={() => handleTurnInto(KEYS.blockquote)}
+                >
+                  Blockquote
+                </ContextMenuItem>
+              </ContextMenuSubContent>
+            </ContextMenuSub>
+          </ContextMenuGroup>
+
+          <ContextMenuGroup>
+            <ContextMenuItem
+              onClick={() =>
+                editor
+                  .getTransforms(BlockSelectionPlugin)
+                  .blockSelection.setIndent(1)
+              }
+            >
+              Indent
+            </ContextMenuItem>
+            <ContextMenuItem
+              onClick={() =>
+                editor
+                  .getTransforms(BlockSelectionPlugin)
+                  .blockSelection.setIndent(-1)
+              }
+            >
+              Outdent
+            </ContextMenuItem>
+            <ContextMenuSub>
+              <ContextMenuSubTrigger>Align</ContextMenuSubTrigger>
+              <ContextMenuSubContent className="w-48">
+                <ContextMenuItem onClick={() => handleAlign('left')}>
+                  Left
+                </ContextMenuItem>
+                <ContextMenuItem onClick={() => handleAlign('center')}>
+                  Center
+                </ContextMenuItem>
+                <ContextMenuItem onClick={() => handleAlign('right')}>
+                  Right
+                </ContextMenuItem>
+              </ContextMenuSubContent>
+            </ContextMenuSub>
+          </ContextMenuGroup>
+        </ContextMenuContent>
+      )}
     </ContextMenu>
   );
 }

--- a/docs/components/changelog.mdx
+++ b/docs/components/changelog.mdx
@@ -10,6 +10,9 @@ Use the [CLI](https://platejs.org/docs/components/cli) to install the latest ver
 
 ## September 2025 #26
 
+### September 7 #26.2
+- `block-context-menu`: Fixed menu position sticking when triggered multiple times in different locations
+
 ### September 5 #26.1
 - `block-draggable`: Fixed block selection to work with right-click events
 

--- a/templates/plate-playground-template/src/components/ui/block-context-menu.tsx
+++ b/templates/plate-playground-template/src/components/ui/block-context-menu.tsx
@@ -9,7 +9,7 @@ import {
   BlockSelectionPlugin,
 } from '@platejs/selection/react';
 import { KEYS } from 'platejs';
-import { useEditorPlugin, usePlateState } from 'platejs/react';
+import { useEditorPlugin, usePlateState, usePluginOption } from 'platejs/react';
 
 import {
   ContextMenu,
@@ -30,6 +30,8 @@ export function BlockContextMenu({ children }: { children: React.ReactNode }) {
   const [value, setValue] = React.useState<Value>(null);
   const isTouch = useIsTouchDevice();
   const [readOnly] = usePlateState('readOnly');
+  const openId = usePluginOption(BlockMenuPlugin, 'openId');
+  const isOpen = openId === BLOCK_CONTEXT_MENU_ID;
 
   const handleTurnInto = React.useCallback(
     (type: string) => {
@@ -85,15 +87,17 @@ export function BlockContextMenu({ children }: { children: React.ReactNode }) {
 
           if (disabled) return event.preventDefault();
 
-          api.blockMenu.show(BLOCK_CONTEXT_MENU_ID, {
-            x: event.clientX,
-            y: event.clientY,
-          });
+         setTimeout(() => {
+            api.blockMenu.show(BLOCK_CONTEXT_MENU_ID, {
+              x: event.clientX,
+              y: event.clientY,
+            });
+         }, 0);
         }}
       >
         <div className="w-full">{children}</div>
       </ContextMenuTrigger>
-      <ContextMenuContent
+      {isOpen && (<ContextMenuContent
         className="w-64"
         onCloseAutoFocus={(e) => {
           e.preventDefault();
@@ -191,7 +195,7 @@ export function BlockContextMenu({ children }: { children: React.ReactNode }) {
             </ContextMenuSubContent>
           </ContextMenuSub>
         </ContextMenuGroup>
-      </ContextMenuContent>
+      </ContextMenuContent>)}
     </ContextMenu>
   );
 }

--- a/templates/plate-playground-template/src/components/ui/block-context-menu.tsx
+++ b/templates/plate-playground-template/src/components/ui/block-context-menu.tsx
@@ -87,115 +87,117 @@ export function BlockContextMenu({ children }: { children: React.ReactNode }) {
 
           if (disabled) return event.preventDefault();
 
-         setTimeout(() => {
+          setTimeout(() => {
             api.blockMenu.show(BLOCK_CONTEXT_MENU_ID, {
               x: event.clientX,
               y: event.clientY,
             });
-         }, 0);
+          }, 0);
         }}
       >
         <div className="w-full">{children}</div>
       </ContextMenuTrigger>
-      {isOpen && (<ContextMenuContent
-        className="w-64"
-        onCloseAutoFocus={(e) => {
-          e.preventDefault();
-          editor.getApi(BlockSelectionPlugin).blockSelection.focus();
+      {isOpen && (
+        <ContextMenuContent
+          className="w-64"
+          onCloseAutoFocus={(e) => {
+            e.preventDefault();
+            editor.getApi(BlockSelectionPlugin).blockSelection.focus();
 
-          if (value === 'askAI') {
-            editor.getApi(AIChatPlugin).aiChat.show();
-          }
-
-          setValue(null);
-        }}
-      >
-        <ContextMenuGroup>
-          <ContextMenuItem
-            onClick={() => {
-              setValue('askAI');
-            }}
-          >
-            Ask AI
-          </ContextMenuItem>
-          <ContextMenuItem
-            onClick={() => {
-              editor
-                .getTransforms(BlockSelectionPlugin)
-                .blockSelection.removeNodes();
-              editor.tf.focus();
-            }}
-          >
-            Delete
-          </ContextMenuItem>
-          <ContextMenuItem
-            onClick={() => {
-              editor
-                .getTransforms(BlockSelectionPlugin)
-                .blockSelection.duplicate();
-            }}
-          >
-            Duplicate
-            {/* <ContextMenuShortcut>⌘ + D</ContextMenuShortcut> */}
-          </ContextMenuItem>
-          <ContextMenuSub>
-            <ContextMenuSubTrigger>Turn into</ContextMenuSubTrigger>
-            <ContextMenuSubContent className="w-48">
-              <ContextMenuItem onClick={() => handleTurnInto(KEYS.p)}>
-                Paragraph
-              </ContextMenuItem>
-
-              <ContextMenuItem onClick={() => handleTurnInto(KEYS.h1)}>
-                Heading 1
-              </ContextMenuItem>
-              <ContextMenuItem onClick={() => handleTurnInto(KEYS.h2)}>
-                Heading 2
-              </ContextMenuItem>
-              <ContextMenuItem onClick={() => handleTurnInto(KEYS.h3)}>
-                Heading 3
-              </ContextMenuItem>
-              <ContextMenuItem onClick={() => handleTurnInto(KEYS.blockquote)}>
-                Blockquote
-              </ContextMenuItem>
-            </ContextMenuSubContent>
-          </ContextMenuSub>
-        </ContextMenuGroup>
-
-        <ContextMenuGroup>
-          <ContextMenuItem
-            onClick={() =>
-              editor
-                .getTransforms(BlockSelectionPlugin)
-                .blockSelection.setIndent(1)
+            if (value === 'askAI') {
+              editor.getApi(AIChatPlugin).aiChat.show();
             }
-          >
-            Indent
-          </ContextMenuItem>
-          <ContextMenuItem
-            onClick={() =>
-              editor
-                .getTransforms(BlockSelectionPlugin)
-                .blockSelection.setIndent(-1)
-            }
-          >
-            Outdent
-          </ContextMenuItem>
-          <ContextMenuSub>
-            <ContextMenuSubTrigger>Align</ContextMenuSubTrigger>
-            <ContextMenuSubContent className="w-48">
-              <ContextMenuItem onClick={() => handleAlign('left')}>
-                Left
-              </ContextMenuItem>
-              <ContextMenuItem onClick={() => handleAlign('center')}>
-                Center
-              </ContextMenuItem>
-              <ContextMenuItem onClick={() => handleAlign('right')}>
-                Right
-              </ContextMenuItem>
-            </ContextMenuSubContent>
-          </ContextMenuSub>
-        </ContextMenuGroup>
-      </ContextMenuContent>)}
+
+            setValue(null);
+          }}
+        >
+          <ContextMenuGroup>
+            <ContextMenuItem
+              onClick={() => {
+                setValue('askAI');
+              }}
+            >
+              Ask AI
+            </ContextMenuItem>
+            <ContextMenuItem
+              onClick={() => {
+                editor
+                  .getTransforms(BlockSelectionPlugin)
+                  .blockSelection.removeNodes();
+                editor.tf.focus();
+              }}
+            >
+              Delete
+            </ContextMenuItem>
+            <ContextMenuItem
+              onClick={() => {
+                editor
+                  .getTransforms(BlockSelectionPlugin)
+                  .blockSelection.duplicate();
+              }}
+            >
+              Duplicate
+              {/* <ContextMenuShortcut>⌘ + D</ContextMenuShortcut> */}
+            </ContextMenuItem>
+            <ContextMenuSub>
+              <ContextMenuSubTrigger>Turn into</ContextMenuSubTrigger>
+              <ContextMenuSubContent className="w-48">
+                <ContextMenuItem onClick={() => handleTurnInto(KEYS.p)}>
+                  Paragraph
+                </ContextMenuItem>
+
+                <ContextMenuItem onClick={() => handleTurnInto(KEYS.h1)}>
+                  Heading 1
+                </ContextMenuItem>
+                <ContextMenuItem onClick={() => handleTurnInto(KEYS.h2)}>
+                  Heading 2
+                </ContextMenuItem>
+                <ContextMenuItem onClick={() => handleTurnInto(KEYS.h3)}>
+                  Heading 3
+                </ContextMenuItem>
+                <ContextMenuItem onClick={() => handleTurnInto(KEYS.blockquote)}>
+                  Blockquote
+                </ContextMenuItem>
+              </ContextMenuSubContent>
+            </ContextMenuSub>
+          </ContextMenuGroup>
+
+          <ContextMenuGroup>
+            <ContextMenuItem
+              onClick={() =>
+                editor
+                  .getTransforms(BlockSelectionPlugin)
+                  .blockSelection.setIndent(1)
+              }
+            >
+              Indent
+            </ContextMenuItem>
+            <ContextMenuItem
+              onClick={() =>
+                editor
+                  .getTransforms(BlockSelectionPlugin)
+                  .blockSelection.setIndent(-1)
+              }
+            >
+              Outdent
+            </ContextMenuItem>
+            <ContextMenuSub>
+              <ContextMenuSubTrigger>Align</ContextMenuSubTrigger>
+              <ContextMenuSubContent className="w-48">
+                <ContextMenuItem onClick={() => handleAlign('left')}>
+                  Left
+                </ContextMenuItem>
+                <ContextMenuItem onClick={() => handleAlign('center')}>
+                  Center
+                </ContextMenuItem>
+                <ContextMenuItem onClick={() => handleAlign('right')}>
+                  Right
+                </ContextMenuItem>
+              </ContextMenuSubContent>
+            </ContextMenuSub>
+          </ContextMenuGroup>
+        </ContextMenuContent>
+      )}
     </ContextMenu>
   );
 }


### PR DESCRIPTION
fix https://github.com/udecode/plate/issues/4608

**Checklist**

- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- yarn brl: Required if adding, moving or removing a file in a package.
- yarn changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/src/registry/components/changelog.mdx`.

-->

### Problem

When users right-click to trigger the block context menu multiple times in different locations, the menu position gets stuck at the first trigger location instead of updating to the new click position. This affects both:

1. Block draggable area - menu stays at first right-click position
2. Content area - menu position doesn't update on subsequent right-clicks

### Root Cause

The `ContextMenuContent` was being rendered immediately without proper state management, causing the menu to render at the initial position and not re-render when the position changes.

### Solution

- Added `usePluginOption` to track menu open state
- Wrapped `ContextMenuContent` with conditional rendering based on `isOpen` state  
- Added `setTimeout` to ensure proper timing for menu positioning

### Changes

- **Before**: Menu position sticks to first right-click location
- **After**: Menu position updates correctly on each right-click

### Files Modified

- `apps/www/src/registry/ui/block-context-menu.tsx`
- `templates/plate-playground-template/src/components/ui/block-context-menu.tsx`

