### PR TITLE
Fix `remarkStringifyOptions` not taken into account

### DIFF
--- a/.changeset/hot-students-sort.md
+++ b/.changeset/hot-students-sort.md
@@ -1,0 +1,5 @@
+---
+'@platejs/markdown': patch
+---
+
+Fix remarkStringifyOptions not taken into account

--- a/packages/markdown/src/lib/MarkdownPlugin.ts
+++ b/packages/markdown/src/lib/MarkdownPlugin.ts
@@ -47,6 +47,12 @@ export type MarkdownConfig = PluginConfig<
      */
     remarkPlugins: Plugin[];
     /**
+     * Custom options passed to remark-stringify.
+     *
+     * @default null
+     */
+    remarkStringifyOptions: RemarkStringifyOptions | null;
+    /**
      * Rules that define how to convert Markdown syntax elements to Slate editor
      * elements. Or rules that how to convert Slate editor elements to Markdown
      * syntax elements. Includes conversion rules for elements such as
@@ -66,12 +72,6 @@ export type MarkdownConfig = PluginConfig<
      * @default null
      */
     allowNode?: AllowNodeConfig;
-    /**
-     * Custom options passed to remark-stringify.
-     *
-     * @default undefined
-     */
-    remarkStringifyOptions?: RemarkStringifyOptions;
   },
   {
     markdown: {
@@ -88,6 +88,7 @@ export const MarkdownPlugin = createTSlatePlugin<MarkdownConfig>({
     allowedNodes: null,
     disallowedNodes: null,
     remarkPlugins: [],
+    remarkStringifyOptions: null,
     rules: null,
   },
 })

--- a/packages/markdown/src/lib/MarkdownPlugin.ts
+++ b/packages/markdown/src/lib/MarkdownPlugin.ts
@@ -1,3 +1,4 @@
+import type { Options as RemarkStringifyOptions } from 'remark-stringify';
 import type { Plugin } from 'unified';
 
 import {
@@ -65,6 +66,12 @@ export type MarkdownConfig = PluginConfig<
      * @default null
      */
     allowNode?: AllowNodeConfig;
+    /**
+     * Custom options passed to remark-stringify.
+     *
+     * @default undefined
+     */
+    remarkStringifyOptions?: RemarkStringifyOptions;
   },
   {
     markdown: {

--- a/packages/markdown/src/lib/serializer/serializeMd.spec.tsx
+++ b/packages/markdown/src/lib/serializer/serializeMd.spec.tsx
@@ -304,4 +304,33 @@ describe('serializeMd', () => {
     });
     expect(resultWithSpread).toBe('1. 1\n\n2. 2\n');
   });
+
+  it('should serialize lists with custom remark-stringify options', () => {
+    const slateNodes = [
+      {
+        children: [
+          {
+            text: 'Make text ',
+          },
+          {
+            bold: true,
+            text: 'bold',
+          },
+        ],
+        type: 'p',
+      },
+    ];
+    const result = serializeMd(editor as any, {
+      remarkStringifyOptions: {
+        handlers: {
+          strong: (node, _parent, state, info) => {
+            const value = state.containerPhrasing(node, info);
+            return `*${value}*`;
+          },
+        },
+      },
+      value: slateNodes,
+    });
+    expect(result).toBe('Make text *bold*\n');
+  });
 });

--- a/packages/markdown/src/lib/serializer/serializeMd.ts
+++ b/packages/markdown/src/lib/serializer/serializeMd.ts
@@ -18,7 +18,7 @@ export type SerializeMdOptions = {
   editor?: SlateEditor;
   preserveEmptyParagraphs?: boolean;
   remarkPlugins?: Plugin[];
-  remarkStringifyOptions?: RemarkStringifyOptions;
+  remarkStringifyOptions?: RemarkStringifyOptions | null;
   rules?: MdRules;
   spread?: boolean;
   value?: Descendant[];

--- a/packages/markdown/src/lib/serializer/utils/getMergedOptionsSerialize.ts
+++ b/packages/markdown/src/lib/serializer/utils/getMergedOptionsSerialize.ts
@@ -22,6 +22,7 @@ export const getMergedOptionsSerialize = (
     allowNode: PluginAllowNode,
     disallowedNodes: PluginDisallowedNodes,
     remarkPlugins: PluginRemarkPlugins,
+    remarkStringifyOptions: PluginRemarkStringifyOptions,
     rules: PluginRules,
   } = editor.getOptions(MarkdownPlugin);
 
@@ -37,6 +38,8 @@ export const getMergedOptionsSerialize = (
     disallowedNodes: options?.disallowedNodes ?? PluginDisallowedNodes,
     editor,
     remarkPlugins: options?.remarkPlugins ?? PluginRemarkPlugins ?? [],
+    remarkStringifyOptions:
+      options?.remarkStringifyOptions ?? PluginRemarkStringifyOptions,
     rules: mergedRules,
     spread: options?.spread,
     value: options?.value ?? editor.children,


### PR DESCRIPTION
Fixes #4615. Forgot to add it to plugin config and correctly merge the options. Also added a test.
