### PR TITLE
test: expand markdown and table logic coverage

### DIFF
--- a/.changeset/markdown-incomplete-mdx-fallback.md
+++ b/.changeset/markdown-incomplete-mdx-fallback.md
@@ -1,0 +1,5 @@
+---
+"@platejs/markdown": patch
+---
+
+Fix incomplete MDX fallback dropping preceding void blocks during markdown deserialization

--- a/.claude/docs/plans/2026-03-14-phase-4-markdown-execution.md
+++ b/.claude/docs/plans/2026-03-14-phase-4-markdown-execution.md
@@ -1,0 +1,62 @@
+# Phase 4 Markdown Execution
+
+## Goal
+
+Complete the phase-4 `markdown` slice only. Add high-ROI non-React logic coverage for parser and serializer helpers plus incomplete-MDX fallback behavior.
+
+## Checklist
+
+- [completed] Audit current markdown seams and existing tests
+- [completed] Add focused helper specs for markdown lib utilities
+- [completed] Add focused `markdownToSlateNodesSafely` behavior specs
+- [completed] Fix any real runtime bug exposed by the new specs
+- [completed] Run markdown package verification
+- [completed] Record learnings and final results
+
+## Findings
+
+- `markdown` already has broad deserializer/serializer coverage, but several helper seams are still only covered indirectly.
+- High-ROI direct seams are:
+  - `stripMarkdown*`
+  - `parseAttributes` / `propsToAttributes`
+  - `tagRemarkPlugin` / `getRemarkPluginsWithoutMdx`
+  - `getCustomMark`
+  - `markdownToSlateNodesSafely`
+- `markdownToSlateNodesSafely` currently drops already-parsed content when the last complete block is void and the input ends with incomplete MDX. Example probe: `"<hr /><u>"` returns only a paragraph with `"<u>"`, losing the horizontal rule.
+
+## Progress
+
+- Re-read the phase-4 plan, `task.mdc`, `testing.mdc`, `planning-with-files`, `tdd`, and changeset guidance.
+- Audited markdown package structure, existing specs, and helper/test harnesses.
+- Probed live `markdownToSlateNodesSafely` output with a temporary Bun script to identify public behavior and confirm a likely fallback bug.
+- Added focused markdown helper specs for:
+  - `stripMarkdown*`
+  - `parseAttributes` / `propsToAttributes`
+  - `tagRemarkPlugin` / `getRemarkPluginsWithoutMdx`
+  - `getCustomMark`
+- Added a focused `markdownToSlateNodesSafely` suite covering:
+  - normal markdown passthrough
+  - incomplete MDX appended to a non-void block
+  - no-complete-block fallback
+  - void-block preservation
+- Fixed `markdownToSlateNodesSafely` so incomplete-MDX fallback appends a new paragraph after a complete void block instead of dropping the already-parsed node.
+- Added a patch changeset for `@platejs/markdown`.
+
+## Verification
+
+- `bun test packages/markdown/src/lib/deserializer/utils/stripMarkdown.spec.ts packages/markdown/src/lib/rules/utils/parseAttributes.spec.ts packages/markdown/src/lib/utils/getRemarkPluginsWithoutMdx.spec.ts packages/markdown/src/lib/serializer/utils/getCustomMark.spec.ts packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.spec.tsx`
+- `bun test packages/markdown/src`
+- `bun run test:slowest -- --top 15 packages/markdown/src`
+- `pnpm install`
+- `pnpm turbo build --filter=./packages/markdown`
+  - failed before package code execution in `rolldown` / Node `20.12.1` with `ERR_INVALID_ARG_VALUE` from `node:util.styleText`
+- `NO_COLOR=1 pnpm turbo build --filter=./packages/markdown`
+  - failed with the same external tooling error
+- `pnpm lint:fix`
+- `bun test packages/markdown/src` (post-lint rerun)
+
+## Learnings
+
+- `package reality`: `markdownToSlateNodesSafely` had a real content-loss bug on the incomplete-MDX fallback path when the fully parsed prefix ended in a void node.
+- `package reality`: the safe fallback should preserve complete parsed output and append the fallback paragraph, not replace the whole result set.
+- `verification blocker`: package build is currently blocked outside slice scope by a `rolldown` + Node `20.12.1` `styleText` call that passes `['underline', 'gray']` where Node expects a single format string.

--- a/.claude/docs/plans/2026-03-15-phase-4-table-execution.md
+++ b/.claude/docs/plans/2026-03-15-phase-4-table-execution.md
@@ -1,0 +1,63 @@
+# Phase 4 Table Execution
+
+## Goal
+
+Complete the phase-4 `table` slice only. Add high-ROI non-React logic coverage for merge-heavy table behavior plus the remaining small sizing and selection helpers in `packages/table/src/lib`.
+
+## Checklist
+
+- [completed] Audit table merge and transform seams plus current test helpers
+- [completed] Add merge-focused table lib specs
+- [completed] Add size and selection helper specs
+- [completed] Fix any real runtime bug exposed by the new specs
+- [completed] Run table package verification
+- [completed] Record learnings and final results
+
+## Findings
+
+- Existing `table` coverage is decent on insert/basic-query seams but still light on the merge cluster that carries the real branchy behavior.
+- The highest-value uncovered behaviors are:
+  - `mergeTableCells`
+  - `splitTableCell`
+  - `deleteRowWhenExpanded`
+  - `deleteColumnWhenExpanded`
+  - `setTableColSize`
+  - `setTableRowSize`
+  - `moveSelectionFromCell`
+- `deleteRowWhenExpanded` only removes rows when the expanded selection spans the full row width of the first selected row.
+- `deleteColumnWhenExpanded` only removes a column when the expanded selection spans both the first and last table rows.
+
+## Progress
+
+- Re-read the phase-4 plan, `task.mdc`, `testing.mdc`, and `tdd`.
+- Audited current table lib specs, helper placement, and merge-path wrappers.
+- Probed live merge/delete/selection behavior with temporary Bun scripts to pin the actual public contracts before adding specs.
+- Added a merge-focused lib spec cluster that covers:
+  - `mergeTableCells`
+  - `splitTableCell`
+  - `deleteRowWhenExpanded`
+  - `deleteColumnWhenExpanded`
+- Added a size/selection helper cluster that covers:
+  - `setTableColSize`
+  - `setTableRowSize`
+  - `moveSelectionFromCell`
+- Tightened the collapsed-selection fixture in `moveSelectionFromCell` so it proves real movement from `21` to `22` instead of accidentally passing with the selection already at the destination.
+
+## Verification
+
+- `bun test packages/table/src/lib/merge/tableMergeBehavior.spec.tsx packages/table/src/lib/transforms/tableSelectionAndSizing.spec.tsx`
+- `bun test packages/table/src/lib`
+- `bun run test:slowest -- --top 15 packages/table/src/lib`
+- `pnpm install`
+- `pnpm turbo build --filter=./packages/table`
+  - failed outside table scope when turbo pulled `@platejs/resizable`
+  - error: `rolldown` on Node `20.12.1` calling `node:util.styleText` with `['underline', 'gray']`
+- `pnpm turbo typecheck --filter=./packages/table`
+- `pnpm lint:fix`
+
+## Learnings
+
+- `package reality`: `deleteRowWhenExpanded` is narrower than its name sounds. It only deletes rows when the expanded selection covers the full width of the first selected row.
+- `package reality`: `deleteColumnWhenExpanded` only deletes a column when the expanded selection spans the first and last rows of the table.
+- `package reality`: `splitTableCell` owns missing-row creation, so the honest split test is the row-creation branch, not only the easy “fill an existing row” path.
+- `verification blocker`: package build is still blocked outside the slice by the same external `rolldown` + Node `20.12.1` `styleText` failure, here reached through `@platejs/resizable`.

