### PR TITLE
fix: handle function values in editor.setOption

### DIFF
--- a/.changeset/core-fix-set-option.md
+++ b/.changeset/core-fix-set-option.md
@@ -1,0 +1,5 @@
+---
+'@platejs/core': patch
+---
+
+- Fixed `editor.setOption` to properly handle function values

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,7 +75,7 @@
     "slate-react": "0.117.4",
     "use-deep-compare": "^1.3.0",
     "zustand": "^5.0.5",
-    "zustand-x": "6.2.0"
+    "zustand-x": "6.2.1"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/core/src/lib/editor/withSlate.ts
+++ b/packages/core/src/lib/editor/withSlate.ts
@@ -272,7 +272,7 @@ export const withSlate = <
 
     return (store.get as any)(key, ...args);
   };
-  editor.setOption = (plugin: any, key: any, value: any) => {
+  editor.setOption = (plugin: any, key: any, ...args: any) => {
     const store = editor.getOptionsStore(plugin);
 
     if (!store) return;
@@ -285,14 +285,7 @@ export const withSlate = <
       return;
     }
 
-    if (typeof value === 'function') {
-      store.set('state', (draft: any) => {
-        draft[key] = value;
-      });
-      return;
-    }
-
-    store.set(key as any, value);
+    (store.set as any)(key, ...args);
   };
   editor.setOptions = (plugin: any, options: any) => {
     const store = editor.getOptionsStore(plugin);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3333,7 +3333,7 @@ __metadata:
     fastest-levenshtein: "npm:1.0.16"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    platejs: ">=49.2.4"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3346,7 +3346,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3358,7 +3358,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3370,7 +3370,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3382,7 +3382,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3395,7 +3395,7 @@ __metadata:
     platejs: "workspace:^"
     react-textarea-autosize: "npm:^8.5.9"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3408,7 +3408,7 @@ __metadata:
     lowlight: "npm:^3.3.0"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3420,7 +3420,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3433,13 +3433,13 @@ __metadata:
     lodash: "npm:^4.17.21"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
   linkType: soft
 
-"@platejs/core@npm:49.2.21, @platejs/core@workspace:packages/core":
+"@platejs/core@npm:50.3.7, @platejs/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@platejs/core@workspace:packages/core"
   dependencies:
@@ -3462,7 +3462,7 @@ __metadata:
     slate-react: "npm:0.117.4"
     use-deep-compare: "npm:^1.3.0"
     zustand: "npm:^5.0.5"
-    zustand-x: "npm:6.2.0"
+    zustand-x: "npm:6.2.1"
   peerDependencies:
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
@@ -3478,7 +3478,7 @@ __metadata:
     papaparse: "npm:^5.5.3"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3490,7 +3490,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3502,7 +3502,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3516,7 +3516,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3530,7 +3530,7 @@ __metadata:
     platejs: "workspace:^"
     raf: "npm:^3.4.1"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dnd: ">=14.0.0"
     react-dnd-html5-backend: ">=14.0.0"
@@ -3545,7 +3545,7 @@ __metadata:
     platejs: "workspace:^"
     validator: "npm:^13.15.15"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3560,7 +3560,7 @@ __metadata:
     platejs: "workspace:^"
   peerDependencies:
     "@emoji-mart/data": ">=1.2.0"
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3575,7 +3575,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3587,7 +3587,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3601,7 +3601,7 @@ __metadata:
     "@floating-ui/react": "npm:^0.27.12"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3613,7 +3613,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3626,7 +3626,7 @@ __metadata:
     juice: "npm:^11.0.1"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3638,7 +3638,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3651,7 +3651,7 @@ __metadata:
     "@platejs/floating": "npm:50.3.2"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3664,7 +3664,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3678,7 +3678,7 @@ __metadata:
     clsx: "npm:^2.1.1"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3700,7 +3700,7 @@ __metadata:
     ts-essentials: "npm:10.1.0"
     unified: "npm:^11.0.5"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3714,7 +3714,7 @@ __metadata:
     katex: "npm:0.16.22"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3727,7 +3727,7 @@ __metadata:
     js-video-url-parser: "npm:^0.5.1"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3740,7 +3740,7 @@ __metadata:
     "@platejs/combobox": "npm:49.0.0"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3753,7 +3753,7 @@ __metadata:
     platejs: "workspace:^"
   peerDependencies:
     "@playwright/test": ">=1.42.1"
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3765,7 +3765,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3778,7 +3778,7 @@ __metadata:
     copy-to-clipboard: "npm:^3.3.3"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3791,7 +3791,7 @@ __metadata:
     "@platejs/combobox": "npm:49.0.0"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3817,7 +3817,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3830,7 +3830,7 @@ __metadata:
     platejs: "workspace:^"
     tabbable: "npm:^6.2.0"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3844,7 +3844,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3856,7 +3856,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3878,7 +3878,7 @@ __metadata:
   dependencies:
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
@@ -3892,17 +3892,17 @@ __metadata:
     lodash: "npm:^4.17.21"
     platejs: "workspace:^"
   peerDependencies:
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   languageName: unknown
   linkType: soft
 
-"@platejs/utils@npm:49.2.21, @platejs/utils@workspace:packages/utils":
+"@platejs/utils@npm:50.3.7, @platejs/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@platejs/utils@workspace:packages/utils"
   dependencies:
-    "@platejs/core": "npm:49.2.21"
+    "@platejs/core": "npm:50.3.7"
     "@platejs/slate": "npm:49.2.21"
     "@udecode/react-utils": "npm:49.0.15"
     "@udecode/utils": "npm:47.2.7"
@@ -3923,7 +3923,7 @@ __metadata:
     yjs: "npm:^13.6.27"
   peerDependencies:
     "@hocuspocus/provider": ^2.15.2
-    platejs: ">=49.2.21"
+    platejs: ">=50.3.7"
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
     y-webrtc: 10.3.0
@@ -18471,9 +18471,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "platejs@workspace:packages/plate"
   dependencies:
-    "@platejs/core": "npm:49.2.21"
+    "@platejs/core": "npm:50.3.7"
     "@platejs/slate": "npm:49.2.21"
-    "@platejs/utils": "npm:49.2.21"
+    "@platejs/utils": "npm:50.3.7"
     "@udecode/react-hotkeys": "npm:37.0.0"
     "@udecode/react-utils": "npm:49.0.15"
     "@udecode/utils": "npm:47.2.7"
@@ -23917,9 +23917,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zustand-x@npm:6.2.0":
-  version: 6.2.0
-  resolution: "zustand-x@npm:6.2.0"
+"zustand-x@npm:6.2.1":
+  version: 6.2.1
+  resolution: "zustand-x@npm:6.2.1"
   dependencies:
     immer: "npm:^10.0.3"
     lodash.mapvalues: "npm:^4.6.0"
@@ -23928,7 +23928,7 @@ __metadata:
     use-sync-external-store: "npm:1.4.0"
   peerDependencies:
     zustand: ">=5.0.2"
-  checksum: 10c0/247958a6c8b65bc874ca4e9cf7fc29f54ccb3d567d650420b0aeed37e4316d3c742d5dc68043a9b5b4ef1ae5959ccf1686973759298a1d6ed6cbcc459bd7f1d9
+  checksum: 10c0/0a6b2f665061a15abd80d4e0f748f9314971cc033a93759687e0a2e563a7b56756c91184f5e877c2ca9042ee03dc5d46a083d31389e6ce780a5fe1d2b2fe90ff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fixes `editor.setOption` to properly handle function values and multiple arguments by delegating all arguments to the underlying zustand-x store's `set` method.

## Changes

- **Updated `editor.setOption` signature**: Changed from `(plugin, key, value)` to `(plugin, key, ...args)` to accept variable arguments
- **Simplified implementation**: Removed special-case handling for function values and now delegates directly to `store.set(key, ...args)`
- **Upgraded zustand-x**: Bumped from `6.2.0` to `6.2.1` to ensure compatibility with the variable argument pattern

## Technical Details

Previously, `editor.setOption` had special logic for handling function values:

```typescript
if (typeof value === 'function') {
  store.set('state', (draft: any) => {
    draft[key] = value;
  });
  return;
}
store.set(key as any, value);
```

This approach didn't properly support zustand-x's full `set` API, which can accept:
- `set(key, value)` - direct value setting
- `set(key, updater)` - function updater
- `set(path, value)` - nested path updates

The new implementation passes all arguments through:

```typescript
(store.set as any)(key, ...args);
```

This ensures `editor.setOption` fully supports the underlying store's capabilities.

## Testing

- Tested with direct value setting
- Tested with function updaters
- Tested with nested path updates
- Verified backward compatibility with existing usage patterns

## Changeset

A patch changeset has been added for `@platejs/core`.

🤖 Generated with [Claude Code](https://claude.ai/code)