### PR TITLE
fixing potential 7 char hex color causing issue

### DIFF
--- a/apps/www/src/registry/ui/remote-cursor-overlay.tsx
+++ b/apps/www/src/registry/ui/remote-cursor-overlay.tsx
@@ -120,5 +120,5 @@ function Caret({
 function addAlpha(hexColor: string, opacity: number): string {
   const normalized = Math.round(Math.min(Math.max(opacity, 0), 1) * 255);
 
-  return hexColor + normalized.toString(16).toUpperCase();
+  return hexColor + normalized.toString(16).padStart(2, '0').toUpperCase();
 }


### PR DESCRIPTION
**Checklist**

- [x] `yarn typecheck`
- [x] `yarn lint:fix`
- [x] `yarn test`
- [x] `yarn brl`
- [x] `yarn changeset`
- [x] [ui changelog](docs/components/changelog.mdx)

If the opacity is set to a low value the original code will generate 7 character hex color.