--- a/.claude/docs/solutions/logic-errors/2026-03-14-markdown-incomplete-mdx-fallback-drops-void-blocks.md
+++ b/.claude/docs/solutions/logic-errors/2026-03-14-markdown-incomplete-mdx-fallback-drops-void-blocks.md
@@ -1,0 +1,80 @@
+---
+module: Markdown
+date: 2026-03-14
+problem_type: logic_error
+component: markdown_deserializer
+symptoms:
+  - "Incomplete MDX fallback dropped already-parsed content when the complete prefix ended in a void node"
+  - "`markdownToSlateNodesSafely('<hr /><u>')` returned only the fallback paragraph and lost the horizontal rule"
+root_cause: fallback_replacement_error
+resolution_type: code_change
+severity: medium
+tags:
+  - markdown
+  - mdx
+  - deserializer
+  - void-nodes
+  - fallback
+  - testing
+---
+
+# Markdown incomplete-MDX fallback should append after void blocks
+
+## Problem
+
+`markdownToSlateNodesSafely` is the recovery path when full markdown deserialization fails and the input ends with incomplete MDX.
+
+That fallback already handled two sane cases:
+
+- no complete blocks yet: return a new paragraph with the inline fallback text
+- last complete block is non-void: append the fallback inline nodes to that block
+
+But the void-block case was wrong. If the complete prefix ended in a void element like a horizontal rule, the function returned only the fallback paragraph and threw away the already-parsed nodes.
+
+## Root cause
+
+The void-node branch returned:
+
+```ts
+return [newBlock];
+```
+
+That replaced the full `completeNodes` array instead of preserving it.
+
+## Fix
+
+Append the fallback paragraph after the complete nodes:
+
+```ts
+if (ElementApi.isElement(lastBlock) && editor.api.isVoid(lastBlock)) {
+  return [...completeNodes, newBlock];
+}
+```
+
+Now the safe fallback keeps the parsed prefix and still exposes the incomplete MDX tail as literal text.
+
+## Verification
+
+These checks passed:
+
+```bash
+bun test packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.spec.tsx
+bun test packages/markdown/src
+bun run test:slowest -- --top 15 packages/markdown/src
+```
+
+The package build lane was blocked by an external tooling issue unrelated to this fix:
+
+```text
+TypeError [ERR_INVALID_ARG_VALUE]: ... node:util.styleText ... Received [ 'underline', 'gray' ]
+```
+
+## Prevention
+
+When a fallback path combines “complete parsed output” with “literal recovery output,” add one test for each final-block shape:
+
+- empty result
+- non-void last block
+- void last block
+
+That catches the easy mistake where the recovery branch accidentally replaces the result instead of extending it.

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: task
+description: Work a task end-to-end with lean context gathering, implementation, and verification
+argument-hint: '[task description | issue id/link]'
+disable-model-invocation: true
+---
+
+@.claude/skills/task/task.mdc

