### PR TITLE
fix(ui): color picker dropdown closing and custom color memory

### DIFF
--- a/apps/www/src/registry/ui/font-color-toolbar-button.tsx
+++ b/apps/www/src/registry/ui/font-color-toolbar-button.tsx
@@ -530,7 +530,7 @@ export function ColorDropdownMenuItems({
             key={name ?? value}
             value={value}
             isBrightColor={isBrightColor}
-            isSelected={color === value}
+            isSelected={!!color && normalizeColor(color) === normalizeColor(value)}
             updateColor={updateColor}
           />
         ))}

--- a/templates/plate-playground-template/src/components/ui/font-color-toolbar-button.tsx
+++ b/templates/plate-playground-template/src/components/ui/font-color-toolbar-button.tsx
@@ -549,7 +549,7 @@ export function ColorDropdownMenuItems({
         {colors.map(({ isBrightColor, name, value }) => (
           <ColorDropdownMenuItem
             isBrightColor={isBrightColor}
-            isSelected={color === value}
+            isSelected={!!color && normalizeColor(color) === normalizeColor(value)}
             key={name ?? value}
             name={name}
             updateColor={updateColor}


### PR DESCRIPTION
## Summary
- Keep dropdown open during native color picker input by switching to modal mode
- Remember custom colors across open/close cycles via session-based queue
- Scan editor marks to populate previously used colors on dropdown open
- Fix + button overlapping color circles with grid-based placement (`col-start-10`)
- Add contrast-aware check icon for selected colors (white on dark backgrounds, bold stroke)

## Test plan
- [ ] Open font color dropdown, use native color picker — dropdown stays open
- [ ] Pick custom colors, close/reopen dropdown — custom colors persist
- [ ] Verify + button doesn't overlap color circles when many custom colors exist
- [ ] Verify selected color shows bold checkmark, visible on both light and dark colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)