### PR TITLE
fix(code-block): fix normalizer and insertBreak for syntax highlighting

### DIFF
--- a/.changeset/code-block-patch.md
+++ b/.changeset/code-block-patch.md
@@ -1,0 +1,6 @@
+---
+'@platejs/code-block': patch
+---
+
+- Fixed normalizer using `setNodes` instead of `wrapNodes` for bare text children in `code_block`, which produced malformed `code_line` nodes (e.g. `{ text: "...", type: "code_line" }` instead of proper element structure). This caused syntax highlighting to only work on the first line.
+- Fixed `insertBreak` not resetting the decoration cache after splitting, so new lines now get syntax highlighting immediately.

--- a/packages/code-block/src/lib/withCodeBlock.ts
+++ b/packages/code-block/src/lib/withCodeBlock.ts
@@ -53,6 +53,9 @@ export const withCodeBlock: OverrideEditor<CodeBlockConfig> = (ctx) => {
             indentDepth,
           });
 
+          // Reset decoration cache so all lines get re-highlighted
+          resetCodeBlockDecorations(codeBlock[0] as TCodeBlockElement);
+
           return true;
         };
 

--- a/packages/code-block/src/lib/withNormalizeCodeBlock.tsx
+++ b/packages/code-block/src/lib/withNormalizeCodeBlock.tsx
@@ -45,7 +45,13 @@ export const withNormalizeCodeBlock: OverrideEditor<CodeBlockConfig> = ({
         );
 
         if (nonCodeLine) {
-          editor.tf.setNodes({ type: codeLineType }, { at: nonCodeLine[1] });
+          // Use wrapNodes instead of setNodes to properly wrap bare text
+          // children in code_line elements (setNodes just adds a type
+          // property to text leaves, producing malformed nodes)
+          editor.tf.wrapNodes(
+            { type: codeLineType, children: [] },
+            { at: nonCodeLine[1] }
+          );
         }
       }
     },


### PR DESCRIPTION
## Summary

- **Normalizer**: Use `wrapNodes` instead of `setNodes` to properly wrap bare text children in `code_line` elements. `setNodes` was producing malformed nodes like `{ text: "...", type: "code_line" }` instead of proper `{ type: "code_line", children: [{ text: "..." }] }` structure.
- **insertBreak**: Call `resetCodeBlockDecorations` after splitting to bust the WeakMap cache and force re-highlighting on all lines.

These two fixes together resolve the issue where only the first line of a code block gets syntax highlighting.

Fixes #4520
Related: #4399, #3407

## Test plan

- [ ] Open the [code block demo](https://platejs.org/docs/code-block) and verify syntax highlighting works on all lines
- [ ] Type multiple lines in a code block and confirm each line is highlighted
- [ ] Press Enter in a code block and verify the new line gets syntax highlighting
- [ ] Test with autoformat (e.g. typing ``` to create a code block) and verify all lines highlight correctly