--- a/.claude/skills/task/task.mdc
+++ b/.claude/skills/task/task.mdc
@@ -1,0 +1,289 @@
+# Work Task
+
+Handle $ARGUMENTS. Be thorough, not ceremonial. Start from the source of truth, load extra skills only when they earn their keep, and verify before calling the task done.
+
+<task>#$ARGUMENTS</task>
+
+## Core Rules
+
+- Read the task source first.
+- Read local repo instructions and relevant files before editing.
+- Search for existing patterns before inventing new ones.
+- Prefer targeted tests and checks during iteration.
+- Keep the user updated at milestones.
+- Verify the actual result before claiming done.
+- Do not default to research swarms, review swarms, browser proof, PR creation, or compounding.
+
+## Intake
+
+1. Classify the input:
+   - Plain task text: the user prompt is the source of truth.
+   - File path or spec path: read it first.
+   - GitHub issue URL: fetch it with `gh issue view` first.
+   - GitHub PR URL: fetch it with `gh pr view` first.
+   - Bare GitHub issue like `#555`: resolve it against the current `gh` repo first, then fetch it with `gh issue view`.
+   - Linear issue link/id: fetch it with the Linear integration first.
+2. Read the full source-of-truth context before doing anything else.
+3. If the task comes from a ticket or issue, also read the comments and attachments when available.
+4. Classify the task shape before choosing a workflow:
+   - Testing or coverage work: triggered by coverage, regressions, test-suite phases, hotspots, package testing, or similar language.
+   - Program or batch work: triggered by multiple packages, phases, buckets, or ordered slices.
+   - Ordinary one-shot work: bug, feature, refactor, docs, review, or investigation that can be finished as a single slice.
+5. Classify task complexity before implementation:
+   - Non-trivial task: multi-step work, research-heavy work, phased execution, or anything likely to take more than a handful of tool calls.
+   - Trivial task: quick question, small edit, or other work that does not need persistent working memory.
+6. If the task is non-trivial:
+   - load `planning-with-files` before implementation
+   - use persistent planning files or the repo's equivalent planning structure so progress survives context loss
+   - follow local repo overrides for where planning files live
+7. If the task is testing or coverage work:
+   - restate it as test work, not generic feature work
+   - load `testing` first and use that testing policy as the source of truth
+   - choose the smallest honest seam before loading `tdd`
+8. If the task is program or batch work:
+   - restate the ordered scope and hard constraints
+   - do not treat the whole batch as one implementation unit
+   - default to completing the first slice cleanly unless the user explicitly asks for a broader sweep
+9. GitHub issue rules:
+   - Resolve bare issue numbers like `#555` against the current repo with `gh repo view --json nameWithOwner -q '.nameWithOwner'`.
+   - Fetch GitHub issues with:
+     ```bash
+     gh issue view <number-or-url> --comments --json number,title,body,comments,labels,state,url
+     ```
+   - Fetch GitHub PRs with `gh pr view ... --json`.
+   - If the input is ambiguous and not clearly a GitHub issue token or URL, do not guess.
+10. For any tracker source, restate for yourself:
+   - source type
+   - source id
+   - exact title
+   - task type: bug, feature, refactor, docs, review, investigation, testing, or batch work
+   - expected outcome or acceptance criteria
+   - caveats, blockers, or missing information from the tracker
+   - likely files, routes, or packages affected
+   - whether there is a real browser surface to verify
+11. Read repo instructions and nearby implementation patterns before editing.
+12. If the task changes code:
+   - if already on a relevant feature branch, continue there
+   - otherwise create a repo-convention branch before editing
+   - if the task has a tracker id, prefer a branch name that includes it:
+     - GitHub issue: `codex/555-short-slug`
+     - Linear issue: `codex/LIN-123-short-slug`
+   - in this repo, otherwise prefer `codex/<slug>`
+   - run install or setup only when the repo or task actually needs it
+13. If the task does not change code, skip branch and setup noise.
+14. If anything important is still ambiguous after the source-of-truth pass and nearby code reading, ask the user the smallest useful clarifying question.
+
+## Tracked Task Rules
+
+Apply this section only when the task source is a tracker item.
+
+### GitHub
+
+- Treat the GitHub issue as the source of truth.
+- Use `gh` for fetch and sync-back.
+- If useful, rename the thread to `<issue-number> <issue-title>`.
+- If the task is code-changing, prefer a branch name that includes the issue number.
+- If the task reaches a meaningful outcome and came from the issue, post a concise issue comment unless blocked or the user said not to.
+
+### Linear
+
+- Keep the same fetch-first behavior as the dedicated Linear workflow.
+- Read the issue, comments, and attachments before implementation.
+- Keep comment-back QA-focused.
+- Do not force browser proof unless the task actually has a browser surface.
+
+### Tracked Task Non-Rules
+
+- Do not require PR creation for every tracked task.
+- Do not require browser screenshots for every tracked task.
+- Do not require tracker comments for investigations that ended blocked or inconclusive unless sync-back is useful.
+
+## Load Skills Only When Justified
+
+- `planning-with-files`
+  Use for any non-trivial task that needs persistent working memory, phased execution, or likely more than a handful of tool calls.
+  Follow repo-specific overrides for where planning artifacts should live.
+- `testing`
+  Use when the task is primarily about tests, coverage, regression gaps, or phase-based suite work.
+  Load it before `tdd` for testing programs.
+- `tdd`
+  Use for bugs and for feature work where behavior-level automated coverage is sane.
+  For testing programs, load it only after choosing a concrete slice that should be done test-first.
+  Skip for trivial docs, mechanical refactors, or painful UI-only plumbing.
+- `learnings-researcher`
+  Use for non-trivial work in a domain with documented solutions or when the task smells like a repeated issue.
+  Do not load it for tiny isolated edits.
+- `debug`
+  Use when the failure mode is still fuzzy after the first repro pass or first failing test.
+- `brainstorm`
+  Use when requirements are still ambiguous after reading the source of truth and nearby code.
+- `dig` or framework-docs research
+  Use when touching unfamiliar, version-sensitive, or unstable third-party APIs.
+- `agent-browser` or `test-browser`
+  Use only when there is a real browser surface to verify.
+  Require real browser proof only for browser or UI tasks.
+- `ce-compound`
+  Use only after verified, non-trivial work that produced reusable knowledge.
+  Never load it at the start.
+- `ce-review`, `kieran-typescript-reviewer`, `code-simplicity-reviewer`
+  Use only for risky, large, user-facing, or architecture-sensitive changes.
+
+## Execution Path
+
+### Bug
+
+1. Reproduce first if possible.
+2. If behavior-level coverage is sane, turn the repro into the smallest useful automated test and watch it fail for the right reason.
+3. Implement the minimal fix.
+4. Re-run targeted checks.
+5. Re-run the browser flow only if the bug lives on a browser surface.
+
+### Feature
+
+1. Reduce the task to the smallest slice that fully satisfies the acceptance criteria.
+2. Add behavior coverage when sane.
+3. Implement with existing patterns before inventing new ones.
+4. Verify the user-facing outcome.
+
+### Testing Or Coverage Work
+
+1. Use the testing policy as the rulebook before choosing seams or commands.
+2. Identify the smallest honest seam for the first hotspot or ordered slice.
+3. Add or deepen the narrowest useful tests instead of spraying smoke coverage.
+4. Verify with targeted test commands first.
+5. Use broader suite checks only when repo rules or change scope justify them.
+
+### Program Or Batch Work
+
+1. Respect the explicit order from the task source.
+2. Do not fan out across every listed slice immediately.
+3. Define what "done for this slice" means before implementation.
+4. Complete one slice at a time unless the user explicitly asks for broader execution.
+
+### Refactor Or Chore
+
+1. Preserve behavior.
+2. Do not do fake TDD theater.
+3. Run the narrowest regression checks plus the relevant build, typecheck, or lint path for the touched area.
+
+### Docs Or Content
+
+1. Skip engineering ceremony.
+2. Verify links, examples, formatting, and rendered output as appropriate.
+
+### Review Or Investigation
+
+1. Read the relevant diff, files, and surrounding context first.
+2. For review tasks, report findings first, ordered by severity, with concrete file references.
+3. For investigation tasks, identify the failure mode, probable cause, and next action before changing code.
+4. Only implement changes if the user actually asked for them.
+
+## Verification
+
+Keep verification mandatory but proportional.
+
+- Run targeted tests for changed behavior.
+- Run package or app build and typecheck when relevant to the touched area.
+- Run lint when code changed and the repo expects it.
+- Run browser verification only for browser or UI tasks.
+- Run broader repo-wide gates only when repo instructions require them or the change scope justifies them.
+- If the repo has a standard final gate, run it last.
+- If the task came from a tracked issue and the task reached a meaningful outcome, sync back unless the user said not to.
+- If UI changed, capture proof from the real browser surface.
+- Do not hardcode PR creation, screenshots, or tracker comments for every task.
+
+## Final Handoff
+
+Every final response must include:
+
+- what was done
+- what verification ran
+- any blocker or caveat
+
+### UI Or Browser Tasks
+
+- Include at least one real browser proof screenshot in the final response.
+- The screenshot must come from `agent-browser` or the real browser workflow used for verification.
+- Put the screenshot before or immediately next to the completion summary so it is impossible to miss.
+- If no real browser proof exists, the task is not done unless the user explicitly waived it.
+
+### Non-UI Tasks
+
+- No screenshot is required.
+- Keep the final response concise and evidence-based.
+
+### Testing Or Batch Work
+
+- State which slice, bucket, or hotspot was completed.
+- State what verification ran for that completed slice.
+- State what remains queued by design.
+- State any intentional deferral in generic terms only.
+
+### Review Or Investigation Tasks
+
+- Lead with findings or conclusion, not process notes.
+
+## Post Back To Tracker
+
+Apply this section only when the task came from a tracker item and reached a meaningful outcome.
+
+### GitHub Issue
+
+- Use:
+  ```bash
+  gh issue comment <number-or-url> --body-file -
+  ```
+- Write concise italicized paragraphs for the issue owner or QA.
+- Keep it focused on:
+  - reproduced or baselined, when relevant
+  - fixed or implemented
+  - re-verified, with browser mention only when relevant
+  - remaining caveat, if any
+- Do not mention:
+  - file names
+  - tests, typecheck, or lint
+  - screenshot paths
+  - branch names
+  - PR mechanics
+- Start only the first sentence with `Codex ...`.
+- Italicize each paragraph separately.
+
+Example:
+
+```md
+_Codex implemented and verified this issue._
+
+_Reproduced the bug, applied the fix, and re-verified the affected flow._
+
+_Remaining caveat: none._
+```
+
+### Linear
+
+- Keep proof local. Do not upload screenshots or other files to Linear.
+- Post a concise issue comment using the Linear integration.
+- Match the ticket style and write for QA, not developers.
+- Keep the same italic-paragraph rule:
+  - start only the first sentence with `Codex ...`
+  - italicize each paragraph separately
+  - avoid file names, tests, typecheck, lint, branch names, PR mechanics, and screenshot paths
+
+### Blocked Or Inconclusive Tracker Work
+
+- If the task was blocked before meaningful progress, either skip the comment or post a short blocker note only if that helps the tracker owner.
+
+## Success Criteria
+
+- Source-of-truth context was read first.
+- Relevant local instructions and code patterns were read before editing.
+- Tracker items were fetched and summarized correctly when provided.
+- Bare GitHub issues like `#555` were resolved against the current `gh` repo instead of guessed.
+- Non-trivial work loaded `planning-with-files` or the repo-equivalent planning workflow before implementation.
+- Testing work loaded the testing policy before implementation.
+- Only the necessary skills were loaded.
+- The implementation matched the task type instead of following a one-size-fits-all ritual.
+- Batch work did not sprawl across multiple slices without explicit instruction.
+- Verification matched the change scope.
+- Final handoff matched the task type.
+- Testing or batch handoff reported the completed slice, verification, and remaining queue when relevant.
+- Any tracker, browser, review, or compound follow-up was done only if actually relevant.

--- a/.codex/skills/task/SKILL.md
+++ b/.codex/skills/task/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: task
+description: Work a task end-to-end with lean context gathering, implementation, and verification
+argument-hint: '[task description | issue id/link]'
+disable-model-invocation: true
+---
+
+# Work Task
+
+Handle $ARGUMENTS. Be thorough, not ceremonial. Start from the source of truth, load extra skills only when they earn their keep, and verify before calling the task done.
+
+<task>#$ARGUMENTS</task>
+
+## Core Rules
+
+- Read the task source first.
+- Read local repo instructions and relevant files before editing.
+- Search for existing patterns before inventing new ones.
+- Prefer targeted tests and checks during iteration.
+- Keep the user updated at milestones.
+- Verify the actual result before claiming done.
+- Do not default to research swarms, review swarms, browser proof, PR creation, or compounding.
+
+## Intake
+
+1. Classify the input:
+   - Plain task text: the user prompt is the source of truth.
+   - File path or spec path: read it first.
+   - GitHub issue URL: fetch it with `gh issue view` first.
+   - GitHub PR URL: fetch it with `gh pr view` first.
+   - Bare GitHub issue like `#555`: resolve it against the current `gh` repo first, then fetch it with `gh issue view`.
+   - Linear issue link/id: fetch it with the Linear integration first.
+2. Read the full source-of-truth context before doing anything else.
+3. If the task comes from a ticket or issue, also read the comments and attachments when available.
+4. Classify the task shape before choosing a workflow:
+   - Testing or coverage work: triggered by coverage, regressions, test-suite phases, hotspots, package testing, or similar language.
+   - Program or batch work: triggered by multiple packages, phases, buckets, or ordered slices.
+   - Ordinary one-shot work: bug, feature, refactor, docs, review, or investigation that can be finished as a single slice.
+5. Classify task complexity before implementation:
+   - Non-trivial task: multi-step work, research-heavy work, phased execution, or anything likely to take more than a handful of tool calls.
+   - Trivial task: quick question, small edit, or other work that does not need persistent working memory.
+6. If the task is non-trivial:
+   - load `planning-with-files` before implementation
+   - use persistent planning files or the repo's equivalent planning structure so progress survives context loss
+   - follow local repo overrides for where planning files live
+7. If the task is testing or coverage work:
+   - restate it as test work, not generic feature work
+   - load `testing` first and use that testing policy as the source of truth
+   - choose the smallest honest seam before loading `tdd`
+8. If the task is program or batch work:
+   - restate the ordered scope and hard constraints
+   - do not treat the whole batch as one implementation unit
+   - default to completing the first slice cleanly unless the user explicitly asks for a broader sweep
+9. GitHub issue rules:
+   - Resolve bare issue numbers like `#555` against the current repo with `gh repo view --json nameWithOwner -q '.nameWithOwner'`.
+   - Fetch GitHub issues with:
+     ```bash
+     gh issue view <number-or-url> --comments --json number,title,body,comments,labels,state,url
+     ```
+   - Fetch GitHub PRs with `gh pr view ... --json`.
+   - If the input is ambiguous and not clearly a GitHub issue token or URL, do not guess.
+10. For any tracker source, restate for yourself:
+   - source type
+   - source id
+   - exact title
+   - task type: bug, feature, refactor, docs, review, investigation, testing, or batch work
+   - expected outcome or acceptance criteria
+   - caveats, blockers, or missing information from the tracker
+   - likely files, routes, or packages affected
+   - whether there is a real browser surface to verify
+11. Read repo instructions and nearby implementation patterns before editing.
+12. If the task changes code:
+   - if already on a relevant feature branch, continue there
+   - otherwise create a repo-convention branch before editing
+   - if the task has a tracker id, prefer a branch name that includes it:
+     - GitHub issue: `codex/555-short-slug`
+     - Linear issue: `codex/LIN-123-short-slug`
+   - in this repo, otherwise prefer `codex/<slug>`
+   - run install or setup only when the repo or task actually needs it
+13. If the task does not change code, skip branch and setup noise.
+14. If anything important is still ambiguous after the source-of-truth pass and nearby code reading, ask the user the smallest useful clarifying question.
+
+## Tracked Task Rules
+
+Apply this section only when the task source is a tracker item.
+
+### GitHub
+
+- Treat the GitHub issue as the source of truth.
+- Use `gh` for fetch and sync-back.
+- If useful, rename the thread to `<issue-number> <issue-title>`.
+- If the task is code-changing, prefer a branch name that includes the issue number.
+- If the task reaches a meaningful outcome and came from the issue, post a concise issue comment unless blocked or the user said not to.
+
+### Linear
+
+- Keep the same fetch-first behavior as the dedicated Linear workflow.
+- Read the issue, comments, and attachments before implementation.
+- Keep comment-back QA-focused.
+- Do not force browser proof unless the task actually has a browser surface.
+
+### Tracked Task Non-Rules
+
+- Do not require PR creation for every tracked task.
+- Do not require browser screenshots for every tracked task.
+- Do not require tracker comments for investigations that ended blocked or inconclusive unless sync-back is useful.
+
+## Load Skills Only When Justified
+
+- `planning-with-files`
+  Use for any non-trivial task that needs persistent working memory, phased execution, or likely more than a handful of tool calls.
+  Follow repo-specific overrides for where planning artifacts should live.
+- `testing`
+  Use when the task is primarily about tests, coverage, regression gaps, or phase-based suite work.
+  Load it before `tdd` for testing programs.
+- `tdd`
+  Use for bugs and for feature work where behavior-level automated coverage is sane.
+  For testing programs, load it only after choosing a concrete slice that should be done test-first.
+  Skip for trivial docs, mechanical refactors, or painful UI-only plumbing.
+- `learnings-researcher`
+  Use for non-trivial work in a domain with documented solutions or when the task smells like a repeated issue.
+  Do not load it for tiny isolated edits.
+- `debug`
+  Use when the failure mode is still fuzzy after the first repro pass or first failing test.
+- `brainstorm`
+  Use when requirements are still ambiguous after reading the source of truth and nearby code.
+- `dig` or framework-docs research
+  Use when touching unfamiliar, version-sensitive, or unstable third-party APIs.
+- `agent-browser` or `test-browser`
+  Use only when there is a real browser surface to verify.
+  Require real browser proof only for browser or UI tasks.
+- `ce-compound`
+  Use only after verified, non-trivial work that produced reusable knowledge.
+  Never load it at the start.
+- `ce-review`, `kieran-typescript-reviewer`, `code-simplicity-reviewer`
+  Use only for risky, large, user-facing, or architecture-sensitive changes.
+
+## Execution Path
+
+### Bug
+
+1. Reproduce first if possible.
+2. If behavior-level coverage is sane, turn the repro into the smallest useful automated test and watch it fail for the right reason.
+3. Implement the minimal fix.
+4. Re-run targeted checks.
+5. Re-run the browser flow only if the bug lives on a browser surface.
+
+### Feature
+
+1. Reduce the task to the smallest slice that fully satisfies the acceptance criteria.
+2. Add behavior coverage when sane.
+3. Implement with existing patterns before inventing new ones.
+4. Verify the user-facing outcome.
+
+### Testing Or Coverage Work
+
+1. Use the testing policy as the rulebook before choosing seams or commands.
+2. Identify the smallest honest seam for the first hotspot or ordered slice.
+3. Add or deepen the narrowest useful tests instead of spraying smoke coverage.
+4. Verify with targeted test commands first.
+5. Use broader suite checks only when repo rules or change scope justify them.
+
+### Program Or Batch Work
+
+1. Respect the explicit order from the task source.
+2. Do not fan out across every listed slice immediately.
+3. Define what "done for this slice" means before implementation.
+4. Complete one slice at a time unless the user explicitly asks for broader execution.
+
+### Refactor Or Chore
+
+1. Preserve behavior.
+2. Do not do fake TDD theater.
+3. Run the narrowest regression checks plus the relevant build, typecheck, or lint path for the touched area.
+
+### Docs Or Content
+
+1. Skip engineering ceremony.
+2. Verify links, examples, formatting, and rendered output as appropriate.
+
+### Review Or Investigation
+
+1. Read the relevant diff, files, and surrounding context first.
+2. For review tasks, report findings first, ordered by severity, with concrete file references.
+3. For investigation tasks, identify the failure mode, probable cause, and next action before changing code.
+4. Only implement changes if the user actually asked for them.
+
+## Verification
+
+Keep verification mandatory but proportional.
+
+- Run targeted tests for changed behavior.
+- Run package or app build and typecheck when relevant to the touched area.
+- Run lint when code changed and the repo expects it.
+- Run browser verification only for browser or UI tasks.
+- Run broader repo-wide gates only when repo instructions require them or the change scope justifies them.
+- If the repo has a standard final gate, run it last.
+- If the task came from a tracked issue and the task reached a meaningful outcome, sync back unless the user said not to.
+- If UI changed, capture proof from the real browser surface.
+- Do not hardcode PR creation, screenshots, or tracker comments for every task.
+
+## Final Handoff
+
+Every final response must include:
+
+- what was done
+- what verification ran
+- any blocker or caveat
+
+### UI Or Browser Tasks
+
+- Include at least one real browser proof screenshot in the final response.
+- The screenshot must come from `agent-browser` or the real browser workflow used for verification.
+- Put the screenshot before or immediately next to the completion summary so it is impossible to miss.
+- If no real browser proof exists, the task is not done unless the user explicitly waived it.
+
+### Non-UI Tasks
+
+- No screenshot is required.
+- Keep the final response concise and evidence-based.
+
+### Testing Or Batch Work
+
+- State which slice, bucket, or hotspot was completed.
+- State what verification ran for that completed slice.
+- State what remains queued by design.
+- State any intentional deferral in generic terms only.
+
+### Review Or Investigation Tasks
+
+- Lead with findings or conclusion, not process notes.
+
+## Post Back To Tracker
+
+Apply this section only when the task came from a tracker item and reached a meaningful outcome.
+
+### GitHub Issue
+
+- Use:
+  ```bash
+  gh issue comment <number-or-url> --body-file -
+  ```
+- Write concise italicized paragraphs for the issue owner or QA.
+- Keep it focused on:
+  - reproduced or baselined, when relevant
+  - fixed or implemented
+  - re-verified, with browser mention only when relevant
+  - remaining caveat, if any
+- Do not mention:
+  - file names
+  - tests, typecheck, or lint
+  - screenshot paths
+  - branch names
+  - PR mechanics
+- Start only the first sentence with `Codex ...`.
+- Italicize each paragraph separately.
+
+Example:
+
+```md
+_Codex implemented and verified this issue._
+
+_Reproduced the bug, applied the fix, and re-verified the affected flow._
+
+_Remaining caveat: none._
+```
+
+### Linear
+
+- Keep proof local. Do not upload screenshots or other files to Linear.
+- Post a concise issue comment using the Linear integration.
+- Match the ticket style and write for QA, not developers.
+- Keep the same italic-paragraph rule:
+  - start only the first sentence with `Codex ...`
+  - italicize each paragraph separately
+  - avoid file names, tests, typecheck, lint, branch names, PR mechanics, and screenshot paths
+
+### Blocked Or Inconclusive Tracker Work
+
+- If the task was blocked before meaningful progress, either skip the comment or post a short blocker note only if that helps the tracker owner.
+
+## Success Criteria
+
+- Source-of-truth context was read first.
+- Relevant local instructions and code patterns were read before editing.
+- Tracker items were fetched and summarized correctly when provided.
+- Bare GitHub issues like `#555` were resolved against the current `gh` repo instead of guessed.
+- Non-trivial work loaded `planning-with-files` or the repo-equivalent planning workflow before implementation.
+- Testing work loaded the testing policy before implementation.
+- Only the necessary skills were loaded.
+- The implementation matched the task type instead of following a one-size-fits-all ritual.
+- Batch work did not sprawl across multiple slices without explicit instruction.
+- Verification matched the change scope.
+- Final handoff matched the task type.
+- Testing or batch handoff reported the completed slice, verification, and remaining queue when relevant.
+- Any tracker, browser, review, or compound follow-up was done only if actually relevant.

--- a/packages/core/src/react/hooks/useSlateProps.spec.tsx
+++ b/packages/core/src/react/hooks/useSlateProps.spec.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+
+import type { TRange } from '@platejs/slate';
+
+import { act, renderHook } from '@testing-library/react';
+
+import { TestPlate as Plate } from '../__tests__/TestPlate';
+import { createPlateEditor } from '../editor';
+import { createPlatePlugin } from '../plugin';
+import {
+  useEditorVersion,
+  useSelectionVersion,
+  useValueVersion,
+} from '../stores';
+import { useSlateProps } from './useSlateProps';
+
+describe('useSlateProps', () => {
+  it('routes slate callbacks through the matching plate callbacks and versions', () => {
+    const onChange = mock();
+    const onSelectionChange = mock();
+    const onValueChange = mock();
+    const editor = createPlateEditor({
+      value: [{ children: [{ text: 'one' }], type: 'p' }],
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <Plate
+        editor={editor}
+        onChange={onChange}
+        onSelectionChange={onSelectionChange}
+        onValueChange={onValueChange}
+      >
+        {children}
+      </Plate>
+    );
+    const { result } = renderHook(
+      () => ({
+        editorVersion: useEditorVersion(),
+        props: useSlateProps({}),
+        selectionVersion: useSelectionVersion(),
+        valueVersion: useValueVersion(),
+      }),
+      { wrapper }
+    );
+    const nextValue = [{ children: [{ text: 'two' }], type: 'p' }];
+    const nextSelection: TRange = {
+      anchor: { offset: 1, path: [0, 0] },
+      focus: { offset: 1, path: [0, 0] },
+    };
+
+    onChange.mockClear();
+    onSelectionChange.mockClear();
+    onValueChange.mockClear();
+
+    expect(result.current.props.editor).toBe(editor);
+    expect(result.current.props.initialValue).toBe(editor.children);
+    expect(result.current.props.key).toBe(editor.meta.key);
+
+    act(() => {
+      result.current.props.onChange(nextValue as any);
+    });
+
+    expect(result.current.editorVersion).toBe(2);
+    expect(result.current.selectionVersion).toBe(1);
+    expect(result.current.valueVersion).toBe(1);
+    expect(onChange).toHaveBeenCalledWith({ editor, value: nextValue });
+
+    act(() => {
+      result.current.props.onValueChange(nextValue as any);
+    });
+
+    expect(result.current.editorVersion).toBe(2);
+    expect(result.current.selectionVersion).toBe(1);
+    expect(result.current.valueVersion).toBe(2);
+    expect(onValueChange).toHaveBeenCalledWith({ editor, value: nextValue });
+
+    act(() => {
+      result.current.props.onSelectionChange(nextSelection);
+    });
+
+    expect(result.current.editorVersion).toBe(2);
+    expect(result.current.selectionVersion).toBe(2);
+    expect(result.current.valueVersion).toBe(2);
+    expect(onSelectionChange).toHaveBeenCalledWith({
+      editor,
+      selection: nextSelection,
+    });
+  });
+
+  it('increments the editor version without forwarding handled changes', () => {
+    const handledChange = mock(() => true);
+    const onChange = mock();
+    const editor = createPlateEditor({
+      plugins: [
+        createPlatePlugin({
+          handlers: { onChange: handledChange },
+          key: 'handled',
+        }),
+      ],
+      value: [{ children: [{ text: 'one' }], type: 'p' }],
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <Plate editor={editor} onChange={onChange}>
+        {children}
+      </Plate>
+    );
+    const { result } = renderHook(
+      () => ({
+        editorVersion: useEditorVersion(),
+        props: useSlateProps({}),
+      }),
+      { wrapper }
+    );
+
+    handledChange.mockClear();
+    onChange.mockClear();
+
+    act(() => {
+      result.current.props.onChange([
+        { children: [{ text: 'two' }], type: 'p' },
+      ] as any);
+    });
+
+    expect(result.current.editorVersion).toBe(2);
+    expect(handledChange).toHaveBeenCalledTimes(1);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.spec.tsx
+++ b/packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.spec.tsx
@@ -1,0 +1,60 @@
+import { createTestEditor } from '../../__tests__/createTestEditor';
+import { markdownToSlateNodesSafely } from './markdownToSlateNodesSafely';
+
+describe('markdownToSlateNodesSafely', () => {
+  it('deserializes normal markdown when there is no incomplete MDX tail', () => {
+    const editor = createTestEditor();
+
+    expect(markdownToSlateNodesSafely(editor, 'plain **bold**')).toEqual([
+      {
+        children: [{ text: 'plain ' }, { bold: true, text: 'bold' }],
+        type: 'p',
+      },
+    ]);
+  });
+
+  it('appends incomplete inline MDX text to the last non-void block', () => {
+    const editor = createTestEditor();
+
+    expect(
+      markdownToSlateNodesSafely(editor, '<callout>ok</callout><callout>')
+    ).toEqual([
+      {
+        children: [
+          {
+            children: [{ text: 'ok' }],
+            type: 'callout',
+          },
+          { text: '<callout>' },
+        ],
+        type: 'p',
+      },
+    ]);
+  });
+
+  it('wraps incomplete inline MDX in a new paragraph when there are no complete blocks', () => {
+    const editor = createTestEditor();
+
+    expect(markdownToSlateNodesSafely(editor, '<u>')).toEqual([
+      {
+        children: [{ text: '<u>' }],
+        type: 'p',
+      },
+    ]);
+  });
+
+  it('preserves complete void blocks before appending the fallback paragraph', () => {
+    const editor = createTestEditor();
+
+    expect(markdownToSlateNodesSafely(editor, '<hr /><u>')).toEqual([
+      {
+        children: [{ text: '' }],
+        type: 'hr',
+      },
+      {
+        children: [{ text: '<u>' }],
+        type: 'p',
+      },
+    ]);
+  });
+});

--- a/packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.ts
+++ b/packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.ts
@@ -46,7 +46,7 @@ export const markdownToSlateNodesSafely = (
   const lastBlock = completeNodes.at(-1);
 
   if (ElementApi.isElement(lastBlock) && editor.api.isVoid(lastBlock)) {
-    return [newBlock];
+    return [...completeNodes, newBlock];
   }
 
   // FIXME table column will fail, need recursive find the last p

--- a/packages/markdown/src/lib/deserializer/utils/stripMarkdown.spec.ts
+++ b/packages/markdown/src/lib/deserializer/utils/stripMarkdown.spec.ts
@@ -1,0 +1,41 @@
+import {
+  stripMarkdown,
+  stripMarkdownBlocks,
+  stripMarkdownInline,
+} from './stripMarkdown';
+
+describe('stripMarkdownBlocks', () => {
+  it('removes block markdown syntax and preserves text content', () => {
+    const input = [
+      '# Heading',
+      '> Quote',
+      '- bullet',
+      '1. ordered',
+      '```ts',
+      'const x = 1;',
+      '```',
+      'tail<br>line',
+    ].join('\n');
+
+    expect(stripMarkdownBlocks(input)).toBe(
+      ['Heading', 'Quote', 'bullet', 'ordered', '', 'tail', 'line'].join('\n')
+    );
+  });
+});
+
+describe('stripMarkdownInline', () => {
+  it('removes inline markdown syntax and decodes entities', () => {
+    const input =
+      '**bold** _italic_ [link](https://example.com) `code` &lt;&gt;&amp;&nbsp;';
+
+    expect(stripMarkdownInline(input)).toBe('bold italic link code <>& ');
+  });
+});
+
+describe('stripMarkdown', () => {
+  it('combines block and inline stripping', () => {
+    const input = '# Heading\n- **bold** [link](https://example.com)<br>`code`';
+
+    expect(stripMarkdown(input)).toBe('Heading\nbold link\ncode');
+  });
+});

--- a/packages/markdown/src/lib/rules/utils/parseAttributes.spec.ts
+++ b/packages/markdown/src/lib/rules/utils/parseAttributes.spec.ts
@@ -1,0 +1,39 @@
+import { parseAttributes, propsToAttributes } from './parseAttributes';
+
+describe('parseAttributes', () => {
+  it('parses JSON values and keeps raw strings when parsing fails', () => {
+    const attributes = [
+      { name: 'count', value: '3' },
+      { name: 'enabled', value: 'true' },
+      { name: 'config', value: '{"theme":"dark"}' },
+      { name: 'label', value: 'plain-text' },
+      { name: 'missingValue' },
+      { value: 'ignored' },
+    ];
+
+    expect(parseAttributes(attributes as any)).toEqual({
+      config: { theme: 'dark' },
+      count: 3,
+      enabled: true,
+      label: 'plain-text',
+    });
+  });
+});
+
+describe('propsToAttributes', () => {
+  it('serializes strings directly and JSON-encodes other values', () => {
+    expect(
+      propsToAttributes({
+        config: { theme: 'dark' },
+        count: 3,
+        enabled: true,
+        label: 'plain-text',
+      })
+    ).toEqual([
+      { name: 'config', type: 'mdxJsxAttribute', value: '{"theme":"dark"}' },
+      { name: 'count', type: 'mdxJsxAttribute', value: '3' },
+      { name: 'enabled', type: 'mdxJsxAttribute', value: 'true' },
+      { name: 'label', type: 'mdxJsxAttribute', value: 'plain-text' },
+    ]);
+  });
+});

--- a/packages/markdown/src/lib/serializer/utils/getCustomMark.spec.ts
+++ b/packages/markdown/src/lib/serializer/utils/getCustomMark.spec.ts
@@ -1,0 +1,20 @@
+import { getCustomMark } from './getCustomMark';
+
+describe('getCustomMark', () => {
+  it('returns only rules explicitly marked as markdown marks', () => {
+    expect(
+      getCustomMark({
+        rules: {
+          bold: { mark: true } as any,
+          callout: {} as any,
+          comment: { mark: true } as any,
+          mention: { mark: false } as any,
+        },
+      })
+    ).toEqual(['bold', 'comment']);
+  });
+
+  it('returns an empty list when rules are missing', () => {
+    expect(getCustomMark()).toEqual([]);
+  });
+});

--- a/packages/markdown/src/lib/utils/getRemarkPluginsWithoutMdx.spec.ts
+++ b/packages/markdown/src/lib/utils/getRemarkPluginsWithoutMdx.spec.ts
@@ -1,0 +1,33 @@
+import {
+  getRemarkPluginsWithoutMdx,
+  REMARK_MDX_TAG,
+  tagRemarkPlugin,
+} from './getRemarkPluginsWithoutMdx';
+
+describe('tagRemarkPlugin', () => {
+  it('preserves the plugin call contract and stores the tag', () => {
+    const plugin = mock(function (this: { calls: number }, suffix: string) {
+      this.calls += 1;
+      return `value:${suffix}`;
+    });
+
+    const wrapped = tagRemarkPlugin(plugin, REMARK_MDX_TAG);
+    const context = { calls: 0 };
+
+    expect(wrapped.call(context, 'ok')).toBe('value:ok');
+    expect(context.calls).toBe(1);
+    expect((wrapped as any).__pluginTag).toBe(REMARK_MDX_TAG);
+  });
+});
+
+describe('getRemarkPluginsWithoutMdx', () => {
+  it('filters only plugins tagged as remark-mdx', () => {
+    const keepA = () => {};
+    const keepB = () => {};
+    const remove = tagRemarkPlugin(() => {}, REMARK_MDX_TAG);
+
+    expect(
+      getRemarkPluginsWithoutMdx([keepA as any, remove as any, keepB as any])
+    ).toEqual([keepA, keepB]);
+  });
+});

--- a/packages/table/src/lib/merge/tableMergeBehavior.spec.tsx
+++ b/packages/table/src/lib/merge/tableMergeBehavior.spec.tsx
@@ -1,0 +1,338 @@
+/** @jsx jsxt */
+
+import { type SlateEditor, KEYS, createSlateEditor } from 'platejs';
+
+import { jsxt } from '@platejs/test-utils';
+
+import { getTestTablePlugins } from '../__tests__/getTestTablePlugins';
+import { deleteColumnWhenExpanded } from './deleteColumnWhenExpanded';
+import { deleteRowWhenExpanded } from './deleteRowWhenExpanded';
+import { mergeTableCells } from './mergeTableCells';
+import { splitTableCell } from './splitTableCell';
+
+jsxt;
+
+const createTableEditor = (
+  input: SlateEditor,
+  { disableMerge = false }: { disableMerge?: boolean } = {}
+) =>
+  createSlateEditor({
+    nodeId: true,
+    plugins: getTestTablePlugins({ disableMerge }),
+    selection: input.selection,
+    value: input.children,
+  });
+
+const getTableEntry = (editor: SlateEditor) =>
+  editor.api.above({ match: { type: editor.getType(KEYS.table) } })!;
+
+describe('table merge behavior', () => {
+  describe('mergeTableCells', () => {
+    it('merges a 2x2 selection into one spanning cell and keeps cell content order', () => {
+      const input = (
+        <editor>
+          <htable>
+            <htr>
+              <htd>
+                <hp>
+                  <anchor />
+                  11
+                </hp>
+              </htd>
+              <htd>
+                <hp>12</hp>
+              </htd>
+            </htr>
+            <htr>
+              <htd>
+                <hp>21</hp>
+              </htd>
+              <htd>
+                <hp>
+                  22
+                  <focus />
+                </hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any as SlateEditor;
+
+      const editor = createTableEditor(input);
+
+      mergeTableCells(editor);
+
+      const table = editor.children[0] as any;
+      const mergedCell = table.children[0].children[0];
+
+      expect(table.children[0].children).toHaveLength(1);
+      expect(mergedCell).toMatchObject({
+        colSpan: 2,
+        rowSpan: 2,
+        type: 'td',
+      });
+      expect(
+        mergedCell.children.map((child: any) => child.children[0].text)
+      ).toEqual(['11', '12', '21', '22']);
+      expect(editor.selection).toEqual({
+        anchor: { offset: 2, path: [0, 0, 0, 3, 0] },
+        focus: { offset: 2, path: [0, 0, 0, 3, 0] },
+      });
+    });
+  });
+
+  describe('splitTableCell', () => {
+    it('splits a merged cell into 1x1 cells, creates missing rows, and keeps content in the first cell', () => {
+      const input = (
+        <editor>
+          <htable>
+            <htr>
+              <htd colSpan={2} rowSpan={2}>
+                <hp>
+                  merged
+                  <cursor />
+                </hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any as SlateEditor;
+
+      const output = (
+        <editor>
+          <htable>
+            <htr>
+              <htd colSpan={1} rowSpan={1}>
+                <hp>
+                  merged
+                  <cursor />
+                </hp>
+              </htd>
+              <htd colSpan={1} rowSpan={1}>
+                <hp>
+                  <htext />
+                </hp>
+              </htd>
+            </htr>
+            <htr>
+              <htd colSpan={1} rowSpan={1}>
+                <hp>
+                  <htext />
+                </hp>
+              </htd>
+              <htd colSpan={1} rowSpan={1}>
+                <hp>
+                  <htext />
+                </hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any as SlateEditor;
+
+      const editor = createTableEditor(input);
+
+      splitTableCell(editor);
+
+      expect(editor.children).toMatchObject(output.children);
+      expect(editor.selection).toEqual(output.selection);
+    });
+  });
+
+  describe('deleteRowWhenExpanded', () => {
+    it('deletes a fully selected row and collapses the selection to the next row', () => {
+      const input = (
+        <editor>
+          <htable>
+            <htr>
+              <htd>
+                <hp>
+                  <anchor />
+                  11
+                </hp>
+              </htd>
+              <htd>
+                <hp>
+                  12
+                  <focus />
+                </hp>
+              </htd>
+            </htr>
+            <htr>
+              <htd>
+                <hp>21</hp>
+              </htd>
+              <htd>
+                <hp>22</hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any as SlateEditor;
+
+      const output = (
+        <editor>
+          <htable>
+            <htr>
+              <htd>
+                <hp>
+                  <cursor />
+                  21
+                </hp>
+              </htd>
+              <htd>
+                <hp>22</hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any as SlateEditor;
+
+      const editor = createTableEditor(input, { disableMerge: true });
+
+      deleteRowWhenExpanded(editor, getTableEntry(editor) as any);
+
+      expect(editor.children).toMatchObject(output.children);
+      expect(editor.selection).toEqual(output.selection);
+    });
+
+    it('keeps the table unchanged when the selection does not span the full row width', () => {
+      const input = (
+        <editor>
+          <htable>
+            <htr>
+              <htd>
+                <hp>
+                  <anchor />
+                  11
+                </hp>
+              </htd>
+              <htd>
+                <hp>12</hp>
+              </htd>
+            </htr>
+            <htr>
+              <htd>
+                <hp>
+                  21
+                  <focus />
+                </hp>
+              </htd>
+              <htd>
+                <hp>22</hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any as SlateEditor;
+
+      const editor = createTableEditor(input, { disableMerge: true });
+
+      deleteRowWhenExpanded(editor, getTableEntry(editor) as any);
+
+      expect(editor.children).toMatchObject(input.children);
+      expect(editor.selection).toEqual(input.selection);
+    });
+  });
+
+  describe('deleteColumnWhenExpanded', () => {
+    it('deletes a fully selected column and keeps the remaining column selected', () => {
+      const input = (
+        <editor>
+          <htable>
+            <htr>
+              <htd>
+                <hp>11</hp>
+              </htd>
+              <htd>
+                <hp>
+                  <anchor />
+                  12
+                </hp>
+              </htd>
+            </htr>
+            <htr>
+              <htd>
+                <hp>21</hp>
+              </htd>
+              <htd>
+                <hp>
+                  22
+                  <focus />
+                </hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any as SlateEditor;
+
+      const output = (
+        <editor>
+          <htable>
+            <htr>
+              <htd>
+                <hp>
+                  11
+                  <anchor />
+                </hp>
+              </htd>
+            </htr>
+            <htr>
+              <htd>
+                <hp>
+                  21
+                  <focus />
+                </hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any as SlateEditor;
+
+      const editor = createTableEditor(input, { disableMerge: true });
+
+      deleteColumnWhenExpanded(editor, getTableEntry(editor) as any);
+
+      expect(editor.children).toMatchObject(output.children);
+      expect(editor.selection).toEqual(output.selection);
+    });
+
+    it('keeps the table unchanged when the selection does not span every row', () => {
+      const input = (
+        <editor>
+          <htable>
+            <htr>
+              <htd>
+                <hp>
+                  <anchor />
+                  11
+                </hp>
+              </htd>
+              <htd>
+                <hp>
+                  12
+                  <focus />
+                </hp>
+              </htd>
+            </htr>
+            <htr>
+              <htd>
+                <hp>21</hp>
+              </htd>
+              <htd>
+                <hp>22</hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any as SlateEditor;
+
+      const editor = createTableEditor(input, { disableMerge: true });
+
+      deleteColumnWhenExpanded(editor, getTableEntry(editor) as any);
+
+      expect(editor.children).toMatchObject(input.children);
+      expect(editor.selection).toEqual(input.selection);
+    });
+  });
+});

--- a/packages/table/src/lib/transforms/tableSelectionAndSizing.spec.tsx
+++ b/packages/table/src/lib/transforms/tableSelectionAndSizing.spec.tsx
@@ -1,0 +1,263 @@
+/** @jsx jsxt */
+
+import { type SlateEditor, createSlateEditor } from 'platejs';
+
+import { jsxt } from '@platejs/test-utils';
+
+import { getTestTablePlugins } from '../__tests__/getTestTablePlugins';
+import { moveSelectionFromCell } from './moveSelectionFromCell';
+import { setTableColSize } from './setTableColSize';
+import { setTableRowSize } from './setTableRowSize';
+
+jsxt;
+
+const createTableEditor = (input: SlateEditor) =>
+  createSlateEditor({
+    nodeId: true,
+    plugins: getTestTablePlugins(),
+    selection: input.selection,
+    value: input.children,
+  });
+
+describe('table sizing and selection helpers', () => {
+  describe('setTableColSize', () => {
+    it('creates a colSizes array when the table does not have one yet', () => {
+      const input = (
+        <editor>
+          <htable>
+            <htr>
+              <htd>
+                <hp>11</hp>
+              </htd>
+              <htd>
+                <hp>12</hp>
+              </htd>
+            </htr>
+            <htr>
+              <htd>
+                <hp>
+                  21
+                  <cursor />
+                </hp>
+              </htd>
+              <htd>
+                <hp>22</hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any as SlateEditor;
+
+      const editor = createTableEditor(input);
+
+      setTableColSize(editor, { colIndex: 1, width: 120 });
+
+      expect(editor.children).toMatchObject([
+        {
+          colSizes: [0, 120],
+          type: 'table',
+        },
+      ]);
+    });
+
+    it('updates only the requested column width when colSizes already exist', () => {
+      const input = (
+        <editor>
+          <htable colSizes={[20, 30]}>
+            <htr>
+              <htd>
+                <hp>
+                  11
+                  <cursor />
+                </hp>
+              </htd>
+              <htd>
+                <hp>12</hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any as SlateEditor;
+
+      const editor = createTableEditor(input);
+
+      setTableColSize(editor, { colIndex: 0, width: 64 });
+
+      expect(editor.children).toMatchObject([
+        {
+          colSizes: [64, 30],
+          type: 'table',
+        },
+      ]);
+    });
+  });
+
+  describe('setTableRowSize', () => {
+    it('sets the size on the requested table row', () => {
+      const input = (
+        <editor>
+          <htable>
+            <htr>
+              <htd>
+                <hp>11</hp>
+              </htd>
+              <htd>
+                <hp>12</hp>
+              </htd>
+            </htr>
+            <htr>
+              <htd>
+                <hp>
+                  21
+                  <cursor />
+                </hp>
+              </htd>
+              <htd>
+                <hp>22</hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any as SlateEditor;
+
+      const editor = createTableEditor(input);
+
+      setTableRowSize(editor, { height: 48, rowIndex: 0 });
+
+      expect(editor.children).toMatchObject([
+        {
+          children: [{ size: 48 }, {}],
+          type: 'table',
+        },
+      ]);
+    });
+  });
+
+  describe('moveSelectionFromCell', () => {
+    it('moves a collapsed selection to the next cell', () => {
+      const input = (
+        <editor>
+          <htable>
+            <htr>
+              <htd>
+                <hp>11</hp>
+              </htd>
+              <htd>
+                <hp>12</hp>
+              </htd>
+            </htr>
+            <htr>
+              <htd>
+                <hp>
+                  21
+                  <cursor />
+                </hp>
+              </htd>
+              <htd>
+                <hp>22</hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any as SlateEditor;
+
+      const output = (
+        <editor>
+          <htable>
+            <htr>
+              <htd>
+                <hp>11</hp>
+              </htd>
+              <htd>
+                <hp>12</hp>
+              </htd>
+            </htr>
+            <htr>
+              <htd>
+                <hp>21</hp>
+              </htd>
+              <htd>
+                <hp>
+                  22
+                  <cursor />
+                </hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any as SlateEditor;
+
+      const editor = createTableEditor(input);
+
+      moveSelectionFromCell(editor);
+
+      expect(editor.selection).toEqual(output.selection);
+    });
+
+    it('expands the current cell range to the right edge', () => {
+      const input = (
+        <editor>
+          <htable>
+            <htr>
+              <htd>
+                <hp>
+                  <anchor />
+                  11
+                </hp>
+              </htd>
+              <htd>
+                <hp>12</hp>
+              </htd>
+            </htr>
+            <htr>
+              <htd>
+                <hp>
+                  21
+                  <focus />
+                </hp>
+              </htd>
+              <htd>
+                <hp>22</hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any as SlateEditor;
+
+      const output = (
+        <editor>
+          <htable>
+            <htr>
+              <htd>
+                <hp>
+                  <anchor />
+                  11
+                </hp>
+              </htd>
+              <htd>
+                <hp>12</hp>
+              </htd>
+            </htr>
+            <htr>
+              <htd>
+                <hp>21</hp>
+              </htd>
+              <htd>
+                <hp>
+                  <focus />
+                  22
+                </hp>
+              </htd>
+            </htr>
+          </htable>
+        </editor>
+      ) as any as SlateEditor;
+
+      const editor = createTableEditor(input);
+
+      moveSelectionFromCell(editor, { edge: 'right' });
+
+      expect(editor.selection).toEqual(output.selection);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- deepen non-React markdown logic coverage and fix incomplete MDX fallback when a parsed prefix ends in a void block
- add focused table lib coverage for merge, split, expanded row/column deletion, sizing, and selection movement
- include the current checkout's existing task-skill docs and `useSlateProps` test updates as-is

## Testing
- `bun test packages/markdown/src`
- `bun run test:slowest -- --top 15 packages/markdown/src`
- `bun test packages/table/src/lib/merge/tableMergeBehavior.spec.tsx packages/table/src/lib/transforms/tableSelectionAndSizing.spec.tsx`
- `bun test packages/table/src/lib`
- `bun run test:slowest -- --top 15 packages/table/src/lib`
- `pnpm install`
- `pnpm turbo typecheck --filter=./packages/table`
- `pnpm lint:fix`

## Notes
- `pnpm turbo build --filter=./packages/markdown` and `pnpm turbo build --filter=./packages/table` are blocked by an external `rolldown` / Node `20.12.1` `node:util.styleText` failure in transitive build work, not by the package changes here.
- `bun check` was not run before opening this PR because it was explicitly skipped.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This PR is test/doc heavy, and the only runtime change is a narrow markdown fallback fix covered by package tests.
