### PR TITLE
feat: improve skill scores across 84 agent skills

### DIFF
--- a/.claude/skills/components/SKILL.md
+++ b/.claude/skills/components/SKILL.md
@@ -1,6 +1,22 @@
 ---
 name: components
-description: React component architecture for creating composable, accessible components with data attributes. Use when creating/updating composable components, not for higher-level feature/page components.
+description: >-
+  React component architecture for building composable, accessible UI components
+  with data attributes in the Plate design system. Covers accessibility
+  principles (semantic HTML, keyboard navigation, ARIA patterns, focus
+  management), component composition patterns, and data attribute conventions.
+  Use when creating or updating low-level composable components, implementing
+  accessibility features, or reviewing component architecture. Not for
+  higher-level feature pages, application routing, or non-UI utilities.
 ---
+
+## Overview
+
+Comprehensive guide to building accessible, composable React components for the
+Plate component library. Covers core accessibility principles (semantic HTML
+first, keyboard navigation, screen reader support, visual accessibility), ARIA
+patterns and common attributes, component composition with data attributes, and
+focus management strategies. Serves as the reference for all low-level UI
+component work in the Plate design system.
 
 @.claude/skills/components/components.mdc

--- a/.claude/skills/internal-workspace-devdeps-hoist/SKILL.md
+++ b/.claude/skills/internal-workspace-devdeps-hoist/SKILL.md
@@ -1,6 +1,20 @@
 ---
 name: internal-workspace-devdeps-hoist
-description: 'Skill: internal-workspace-devdeps-hoist'
+description: >-
+  Manages internal workspace devDependency hoisting in the Plate monorepo. Use
+  when removing internal @platejs/* devDependencies from individual packages,
+  hoisting shared workspace tooling deps to the root package.json, or debugging
+  typecheck failures caused by missing internal dev deps. Not for managing
+  external third-party dependencies or production dependencies.
 ---
+
+## Overview
+
+Internal `@platejs/*` devDependencies in individual `packages/*/package.json`
+files should be removed and hoisted to root `package.json` with `workspace:^`.
+This prevents typecheck resolution failures (e.g. `@platejs/combobox` breaking
+via `@platejs/test-utils`) and keeps the dependency graph clean. Includes a
+verification checklist: scan for remaining internal devDeps, then run `pnpm
+install`, `bun typecheck`, and `bun lint:fix`.
 
 @.claude/skills/internal-workspace-devdeps-hoist/internal-workspace-devdeps-hoist.mdc

--- a/.claude/skills/react/SKILL.md
+++ b/.claude/skills/react/SKILL.md
@@ -1,6 +1,16 @@
 ---
 name: react
-description: 'Skill: react'
+description: >-
+  React component patterns for Plate including destructured props, compiler
+  optimization, Effects usage, and Tailwind v4 syntax. Use when writing or
+  reviewing React components in .tsx files or editing globals.css. Not intended
+  for non-React utilities, Node.js scripts, or backend logic.
 ---
+
+## Overview
+
+Defines the standard React patterns for this codebase: destructured props over
+props objects, React compiler optimization conventions, correct Effects usage,
+and Tailwind v4 class syntax. Applies to all `.tsx` files and `globals.css`.
 
 @.claude/skills/react/react.mdc

--- a/.claude/skills/shadcn-parity/SKILL.md
+++ b/.claude/skills/shadcn-parity/SKILL.md
@@ -1,6 +1,24 @@
 ---
 name: shadcn-parity
-description: Clone shadcn implementation patterns with source-by-source parity. Use when the user says "shadcn parity", asks to mirror shadcn, copy shadcn UX/architecture/tests, or wants more than inspiration.
+description: >-
+  Maintains source-level parity with upstream shadcn/ui for Plate's registry,
+  templates, and component patterns. Covers ownership boundaries (shadcn owns
+  schema/resolver/CLI; Plate owns registry content/build/delivery), registry
+  item rules, template alignment, namespace semantics, and known divergences.
+  Use when the user says "shadcn parity", asks to mirror shadcn behavior, copy
+  shadcn UX/architecture, or when modifying registry items, template
+  components.json, or build scripts. Not for general component styling or
+  features unrelated to shadcn compatibility.
 ---
+
+## Overview
+
+Defines the contract between Plate and upstream shadcn/ui: shadcn owns the
+registry item schema, namespace semantics, resolver behavior, and CLI; Plate
+owns the registry content, build pipeline, and template sync tooling. Registry
+items must match upstream `RegistryItem` shape, prefer `@shadcn/*` dependencies
+when available, and follow upstream file/layout patterns. Includes rules for
+template alignment, local sync behavior, current known divergences, and red
+flags that signal incorrect approaches.
 
 @.claude/skills/shadcn-parity/shadcn-parity.mdc

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,6 +1,20 @@
 ---
 name: testing
-description: 'Skill: testing'
+description: >-
+  Testing strategy and conventions for Plate packages using Bun as the test
+  runner. Covers three-layer test architecture (unit, contract, golden I/O),
+  seam selection (createEditor vs createSlateEditor vs createPlateEditor), file
+  organization, fixture patterns, and cleanup heuristics. Use when writing,
+  reviewing, or refactoring tests in any Plate package. Not for browser or e2e
+  testing.
 ---
+
+## Overview
+
+Establishes the Plate testing philosophy: Bun-first speed, three test layers
+(pure unit, thin editor/plugin contract, golden I/O), and strict seam selection
+rules. Covers file organization conventions, fixture and assertion patterns,
+package-specific rules (autoformat, markdown, ai, core, slate, selection, docx),
+and cleanup heuristics for maintaining test quality over time.
 
 @.claude/skills/testing/testing.mdc

--- a/.claude/skills/vercel-react-best-practices/SKILL.md
+++ b/.claude/skills/vercel-react-best-practices/SKILL.md
@@ -1,10 +1,29 @@
 ---
 name: vercel-react-best-practices
-description: React and Next.js performance optimization guidelines from Vercel Engineering. This skill should be used when writing, reviewing, or refactoring React/Next.js code to ensure optimal performance patterns. Triggers on tasks involving React components, Next.js pages, data fetching, bundle optimization, or performance improvements.
+description: >-
+  React and Next.js performance optimization guidelines from Vercel Engineering
+  covering 45 rules across 8 priority categories: eliminating waterfalls,
+  bundle size optimization, server-side performance, client-side data fetching,
+  re-render optimization, rendering performance, JavaScript performance, and
+  advanced patterns. Use when writing, reviewing, or refactoring React/Next.js
+  components, optimizing data fetching, reducing bundle size, or improving load
+  times. Not for non-React code, backend-only services, or infrastructure
+  configuration.
 license: MIT
 metadata:
   author: vercel
   version: 1.0.0
 ---
+
+## Overview
+
+A prioritized catalog of 45 performance rules for React and Next.js from Vercel
+Engineering, organized by impact level. Critical rules cover async waterfall
+elimination (Promise.all, Suspense boundaries, deferred awaits) and bundle size
+reduction (tree-shaking barrel imports, dynamic imports, deferred third-party
+scripts). High-impact rules address server-side caching (React.cache, LRU) and
+data serialization. Medium rules cover re-render optimization (memoization,
+derived state, transitions) and rendering patterns (content-visibility, SVG
+precision, hydration). Each rule includes incorrect/correct code examples.
 
 @.claude/skills/vercel-react-best-practices/vercel-react-best-practices.mdc

--- a/.claude/skills/vercel-root-directory-cli/SKILL.md
+++ b/.claude/skills/vercel-root-directory-cli/SKILL.md
@@ -1,6 +1,19 @@
 ---
 name: vercel-root-directory-cli
-description: 'Skill: vercel-root-directory-cli'
+description: >-
+  Diagnoses and fixes Vercel CLI deploy failures caused by Root Directory
+  misconfiguration in monorepos. Use when "vercel deploy" fails with
+  "vercel.json file should be inside of the provided root directory" or when
+  vercel.json placement conflicts with the project Root Directory setting. Not
+  for general Vercel build errors or application-level deployment issues.
 ---
+
+## Overview
+
+Explains why `vercel build` can succeed while `vercel deploy` fails in a
+monorepo: the Vercel project Root Directory is a subdirectory (e.g. `apps/www`)
+but `vercel.json` sits at the repo root. Provides a diagnostic checklist using
+`vercel project inspect` and two resolution paths (move the config or change the
+Root Directory setting).
 
 @.claude/skills/vercel-root-directory-cli/vercel-root-directory-cli.mdc

--- a/.claude/skills/writing-changesets/SKILL.md
+++ b/.claude/skills/writing-changesets/SKILL.md
@@ -1,6 +1,23 @@
 ---
 name: writing-changesets
-description: Use when creating changeset files for Plate releases
+description: >-
+  Changeset authoring conventions for Plate package releases following Radix UI
+  style. Covers file naming, YAML frontmatter structure, imperative voice,
+  one-package-per-file rule, and the critical constraint that core packages
+  (@platejs/slate, @platejs/core, platejs) must use patch not minor to avoid
+  version cascade. Use when creating .changeset/*.md files, documenting package
+  changes, or writing registry changelog entries. Not for commit messages, PR
+  descriptions, or internal documentation.
 ---
+
+## Overview
+
+Defines how to write changeset files for Plate releases: one package per file,
+imperative voice (Add/Fix/Remove, not past tense), bold for package and plugin
+names, minimal code examples for API changes only, and a strict rule that core
+dependency changesets must use `patch` instead of `minor` to prevent cascade
+bumps across all dependent packages. Includes templates for simple fixes, API
+changes, and breaking changes, plus a red-flags checklist to verify before
+submitting.
 
 @.claude/skills/writing-changesets/writing-changesets.mdc

--- a/.codex/skills/agent-native-audit/SKILL.md
+++ b/.codex/skills/agent-native-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-native-audit
-description: Run comprehensive agent-native architecture review with scored principles
+description: Runs a comprehensive agent-native architecture review by launching 8 parallel sub-agents, each auditing one core principle (Action Parity, Tools as Primitives, Context Injection, Shared Workspace, CRUD Completeness, UI Integration, Capability Discovery, Prompt-Native Features). Produces scored tables and prioritized recommendations. Use when evaluating how well a codebase supports agent-driven interaction, or auditing a specific principle. Trigger terms include "agent audit", "agent-native review", "architecture audit", "agent parity check".
 argument-hint: '[optional: specific principle to audit]'
 disable-model-invocation: true
 ---

--- a/.codex/skills/agent-native-reviewer/SKILL.md
+++ b/.codex/skills/agent-native-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-native-reviewer
-description: Reviews code to ensure agent-native parity — any action a user can take, an agent can also take. Use after adding UI features, agent tools, or system prompts.
+description: Reviews code to ensure agent-native parity — any action a user can take, an agent can also take. Checks action parity, context parity, shared workspace architecture, tool design (primitives over workflows), and dynamic context injection. Use after adding UI features, agent tools, or system prompts, or during periodic architecture audits to ensure agents are first-class citizens.
 model: inherit
 ---
 

--- a/.codex/skills/ankane-readme-writer/SKILL.md
+++ b/.codex/skills/ankane-readme-writer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ankane-readme-writer
-description: Creates or updates README files following Ankane-style template for Ruby gems. Use when writing gem documentation with imperative voice, concise prose, and standard section ordering.
+description: Creates or updates README files following the Ankane-style template for Ruby gems, enforcing imperative voice, 15-word sentence limits, standard section ordering (Header, Installation, Quick Start, Usage, Options, Contributing, License), and single-purpose code fences. Use when writing gem documentation, reformatting an existing README to Ankane style, or creating a new Ruby gem README from scratch.
 color: cyan
 model: inherit
 ---

--- a/.codex/skills/architecture-strategist/SKILL.md
+++ b/.codex/skills/architecture-strategist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architecture-strategist
-description: Analyzes code changes from an architectural perspective for pattern compliance and design integrity. Use when reviewing PRs, adding services, or evaluating structural refactors.
+description: Analyzes code changes from an architectural perspective, checking pattern compliance, SOLID principles, coupling metrics, dependency boundaries, and design integrity. Produces structured reports covering architecture overview, change assessment, compliance checks, risk analysis, and recommendations. Use when reviewing PRs, adding services, evaluating structural refactors, or checking for architectural anti-patterns. Trigger terms include "architecture review", "design review", "structural analysis", "architecture strategist".
 model: inherit
 ---
 

--- a/.codex/skills/best-practices-researcher/SKILL.md
+++ b/.codex/skills/best-practices-researcher/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: best-practices-researcher
-description: Researches and synthesizes external best practices, documentation, and examples for any technology or framework. Use when you need industry standards, community conventions, or implementation guidance.
+description: Researches and synthesizes best practices by first checking available skills for curated guidance, verifying API deprecations, then gathering official documentation and community examples. Use when you need industry standards, community conventions, implementation guidance, or want to validate an approach against current best practices for any technology or framework.
 model: inherit
 ---
 

--- a/.codex/skills/bug-reproduction-validator/SKILL.md
+++ b/.codex/skills/bug-reproduction-validator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bug-reproduction-validator
-description: Systematically reproduces and validates bug reports to confirm whether reported behavior is an actual bug. Use when you receive a bug report or issue that needs verification.
+description: Systematically reproduces and validates bug reports to confirm whether reported behavior is an actual bug. Extracts reproduction steps, sets up minimal test cases, classifies issues, and produces structured validation reports. Use when a bug report, issue ticket, or user-reported defect needs verification, reproduction, or root-cause triage.
 model: inherit
 ---
 

--- a/.codex/skills/ce-brainstorm/SKILL.md
+++ b/.codex/skills/ce-brainstorm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-brainstorm
-description: Explore requirements and approaches through collaborative dialogue before planning implementation
+description: Explores feature requirements and design approaches through structured collaborative dialogue before planning. Assesses clarity, conducts repo research, asks questions one at a time, proposes 2-3 approaches, and captures decisions in a brainstorm document under docs/brainstorms/. Use when a feature idea needs exploration, requirements are unclear, or multiple approaches should be evaluated before planning. Trigger terms include "brainstorm", "explore idea", "ce brainstorm", "what should we build".
 argument-hint: '[feature idea or problem to explore]'
 ---
 

--- a/.codex/skills/ce-compound/SKILL.md
+++ b/.codex/skills/ce-compound/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-compound
-description: Document a recently solved problem to compound your team's knowledge
+description: Documents a recently solved problem to compound team knowledge by coordinating 5 parallel sub-agents (context analyzer, solution extractor, related docs finder, prevention strategist, category classifier) and assembling structured documentation in docs/solutions/. Includes context budget checks and a compact-safe mode for constrained sessions. Use when a non-trivial problem has been solved and the solution should be captured for future reference. Trigger terms include "compound", "document fix", "capture solution", "it's fixed", "problem solved", "ce compound".
 argument-hint: '[optional: brief context about the fix]'
 ---
 

--- a/.codex/skills/ce-plan/SKILL.md
+++ b/.codex/skills/ce-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-plan
-description: Transform feature descriptions into well-structured project plans following conventions
+description: Transforms feature descriptions, bug reports, or improvement ideas into well-structured markdown plan files under docs/plans/. Runs local and optional external research, performs SpecFlow analysis, supports three detail levels (minimal, standard, comprehensive), and offers post-generation options including deepen-plan, issue creation, and ce:work handoff. Use when a feature, fix, or refactor needs a structured plan before implementation. Trigger terms include "ce plan", "create plan", "plan feature", "write plan", "plan bug fix".
 argument-hint: '[feature description, bug report, or improvement idea]'
 ---
 

--- a/.codex/skills/ce-review/SKILL.md
+++ b/.codex/skills/ce-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-review
-description: Perform exhaustive code reviews using multi-agent analysis, ultra-thinking, and worktrees
+description: Performs exhaustive code reviews on pull requests or branches using parallel multi-agent analysis, ultra-thinking deep dives, and Git worktrees for isolated inspection. Synthesizes findings from security, performance, architecture, and quality agents into prioritized todo files (P1/P2/P3). Supports serial mode for long sessions. Trigger terms: "code review", "review PR", "review branch", "ce review", "pull request review". Use when a PR or branch needs thorough multi-perspective code review before merge.
 argument-hint: '[PR number, GitHub URL, branch name, or latest] [--serial]'
 ---
 
@@ -341,44 +341,7 @@ Sub-agents can:
 
 5. Follow template structure from file-todos skill: `.claude/skills/file-todos/assets/todo-template.md`
 
-**Todo File Structure (from template):**
-
-Each todo must include:
-
-- **YAML frontmatter**: status, priority, issue_id, tags, dependencies
-- **Problem Statement**: What's broken/missing, why it matters
-- **Findings**: Discoveries from agents with evidence/location
-- **Proposed Solutions**: 2-3 options, each with pros/cons/effort/risk
-- **Recommended Action**: (Filled during triage, leave blank initially)
-- **Technical Details**: Affected files, components, database changes
-- **Acceptance Criteria**: Testable checklist items
-- **Work Log**: Dated record with actions and learnings
-- **Resources**: Links to PR, issues, documentation, similar patterns
-
-**File naming convention:**
-
-```
-{issue_id}-{status}-{priority}-{description}.md
-
-Examples:
-- 001-pending-p1-security-vulnerability.md
-- 002-pending-p2-performance-optimization.md
-- 003-pending-p3-code-cleanup.md
-```
-
-**Status values:**
-
-- `pending` - New findings, needs triage/decision
-- `ready` - Approved by manager, ready to work
-- `complete` - Work finished
-
-**Priority values:**
-
-- `p1` - Critical (blocks merge, security/data issues)
-- `p2` - Important (should fix, architectural/performance)
-- `p3` - Nice-to-have (enhancements, cleanup)
-
-**Tagging:** Always add `code-review` tag, plus: `security`, `performance`, `architecture`, `rails`, `quality`, etc.
+**Todo File Structure:** Follow the template at `.claude/skills/file-todos/assets/todo-template.md`. Each file uses `{issue_id}-{status}-{priority}-{description}.md` naming (e.g., `001-pending-p1-security-vulnerability.md`). Status: `pending` / `ready` / `complete`. Priority: `p1` (critical) / `p2` (important) / `p3` (nice-to-have). Always tag with `code-review` plus relevant domain tags.
 
 #### Step 3: Summary Report
 
@@ -446,113 +409,20 @@ After creating all todo files, present comprehensive summary:
    - Update Work Log as you work
    - Commit todos: `git add todos/ && git commit -m "refactor: add code review findings"`
 
-### Severity Breakdown:
-
-**🔴 P1 (Critical - Blocks Merge):**
-
-- Security vulnerabilities
-- Data corruption risks
-- Breaking changes
-- Critical architectural issues
-
-**🟡 P2 (Important - Should Fix):**
-
-- Performance issues
-- Significant architectural concerns
-- Major code quality problems
-- Reliability issues
-
-**🔵 P3 (Nice-to-Have):**
-
-- Minor improvements
-- Code cleanup
-- Optimization opportunities
-- Documentation updates
 ````
 
 ### 6. End-to-End Testing (Optional)
 
-<detect_project_type>
+Detect project type from PR files and offer appropriate testing:
 
-**First, detect the project type from PR files:**
+| Indicator | Type | Command |
+|-----------|------|---------|
+| `*.xcodeproj`, `Package.swift` | iOS/macOS | `/xcode-test` |
+| `package.json`, `app/views/*` | Web | `/test-browser` |
+| Both | Hybrid | Both commands |
 
-| Indicator | Project Type |
-|-----------|--------------|
-| `*.xcodeproj`, `*.xcworkspace`, `Package.swift` (iOS) | iOS/macOS |
-| `Gemfile`, `package.json`, `app/views/*`, `*.html.*` | Web |
-| Both iOS files AND web files | Hybrid (test both) |
-
-</detect_project_type>
-
-<offer_testing>
-
-After presenting the Summary Report, offer appropriate testing based on project type:
-
-**For Web Projects:**
-```markdown
-**"Want to run browser tests on the affected pages?"**
-1. Yes - run `/test-browser`
-2. No - skip
-```
-
-**For iOS Projects:**
-```markdown
-**"Want to run Xcode simulator tests on the app?"**
-1. Yes - run `/xcode-test`
-2. No - skip
-```
-
-**For Hybrid Projects (e.g., Rails + Hotwire Native):**
-```markdown
-**"Want to run end-to-end tests?"**
-1. Web only - run `/test-browser`
-2. iOS only - run `/xcode-test`
-3. Both - run both commands
-4. No - skip
-```
-
-</offer_testing>
-
-#### If User Accepts Web Testing:
-
-Spawn a subagent to run browser tests (preserves main context):
-
-```
-Task general-purpose("Run /test-browser for PR #[number]. Test all affected pages, check for console errors, handle failures by creating todos and fixing.")
-```
-
-The subagent will:
-1. Identify pages affected by the PR
-2. Navigate to each page and capture snapshots (using Playwright MCP or agent-browser CLI)
-3. Check for console errors
-4. Test critical interactions
-5. Pause for human verification on OAuth/email/payment flows
-6. Create P1 todos for any failures
-7. Fix and retry until all tests pass
-
-**Standalone:** `/test-browser [PR number]`
-
-#### If User Accepts iOS Testing:
-
-Spawn a subagent to run Xcode tests (preserves main context):
-
-```
-Task general-purpose("Run /xcode-test for scheme [name]. Build for simulator, install, launch, take screenshots, check for crashes.")
-```
-
-The subagent will:
-1. Verify XcodeBuildMCP is installed
-2. Discover project and schemes
-3. Build for iOS Simulator
-4. Install and launch app
-5. Take screenshots of key screens
-6. Capture console logs for errors
-7. Pause for human verification (Sign in with Apple, push, IAP)
-8. Create P1 todos for any failures
-9. Fix and retry until all tests pass
-
-**Standalone:** `/xcode-test [scheme]`
+Spawn subagents via `Task general-purpose(...)` for each test type the user accepts. Subagents identify affected pages/screens, run tests, capture snapshots, create P1 todos for failures, and retry until passing.
 
 ### Important: P1 Findings Block Merge
 
-Any **🔴 P1 (CRITICAL)** findings must be addressed before merging the PR. Present these prominently and ensure they're resolved before accepting the PR.
+Any P1 (CRITICAL) findings must be addressed before merging. Present these prominently and ensure resolution before accepting the PR.

--- a/.codex/skills/ce-work/SKILL.md
+++ b/.codex/skills/ce-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-work
-description: Execute work plans efficiently while maintaining quality and finishing features
+description: Executes a work plan by reading the document, setting up a branch or worktree, breaking tasks into todos, implementing with incremental commits, running tests continuously, and shipping a complete PR with post-deploy monitoring. Supports swarm mode for parallel execution of complex plans. Use when a plan exists and implementation should begin, or when executing a specification or todo file. Trigger terms include "ce work", "execute plan", "implement feature", "start building", "ship it".
 argument-hint: '[plan file, specification, or todo file path]'
 ---
 

--- a/.codex/skills/changelog/SKILL.md
+++ b/.codex/skills/changelog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: changelog
-description: Create engaging changelogs for recent merges to main branch
+description: Generates engaging, structured changelogs from recent merges to the main branch. Analyzes PRs via gh CLI, groups by type (breaking, features, fixes, improvements), credits contributors, and optionally posts to Discord. Use when summarizing daily or weekly development activity, creating release notes, or posting team updates. Trigger terms include "changelog", "release notes", "what changed", "daily summary", "weekly summary".
 argument-hint: '[optional: daily|weekly, or time period in days]'
 disable-model-invocation: true
 ---

--- a/.codex/skills/changeset/SKILL.md
+++ b/.codex/skills/changeset/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: changeset
-description: 'Command: changeset'
+description: >-
+  Creates properly formatted changeset files for the Plate editor project following semver
+  conventions. Generates YAML frontmatter with affected packages and change types (major,
+  minor, patch), plus concise Markdown descriptions of user-facing changes. Handles both
+  package changesets and registry changelog updates. Trigger terms: "changeset", "create
+  changeset", "version bump", "changelog", "release notes". Use when a code change to
+  packages/ or apps/www/src/registry/ needs a versioning or changelog entry.
 ---
 
 # How to Create a Plate Project Changeset

--- a/.codex/skills/code-simplicity-reviewer/SKILL.md
+++ b/.codex/skills/code-simplicity-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-simplicity-reviewer
-description: Final review pass to ensure code is as simple and minimal as possible. Use after implementation is complete to identify YAGNI violations and simplification opportunities.
+description: Final review pass to ensure code is as simple and minimal as possible by analyzing every line for necessity, challenging abstractions, removing redundancy, and enforcing YAGNI principles. Use after implementation is complete to identify over-engineering, unnecessary complexity, dead code, premature generalizations, or simplification opportunities.
 model: inherit
 ---
 

--- a/.codex/skills/components/SKILL.md
+++ b/.codex/skills/components/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: components
-description: React component architecture for creating composable, accessible components with data attributes. Use when creating/updating composable components, not for higher-level feature/page components.
+description: React component architecture for creating composable, accessible components with data attributes, variant systems, keyboard navigation, and screen reader support. Use when creating or updating low-level composable UI components with proper ARIA patterns, not for higher-level feature or page components.
 ---
 
 # Accessibility

--- a/.codex/skills/compound-docs/SKILL.md
+++ b/.codex/skills/compound-docs/SKILL.md
@@ -1,12 +1,8 @@
 ---
 name: compound-docs
-description: Capture solved problems as categorized documentation with YAML frontmatter for fast lookup
+description: Capture solved problems as categorized documentation with YAML frontmatter for fast lookup. Use when a problem is solved, a fix is confirmed, or when asked to document a solution, create a knowledge base entry, or run /doc-fix.
 disable-model-invocation: true
-allowed-tools:
-  - Read
-  - Write
-  - Bash
-  - Grep
+allowed-tools: Read, Write, Bash, Grep
 preconditions:
   - Problem has been solved (not in-progress)
   - Solution has been verified working
@@ -424,25 +420,9 @@ Documentation is successful when ALL of the following are true:
 
 ## Quality Guidelines
 
-**Good documentation has:**
+**Include:** exact error messages, file:line references, observable symptoms, failed attempts, technical root cause explanations, code examples (before/after), prevention guidance, and cross-references.
 
-- ✅ Exact error messages (copy-paste from output)
-- ✅ Specific file:line references
-- ✅ Observable symptoms (what you saw, not interpretations)
-- ✅ Failed attempts documented (helps avoid wrong paths)
-- ✅ Technical explanation (not just "what" but "why")
-- ✅ Code examples (before/after if applicable)
-- ✅ Prevention guidance (how to catch early)
-- ✅ Cross-references (related issues)
-
-**Avoid:**
-
-- ❌ Vague descriptions ("something was wrong")
-- ❌ Missing technical details ("fixed the code")
-- ❌ No context (which version? which file?)
-- ❌ Just code dumps (explain why it works)
-- ❌ No prevention guidance
-- ❌ No cross-references
+**Avoid:** vague descriptions, missing technical details, no context (version/file), unexplained code dumps, missing prevention guidance or cross-references.
 
 ---
 
@@ -450,62 +430,4 @@ Documentation is successful when ALL of the following are true:
 
 **User:** "That worked! The N+1 query is fixed."
 
-**Skill activates:**
-
-1. **Detect confirmation:** "That worked!" triggers auto-invoke
-2. **Gather context:**
-   - Module: Brief System
-   - Symptom: Brief generation taking >5 seconds, N+1 query when loading email threads
-   - Failed attempts: Added pagination (didn't help), checked background job performance
-   - Solution: Added eager loading with `includes(:emails)` on Brief model
-   - Root cause: Missing eager loading causing separate database query per email thread
-3. **Check existing:** No similar issue found
-4. **Generate filename:** `n-plus-one-brief-generation-BriefSystem-20251110.md`
-5. **Validate YAML:**
-   ```yaml
-   module: Brief System
-   date: 2025-11-10
-   problem_type: performance_issue
-   component: rails_model
-   symptoms:
-     - "N+1 query when loading email threads"
-     - "Brief generation taking >5 seconds"
-   root_cause: missing_include
-   severity: high
-   tags: [n-plus-one, eager-loading, performance]
-   ```
-   ✅ Valid
-6. **Create documentation:**
-   - `docs/solutions/performance-issues/n-plus-one-brief-generation-BriefSystem-20251110.md`
-7. **Cross-reference:** None needed (no similar issues)
-
-**Output:**
-
-```
-✓ Solution documented
-
-File created:
-- docs/solutions/performance-issues/n-plus-one-brief-generation-BriefSystem-20251110.md
-
-What's next?
-1. Continue workflow (recommended)
-2. Add to Required Reading - Promote to critical patterns (critical-patterns.md)
-3. Link related issues - Connect to similar problems
-4. Add to existing skill - Add to a learning skill (e.g., hotwire-native)
-5. Create new skill - Extract into new learning skill
-6. View documentation - See what was captured
-7. Other
-```
-
----
-
-## Future Enhancements
-
-**Not in Phase 7 scope, but potential:**
-
-- Search by date range
-- Filter by severity
-- Tag-based search interface
-- Metrics (most common issues, resolution time)
-- Export to shareable format (community knowledge sharing)
-- Import community solutions
+**Skill activates:** Detects confirmation phrase, gathers context (module, symptom, failed attempts, solution, root cause), checks for existing docs, generates filename `n-plus-one-brief-generation-BriefSystem-20251110.md`, validates YAML (problem_type: performance_issue, severity: high), creates doc at `docs/solutions/performance-issues/`, then presents decision menu.

--- a/.codex/skills/compound-engineering-every-style-editor/SKILL.md
+++ b/.codex/skills/compound-engineering-every-style-editor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: compound-engineering-every-style-editor
-description: This skill should be used when reviewing or editing copy to ensure adherence to Every's style guide. It provides a systematic line-by-line review process for grammar, punctuation, mechanics, and style guide compliance.
+description: This skill should be used when reviewing or editing copy to ensure adherence to Every's style guide. It performs a systematic four-phase review — initial assessment, detailed line edit, mechanical review, and recommendations — checking grammar, punctuation, capitalization, number formatting, and style guide compliance. Use when proofreading articles, blog posts, newsletters, or preparing clean copy for editorial review against Every's conventions.
 ---
 
 # Every Style Editor

--- a/.codex/skills/create-agent-skill/SKILL.md
+++ b/.codex/skills/create-agent-skill/SKILL.md
@@ -1,9 +1,31 @@
 ---
 name: create-agent-skill
-description: Create or edit Claude Code skills with expert guidance on structure and best practices
+description: Creates or edits Claude Code agent skill files (SKILL.md) with proper YAML frontmatter, structured content sections, and best-practice patterns. Accepts a skill description or requirements and delegates to the create-agent-skills sub-skill. Trigger terms: "create skill", "new skill", "edit skill", "skill template", "agent skill". Use when the user wants to scaffold, author, or refine an agent skill definition.
 allowed-tools: Skill(create-agent-skills)
 argument-hint: '[skill description or requirements]'
 disable-model-invocation: true
 ---
 
+# Create or Edit Agent Skill
+
+## Overview
+
+Delegates to the `create-agent-skills` sub-skill to produce a well-structured SKILL.md file.
+The sub-skill handles YAML frontmatter generation, content scaffolding, and best-practice
+validation.
+
+## Workflow
+
+1. **Receive requirements** -- the user provides a skill description or requirements via `$ARGUMENTS`.
+2. **Delegate** -- invoke the `create-agent-skills` skill with the provided input.
+3. **Output** -- return the generated or updated SKILL.md content.
+
+## Invocation
+
 Invoke the create-agent-skills skill for: $ARGUMENTS
+
+## Example
+
+```
+/create-agent-skill "A skill that lints Markdown files and reports issues"
+```

--- a/.codex/skills/create-app-design/SKILL.md
+++ b/.codex/skills/create-app-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
-allowed-tools: Read, Glob, Grep, Write, MultiEdit, TodoWrite
-description: Generate comprehensive app design document with project stage assessment
 name: create-app-design
+description: Generates a comprehensive Application Design Document by analyzing the codebase, assessing the project stage (Pre-MVP/MVP/Production/Enterprise), and running an interactive Q&A session. Produces a technology-agnostic design doc covering architecture, features, user experience, and business logic. Saves output to .claude/skills/1-app-design-document.mdc. Trigger terms: "app design", "design document", "architecture doc", "create design doc", "application overview". Use when the project needs a high-level design document for stakeholders, new developers, or architectural planning.
+allowed-tools: Read, Glob, Grep, Write, MultiEdit, TodoWrite
 ---
 
 # Generate Application Design Document

--- a/.codex/skills/create-tech-stack/SKILL.md
+++ b/.codex/skills/create-tech-stack/SKILL.md
@@ -1,7 +1,7 @@
 ---
-allowed-tools: Read, Glob, Grep, Write, MultiEdit, TodoWrite, Bash
-description: Generate comprehensive technical stack documentation from codebase analysis
 name: create-tech-stack
+description: Generates comprehensive Tech Stack documentation by parsing package.json, configuration files, and codebase patterns. Detects frameworks, databases, testing tools, CI/CD setup, and deployment configs. Runs an interactive Q&A for non-discoverable infrastructure details. Saves output to .claude/skills/2-tech-stack.mdc with exact version numbers and config examples. Trigger terms: "tech stack", "create tech stack", "document dependencies", "stack documentation", "technology overview". Use when the project needs technical onboarding documentation or a comprehensive technology inventory.
+allowed-tools: Read, Glob, Grep, Write, MultiEdit, TodoWrite, Bash
 ---
 
 # Generate Tech Stack Documentation

--- a/.codex/skills/deepen-plan/SKILL.md
+++ b/.codex/skills/deepen-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deepen-plan
-description: Enhance a plan with parallel research agents for each section to add depth, best practices, and implementation details
+description: Enhances an existing plan file by launching parallel research sub-agents for each section to add best practices, performance optimizations, edge-case handling, and concrete implementation details. Discovers and applies all available skills, learnings from docs/solutions/, and review agents against the plan content. Trigger terms: "deepen plan", "enhance plan", "research plan", "add detail to plan", "enrich plan". Use when an existing plan from /ce:plan needs deeper research grounding before implementation begins.
 argument-hint: '[path to plan file]'
 ---
 
@@ -148,122 +148,21 @@ Task general-purpose: "Use the security-patterns skill at ~/.claude/skills/secur
 Check for documented learnings from /ce:compound. These are solved problems stored as markdown files. Spawn a sub-agent for each learning to check if it's relevant.
 </thinking>
 
-**LEARNINGS LOCATION - Check these exact folders:**
+**Learnings locations** (check in order): `docs/solutions/`, `.claude/docs/`, `~/.claude/docs/`
+
+**Process:**
+1. Find all `.md` files in learnings directories
+2. Read frontmatter (tags, category, module, symptom) of each file
+3. Filter by relevance: match tags/category/module against plan content. Skip clearly unrelated learnings (e.g., skip database learnings for frontend-only plans)
+4. Spawn parallel sub-agents for each relevant learning:
 
 ```
-docs/solutions/           <-- PRIMARY: Project-level learnings (created by /ce:compound)
-├── performance-issues/
-│   └── *.md
-├── debugging-patterns/
-│   └── *.md
-├── configuration-fixes/
-│   └── *.md
-├── integration-issues/
-│   └── *.md
-├── deployment-issues/
-│   └── *.md
-└── [other-categories]/
-    └── *.md
+Task general-purpose: "Read [learning path]. Check if it applies to this plan: [plan content].
+If relevant: explain how, quote key insight, suggest incorporation.
+If not: say 'Not applicable: [reason]'"
 ```
 
-**Step 1: Find ALL learning markdown files**
-
-Run these commands to get every learning file:
-
-```bash
-# PRIMARY LOCATION - Project learnings
-find docs/solutions -name "*.md" -type f 2>/dev/null
-
-# If docs/solutions doesn't exist, check alternate locations:
-find .claude/docs -name "*.md" -type f 2>/dev/null
-find ~/.claude/docs -name "*.md" -type f 2>/dev/null
-```
-
-**Step 2: Read frontmatter of each learning to filter**
-
-Each learning file has YAML frontmatter with metadata. Read the first ~20 lines of each file to get:
-
-```yaml
----
-title: "N+1 Query Fix for Briefs"
-category: performance-issues
-tags: [activerecord, n-plus-one, includes, eager-loading]
-module: Briefs
-symptom: "Slow page load, multiple queries in logs"
-root_cause: "Missing includes on association"
----
-```
-
-**For each .md file, quickly scan its frontmatter:**
-
-```bash
-# Read first 20 lines of each learning (frontmatter + summary)
-head -20 docs/solutions/**/*.md
-```
-
-**Step 3: Filter - only spawn sub-agents for LIKELY relevant learnings**
-
-Compare each learning's frontmatter against the plan:
-- `tags:` - Do any tags match technologies/patterns in the plan?
-- `category:` - Is this category relevant? (e.g., skip deployment-issues if plan is UI-only)
-- `module:` - Does the plan touch this module?
-- `symptom:` / `root_cause:` - Could this problem occur with the plan?
-
-**SKIP learnings that are clearly not applicable:**
-- Plan is frontend-only → skip `database-migrations/` learnings
-- Plan is Python → skip `rails-specific/` learnings
-- Plan has no auth → skip `authentication-issues/` learnings
-
-**SPAWN sub-agents for learnings that MIGHT apply:**
-- Any tag overlap with plan technologies
-- Same category as plan domain
-- Similar patterns or concerns
-
-**Step 4: Spawn sub-agents for filtered learnings**
-
-For each learning that passes the filter:
-
-```
-Task general-purpose: "
-LEARNING FILE: [full path to .md file]
-
-1. Read this learning file completely
-2. This learning documents a previously solved problem
-
-Check if this learning applies to this plan:
-
----
-[full plan content]
----
-
-If relevant:
-- Explain specifically how it applies
-- Quote the key insight or solution
-- Suggest where/how to incorporate it
-
-If NOT relevant after deeper analysis:
-- Say 'Not applicable: [reason]'
-"
-```
-
-**Example filtering:**
-```
-# Found 15 learning files, plan is about "Rails API caching"
-
-# SPAWN (likely relevant):
-docs/solutions/performance-issues/n-plus-one-queries.md      # tags: [activerecord] ✓
-docs/solutions/performance-issues/redis-cache-stampede.md    # tags: [caching, redis] ✓
-docs/solutions/configuration-fixes/redis-connection-pool.md  # tags: [redis] ✓
-
-# SKIP (clearly not applicable):
-docs/solutions/deployment-issues/heroku-memory-quota.md      # not about caching
-docs/solutions/frontend-issues/stimulus-race-condition.md    # plan is API, not frontend
-docs/solutions/authentication-issues/jwt-expiry.md           # plan has no auth
-```
-
-**Spawn sub-agents in PARALLEL for all filtered learnings.**
-
-**These learnings are institutional knowledge - applying them prevents repeating past mistakes.**
+These learnings are institutional knowledge -- applying them prevents repeating past mistakes.
 
 ### 4. Launch Per-Section Research Agents
 
@@ -301,65 +200,17 @@ Search for recent (2024-2026) articles, blog posts, and documentation on topics 
 Dynamically discover every available agent and run them ALL against the plan. Don't filter, don't skip, don't assume relevance. 40+ parallel agents is fine. Use everything available.
 </thinking>
 
-**Step 1: Discover ALL available agents from ALL sources**
+**Discover agents from ALL sources:** `.claude/agents/`, `~/.claude/agents/`, all plugin caches (`~/.claude/plugins/cache/*/...`), and local plugins from `installed_plugins.json`.
 
-```bash
-# 1. Project-local agents (highest priority - project-specific)
-find .claude/agents -name "*.md" 2>/dev/null
+For compound-engineering plugin: USE `review/`, `research/`, `design/`, `docs/` agents. SKIP `workflow/` agents.
 
-# 2. User's global agents (~/.claude/)
-find ~/.claude/agents -name "*.md" 2>/dev/null
-
-# 3. compound-engineering plugin agents (all subdirectories)
-find ~/.claude/plugins/cache/*/compound-engineering/*/agents -name "*.md" 2>/dev/null
-
-# 4. ALL other installed plugins - check every plugin for agents
-find ~/.claude/plugins/cache -path "*/agents/*.md" 2>/dev/null
-
-# 5. Check installed_plugins.json to find all plugin locations
-cat ~/.claude/plugins/installed_plugins.json
-
-# 6. For local plugins (isLocal: true), check their source directories
-# Parse installed_plugins.json and find local plugin paths
-```
-
-**Important:** Check EVERY source. Include agents from:
-- Project `.claude/agents/`
-- User's `~/.claude/agents/`
-- compound-engineering plugin (but SKIP workflow/ agents - only use review/, research/, design/, docs/)
-- ALL other installed plugins (agent-sdk-dev, frontend-design, etc.)
-- Any local plugins
-
-**For compound-engineering plugin specifically:**
-- USE: `agents/review/*` (all reviewers)
-- USE: `agents/research/*` (all researchers)
-- USE: `agents/design/*` (design agents)
-- USE: `agents/docs/*` (documentation agents)
-- SKIP: `agents/workflow/*` (these are workflow orchestrators, not reviewers)
-
-**Step 2: For each discovered agent, read its description**
-
-Read the first few lines of each agent file to understand what it reviews/analyzes.
-
-**Step 3: Launch ALL agents in parallel**
-
-For EVERY agent discovered, launch a Task in parallel:
+**Launch ALL discovered agents in parallel** -- do NOT filter by relevance. Let each agent decide applicability. 20-40+ parallel agents is fine. Goal is maximum coverage.
 
 ```
-Task [agent-name]: "Review this plan using your expertise. Apply all your checks and patterns. Plan content: [full plan content]"
+Task [agent-name]: "Review this plan using your expertise. Apply all checks and patterns. Plan content: [full plan]"
 ```
 
-**CRITICAL RULES:**
-- Do NOT filter agents by "relevance" - run them ALL
-- Do NOT skip agents because they "might not apply" - let them decide
-- Launch ALL agents in a SINGLE message with multiple Task tool calls
-- 20, 30, 40 parallel agents is fine - use everything
-- Each agent may catch something others miss
-- The goal is MAXIMUM coverage, not efficiency
-
-**Step 4: Also discover and run research agents**
-
-Research agents (like `best-practices-researcher`, `framework-docs-researcher`, `git-history-analyzer`, `repo-research-analyst`) should also be run for relevant plan sections.
+Also run research agents (best-practices-researcher, framework-docs-researcher, etc.) for relevant plan sections.
 
 ### 6. Wait for ALL Agents and Synthesize Everything
 
@@ -492,53 +343,8 @@ Based on selection:
 
 ## Example Enhancement
 
-**Before (from /workflows:plan):**
-```markdown
-## Technical Approach
+**Before:** `"Use React Query for data fetching with optimistic updates."`
 
-Use React Query for data fetching with optimistic updates.
-```
-
-**After (from /workflows:deepen-plan):**
-```markdown
-## Technical Approach
-
-Use React Query for data fetching with optimistic updates.
-
-### Research Insights
-
-**Best Practices:**
-- Configure `staleTime` and `cacheTime` based on data freshness requirements
-- Use `queryKey` factories for consistent cache invalidation
-- Implement error boundaries around query-dependent components
-
-**Performance Considerations:**
-- Enable `refetchOnWindowFocus: false` for stable data to reduce unnecessary requests
-- Use `select` option to transform and memoize data at query level
-- Consider `placeholderData` for instant perceived loading
-
-**Implementation Details:**
-```typescript
-// Recommended query configuration
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 5 * 60 * 1000, // 5 minutes
-      retry: 2,
-      refetchOnWindowFocus: false,
-    },
-  },
-});
-```
-
-**Edge Cases:**
-- Handle race conditions with `cancelQueries` on component unmount
-- Implement retry logic for transient network failures
-- Consider offline support with `persistQueryClient`
-
-**References:**
-- https://tanstack.com/query/latest/docs/react/guides/optimistic-updates
-- https://tkdodo.eu/blog/practical-react-query
-```
+**After:** Same content preserved, plus a "Research Insights" subsection with best practices (staleTime/cacheTime config, queryKey factories), performance tips (refetchOnWindowFocus, select option), code examples, edge cases (race conditions, offline support), and reference links.
 
 NEVER CODE! Just research and enhance the plan.

--- a/.codex/skills/deploy-docs/SKILL.md
+++ b/.codex/skills/deploy-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy-docs
-description: Validate and prepare documentation for GitHub Pages deployment
+description: Validates documentation site readiness and prepares it for GitHub Pages deployment by checking HTML pages, JSON configs, component counts, and uncommitted changes. Use when deploying docs, verifying deployment readiness, or setting up a GitHub Pages workflow for the first time.
 disable-model-invocation: true
 ---
 

--- a/.codex/skills/design-iterator/SKILL.md
+++ b/.codex/skills/design-iterator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design-iterator
-description: Iteratively refines UI design through N screenshot-analyze-improve cycles. Use PROACTIVELY when design changes aren't coming together after 1-2 attempts, or when user requests iterative refinement.
+description: Iteratively refines UI design through N screenshot-analyze-improve cycles, making one targeted change per iteration across visual hierarchy, typography, layout, and polish details. Use proactively when design changes are not coming together after 1-2 attempts, when a user requests iterative refinement with a specific count, or when competitor research should inform progressive design improvements.
 color: violet
 model: inherit
 ---

--- a/.codex/skills/dhh-rails-reviewer/SKILL.md
+++ b/.codex/skills/dhh-rails-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dhh-rails-reviewer
-description: Brutally honest Rails code review from DHH's perspective. Use when reviewing Rails code for anti-patterns, JS framework contamination, or violations of Rails conventions.
+description: Brutally honest Rails code review channeling DHH's philosophy of convention over configuration and the majestic monolith. Identifies unnecessary abstractions, JS framework pattern contamination, and deviations from RESTful Rails conventions. Use when reviewing Rails controllers, models, services, or architectural decisions for anti-patterns, overengineering, or violations of Rails conventions.
 model: inherit
 ---
 

--- a/.codex/skills/docs-plugin/SKILL.md
+++ b/.codex/skills/docs-plugin/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: 'Command: docs-plugin'
+description: Generates and structures plugin documentation for the Plate editor framework following headless-first conventions. Produces consistent Kit Usage, Manual Usage, Plugins, API, and Transforms sections with proper formatting. Use when writing docs for a new plugin, updating existing plugin documentation, or standardizing documentation structure across Plate packages. Trigger terms include "document plugin", "plugin docs", "write documentation", "docs-plugin".
 globs: null
 alwaysApply: false
 name: docs-plugin

--- a/.codex/skills/document-review/SKILL.md
+++ b/.codex/skills/document-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: document-review
-description: This skill should be used to refine brainstorm or plan documents before proceeding to the next workflow step. It applies when a brainstorm or plan document exists and the user wants to improve it.
+description: This skill should be used to refine brainstorm or plan documents before proceeding to the next workflow step. It assesses clarity, completeness, specificity, and YAGNI compliance, then auto-fixes minor issues and proposes substantive changes for approval. Use when a brainstorm or plan document exists and needs structured review, simplification, or quality improvement before implementation.
 ---
 
 # Document Review

--- a/.codex/skills/feature-video/SKILL.md
+++ b/.codex/skills/feature-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: feature-video
-description: Record a video walkthrough of a feature and add it to the PR description
+description: Records a video walkthrough of a feature by capturing browser screenshots with agent-browser, assembling them into MP4/GIF via ffmpeg, uploading to cloud storage via rclone, and embedding the result in the PR description. Use when a PR needs a visual demo, or when documenting a feature for reviewers. Trigger terms include "feature video", "record demo", "video walkthrough", "PR video", "demo recording".
 argument-hint: '[PR number or ''current''] [optional: base URL, default localhost:3000]'
 ---
 

--- a/.codex/skills/figma-design-sync/SKILL.md
+++ b/.codex/skills/figma-design-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: figma-design-sync
-description: Detects and fixes visual differences between a web implementation and its Figma design. Use iteratively when syncing implementation to match Figma specs.
+description: Detects and fixes visual differences between a web implementation and its Figma design by capturing screenshots, comparing layout, typography, colors, and spacing, then applying precise CSS/Tailwind corrections. Use when syncing a component or page to match Figma specs, checking pixel-perfect alignment, or iteratively refining design-to-code fidelity.
 model: inherit
 color: purple
 ---

--- a/.codex/skills/framework-docs-researcher/SKILL.md
+++ b/.codex/skills/framework-docs-researcher/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: framework-docs-researcher
-description: Gathers comprehensive documentation and best practices for frameworks, libraries, or dependencies. Use when you need official docs, version-specific constraints, or implementation patterns.
+description: Gathers comprehensive documentation and best practices for frameworks, libraries, or dependencies by querying official docs, checking for deprecations, exploring gem or package source code, and searching GitHub for real-world usage. Use when you need official docs, version-specific constraints, API references, deprecation checks, or implementation patterns for a specific library or framework.
 model: inherit
 ---
 

--- a/.codex/skills/frontend-design-frontend-design/SKILL.md
+++ b/.codex/skills/frontend-design-frontend-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-design-frontend-design
-description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.
+description: Creates distinctive, production-grade frontend interfaces with high design quality, bold aesthetic direction, and polished typography, color, motion, and layout choices. Use when building web components, pages, landing sections, or full applications that need creative, memorable design rather than generic AI aesthetics.
 license: Complete terms in LICENSE.txt
 ---
 

--- a/.codex/skills/frontend-design/SKILL.md
+++ b/.codex/skills/frontend-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-design
-description: This skill should be used when creating distinctive, production-grade frontend interfaces with high design quality. It applies when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.
+description: This skill should be used when creating distinctive, production-grade frontend interfaces with high design quality. It generates creative, polished HTML/CSS/JS, React, or Vue code with bold typography, color, motion, and spatial composition choices. Use when building web components, pages, landing sections, or full applications that need memorable, context-specific design rather than generic AI aesthetics.
 license: Complete terms in LICENSE.txt
 ---
 

--- a/.codex/skills/generate_command/SKILL.md
+++ b/.codex/skills/generate_command/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: generate_command
-description: Create a new custom slash command following conventions and best practices
+name: generate-command
+description: Create custom slash commands in .claude/skills/ with YAML frontmatter, structured workflows, and success criteria. Use when creating new skills, building custom commands, or scaffolding agent automation.
 argument-hint: '[command purpose and requirements]'
 disable-model-invocation: true
 ---

--- a/.codex/skills/git-history-analyzer/SKILL.md
+++ b/.codex/skills/git-history-analyzer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-history-analyzer
-description: Performs archaeological analysis of git history to trace code evolution, identify contributors, and understand why code patterns exist. Use when you need historical context for code changes.
+description: Performs archaeological analysis of git history to trace code evolution, identify contributors, and understand why code patterns exist using git log, git blame, git shortlog, and pickaxe searches. Use when you need historical context for code changes, want to understand why a pattern was introduced, need to map contributor expertise domains, or are investigating the root cause of recurring issues.
 model: inherit
 ---
 

--- a/.codex/skills/git-worktree/SKILL.md
+++ b/.codex/skills/git-worktree/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-worktree
-description: This skill manages Git worktrees for isolated parallel development. It handles creating, listing, switching, and cleaning up worktrees with a simple interactive interface, following KISS principles.
+description: This skill manages Git worktrees for isolated parallel development via the worktree-manager.sh script, handling creating, listing, switching, and cleaning up worktrees with automatic .env file copying and .gitignore management. Use when reviewing PRs in isolation, working on features in parallel, switching between multiple branches simultaneously, or cleaning up completed worktrees.
 ---
 
 # Git Worktree Manager

--- a/.codex/skills/heal-skill/SKILL.md
+++ b/.codex/skills/heal-skill/SKILL.md
@@ -1,12 +1,8 @@
 ---
 name: heal-skill
-description: Fix incorrect SKILL.md files when a skill has wrong instructions or outdated API references
+description: Fix incorrect SKILL.md files when a skill has wrong instructions or outdated API references. Use when a skill failed during execution, has outdated API references, incorrect instructions, or needs corrections based on runtime discovery.
 argument-hint: '[optional: specific issue to fix]'
-allowed-tools:
-  - Read
-  - Edit
-  - Bash(ls:*)
-  - Bash(git:*)
+allowed-tools: Read, Edit, Bash(ls:*), Bash(git:*)
 disable-model-invocation: true
 ---
 

--- a/.codex/skills/install/SKILL.md
+++ b/.codex/skills/install/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Install all dotai registry items in one command
+description: Installs all dotai registry items (dotai, prompt) in one command using the shadcn CLI, and configures a postinstall script for auto-generating agent instructions via skiller. Use when setting up dotai in a project or adding all registry items at once. Trigger terms include "install dotai", "install registry", "setup dotai", "install all".
 allowed-tools: Bash
 name: install
 ---

--- a/.codex/skills/internal-workspace-devdeps-hoist/SKILL.md
+++ b/.codex/skills/internal-workspace-devdeps-hoist/SKILL.md
@@ -1,16 +1,40 @@
 ---
 name: internal-workspace-devdeps-hoist
-description: 'Skill: internal-workspace-devdeps-hoist'
+description: >-
+  Removes internal @platejs/* devDependencies from individual package.json files and hoists
+  shared workspace tooling deps to root package.json with workspace:^ protocol. Verifies
+  changes via pnpm install, typecheck, and lint. Trigger terms: "hoist devdeps", "workspace
+  dependencies", "internal devDependencies", "monorepo deps cleanup". Use when internal
+  platejs devDependencies appear in packages/*/package.json and need consolidation at root.
 ---
 
-# Internal Workspace DevDeps
+# Internal Workspace DevDeps Hoisting
 
-- Remove internal `platejs` / `@platejs/*` `devDependencies` from `packages/*/package.json`.
-- If package-level test or typecheck tooling still needs shared workspace packages, hoist them to the root `package.json` `devDependencies` with `workspace:^` instead of re-adding per-package internal dev deps.
-- Verify with:
-  - scan `packages/*/package.json` for remaining internal `devDependencies`
-  - `pnpm install`
-  - `bun typecheck`
-  - `bun lint:fix`
-- Reason: removing package-level internal dev deps without hoisting shared workspace tooling deps to root breaks package typecheck resolution. `@platejs/combobox` was the canary via `@platejs/test-utils`.
+## Overview
+
+Consolidates internal `@platejs/*` devDependencies from individual packages to the workspace
+root, preventing typecheck resolution failures in the monorepo.
+
+## Workflow
+
+1. **Remove** internal `platejs` / `@platejs/*` `devDependencies` from each `packages/*/package.json`.
+2. **Hoist** any shared workspace packages still needed for test or typecheck tooling to root `package.json` `devDependencies` using `workspace:^`.
+3. **Verify** the changes:
+   - Scan `packages/*/package.json` for remaining internal `devDependencies`
+   - `pnpm install`
+   - `bun typecheck`
+   - `bun lint:fix`
+
+## Why This Matters
+
+Removing package-level internal dev deps without hoisting shared workspace tooling deps to
+root breaks package typecheck resolution. `@platejs/combobox` was the canary case via
+`@platejs/test-utils`.
+
+## Example
+
+```bash
+# Check for remaining internal devDeps after cleanup
+grep -r '"@platejs/' packages/*/package.json | grep devDependencies
+```
 

--- a/.codex/skills/julik-frontend-races-reviewer/SKILL.md
+++ b/.codex/skills/julik-frontend-races-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: julik-frontend-races-reviewer
-description: Reviews JavaScript and Stimulus code for race conditions, timing issues, and DOM lifecycle problems. Use after implementing or modifying frontend controllers or async UI code.
+description: Reviews JavaScript and Stimulus code for race conditions, timing issues, DOM lifecycle problems, unhandled promise rejections, stale timer callbacks, and concurrent operation conflicts. Use after implementing or modifying Stimulus controllers, async UI code, Hotwire/Turbo integrations, or any frontend code involving setTimeout, setInterval, requestAnimationFrame, or CSS animations.
 model: inherit
 ---
 

--- a/.codex/skills/kieran-python-reviewer/SKILL.md
+++ b/.codex/skills/kieran-python-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kieran-python-reviewer
-description: Reviews Python code with an extremely high quality bar for Pythonic patterns, type safety, and maintainability. Use after implementing features, modifying code, or creating new Python modules.
+description: Reviews Python code with an extremely high quality bar for Pythonic patterns, type hints, naming clarity, import organization, and maintainability. Checks for regressions, YAGNI violations, and modern Python 3.10+ idioms. Use after implementing features, modifying existing Python code, creating new modules, or refactoring services that need strict quality review.
 model: inherit
 ---
 

--- a/.codex/skills/kieran-rails-reviewer/SKILL.md
+++ b/.codex/skills/kieran-rails-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kieran-rails-reviewer
-description: Reviews Rails code with an extremely high quality bar for conventions, clarity, and maintainability. Use after implementing features, modifying code, or creating new Rails components.
+description: Reviews Rails code with an extremely high quality bar for conventions, clarity, turbo stream patterns, namespacing, and maintainability. Checks for regressions, service extraction signals, and naming clarity. Use after implementing features, modifying existing Rails controllers or models, creating new view components, or refactoring services that need strict Rails quality review.
 model: inherit
 ---
 

--- a/.codex/skills/kieran-typescript-reviewer/SKILL.md
+++ b/.codex/skills/kieran-typescript-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kieran-typescript-reviewer
-description: Reviews TypeScript code with an extremely high quality bar for type safety, modern patterns, and maintainability. Use after implementing features, modifying code, or creating new TypeScript components.
+description: Reviews TypeScript code with an extremely high quality bar for type safety, modern ES6+/TS5+ patterns, import organization, naming clarity, and maintainability. Flags any usage, regressions, and module extraction opportunities. Use after implementing features, modifying existing TypeScript code, creating new components or utilities, or refactoring modules that need strict type-safety review.
 model: inherit
 ---
 

--- a/.codex/skills/learnings-researcher/SKILL.md
+++ b/.codex/skills/learnings-researcher/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: learnings-researcher
-description: Searches docs/solutions/ for relevant past solutions by frontmatter metadata. Use before implementing features or fixing problems to surface institutional knowledge and prevent repeated mistakes.
+description: Searches docs/solutions/ for relevant past solutions using Grep-based frontmatter filtering on tags, modules, symptoms, and problem types, then distills actionable insights from matching documents. Use before implementing features, fixing bugs, or planning work to surface institutional knowledge, prevent repeated mistakes, and leverage proven patterns from past solutions.
 model: inherit
 ---
 

--- a/.codex/skills/lfg/SKILL.md
+++ b/.codex/skills/lfg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lfg
-description: Full autonomous engineering workflow
+description: Executes a full autonomous engineering workflow from planning through implementation, review, testing, and video recording. Orchestrates ce:plan, ce:work, ce:review, test-browser, and feature-video in strict sequential order with gate checks. Use when launching a complete end-to-end feature build pipeline. Trigger terms include "lfg", "let's go", "full workflow", "build feature end to end".
 argument-hint: '[feature description]'
 disable-model-invocation: true
 ---

--- a/.codex/skills/pattern-recognition-specialist/SKILL.md
+++ b/.codex/skills/pattern-recognition-specialist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pattern-recognition-specialist
-description: Analyzes code for design patterns, anti-patterns, naming conventions, and duplication. Use when checking codebase consistency or verifying new code follows established patterns.
+description: Analyzes code for design patterns, anti-patterns, naming conventions, duplication, and architectural boundary violations using AST-based and text-based search tools. Use when checking codebase consistency, verifying new code follows established patterns, auditing technical debt, or reviewing code quality across a project.
 model: inherit
 ---
 

--- a/.codex/skills/performance-oracle/SKILL.md
+++ b/.codex/skills/performance-oracle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: performance-oracle
-description: Analyzes code for performance bottlenecks, algorithmic complexity, database queries, memory usage, and scalability. Use after implementing features or when performance concerns arise.
+description: Analyzes code for performance bottlenecks including algorithmic complexity (Big O), N+1 database queries, memory leaks, caching opportunities, network round trips, and frontend bundle size impact. Use after implementing features, when API responses are slow, when optimizing for scale, or when performance concerns arise during code review.
 model: inherit
 ---
 

--- a/.codex/skills/plan/SKILL.md
+++ b/.codex/skills/plan/SKILL.md
@@ -1,13 +1,26 @@
 ---
-description: Start Manus-style file-based planning. Creates task_plan.md, findings.md, progress.md for complex tasks.
 name: plan
+description: Starts a file-based planning workflow for complex tasks by creating structured planning documents (task_plan.md, findings.md, progress.md) and guiding the user through phased planning. Delegates to the planning-with-files skill. Trigger terms: "plan", "create plan", "task planning", "project plan", "break down task". Use when the user has a complex, multi-step task that benefits from structured planning before implementation.
 ---
 
-Invoke the planning-with-files:planning-with-files skill and follow it exactly as presented to you.
+# File-Based Planning
 
-Create the three planning files in the current project directory if they don't exist:
-- task_plan.md — for phases, progress, and decisions
-- findings.md — for research and discoveries
-- progress.md — for session logging
+## Overview
 
-Then guide the user through the planning workflow.
+Bootstraps a Manus-style planning workflow using structured Markdown files to track phases,
+findings, and progress across sessions.
+
+## Workflow
+
+1. **Invoke sub-skill** -- delegate to `planning-with-files:planning-with-files` and follow its instructions exactly.
+2. **Create planning files** (if they do not already exist) in the current project directory:
+   - `task_plan.md` -- phases, progress checkpoints, and decisions
+   - `findings.md` -- research results and discoveries
+   - `progress.md` -- session-by-session logging
+3. **Guide the user** through the planning workflow defined by the sub-skill.
+
+## Example
+
+```
+/plan "Migrate authentication from JWT to session-based cookies"
+```

--- a/.codex/skills/pr-comment-resolver/SKILL.md
+++ b/.codex/skills/pr-comment-resolver/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-comment-resolver
-description: Addresses PR review comments by implementing requested changes and reporting resolutions. Use when code review feedback needs to be resolved with code changes.
+description: Addresses PR review comments by analyzing reviewer feedback, planning minimal targeted changes, implementing the requested modifications, and producing structured resolution reports. Use when code review feedback needs to be resolved with code changes, multiple review comments need systematic handling, or a reviewer has requested specific refactoring or improvements.
 color: blue
 model: inherit
 ---

--- a/.codex/skills/proof/SKILL.md
+++ b/.codex/skills/proof/SKILL.md
@@ -1,11 +1,7 @@
 ---
 name: proof
-description: Create, edit, comment on, and share markdown documents via Proof's web API and local bridge. Use when asked to "proof", "share a doc", "create a proof doc", "comment on a document", "suggest edits", "review in proof", or when given a proofeditor.ai URL.
-allowed-tools:
-  - Bash
-  - Read
-  - Write
-  - WebFetch
+description: Create, edit, comment on, and share markdown documents via Proof's web API and local bridge. Use when asked to "proof", "share a doc", "create a proof doc", "comment on a document", "suggest edits", "review in proof", when given a proofeditor.ai URL, or when collaborative document editing is needed.
+allowed-tools: Bash, Read, Write, WebFetch
 ---
 
 # Proof - Collaborative Markdown Editor

--- a/.codex/skills/react/SKILL.md
+++ b/.codex/skills/react/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: react
-description: 'Skill: react'
----
-
----
-name: react
-description: React patterns with destructured props, compiler optimization, Effects, and Tailwind v4 syntax. ALWAYS use when using React. Applies to files matching: *.tsx, **/globals.css.
+description: React patterns with destructured props, compiler optimization, Effects, and Tailwind v4 syntax. Use when working with React components, JSX, hooks, or Tailwind CSS styling. Applies to files matching *.tsx and **/globals.css.
 ---
 
 @.claude/skills/react.mdc

--- a/.codex/skills/repo-research-analyst/SKILL.md
+++ b/.codex/skills/repo-research-analyst/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: repo-research-analyst
-description: Conducts thorough research on repository structure, documentation, conventions, and implementation patterns. Use when onboarding to a new codebase or understanding project conventions.
+description: Conducts thorough research on repository structure, documentation, conventions, templates, and implementation patterns by analyzing architecture files, issue history, contribution guidelines, and codebase search results. Use when onboarding to a new codebase, understanding project conventions, discovering issue or PR templates, or mapping naming and code organization patterns before contributing.
 model: inherit
 ---
 

--- a/.codex/skills/report-bug/SKILL.md
+++ b/.codex/skills/report-bug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: report-bug
-description: Report a bug in the compound-engineering plugin
+description: Collects structured bug information (category, component, reproduction steps, expected vs actual behavior, error messages) and environment details, then files a GitHub issue against the compound-engineering plugin repository. Use when encountering a bug in any compound-engineering component (agent, command, skill, MCP server, or installation). Trigger terms include "report bug", "file bug", "bug report", "something broke".
 argument-hint: '[optional: brief description of the bug]'
 disable-model-invocation: true
 ---

--- a/.codex/skills/reproduce-bug/SKILL.md
+++ b/.codex/skills/reproduce-bug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reproduce-bug
-description: Reproduce and investigate a bug using logs, console inspection, and browser screenshots
+description: Investigates and reproduces a bug from a GitHub issue by reading the issue, running parallel log analysis (Rails console, AppSignal), visually reproducing via Playwright with screenshots, and documenting findings as a comment on the issue. Use when a bug needs investigation, reproduction, or visual verification before fixing. Trigger terms include "reproduce bug", "investigate issue", "repro bug", "debug issue".
 argument-hint: '[GitHub issue number]'
 disable-model-invocation: true
 ---

--- a/.codex/skills/resolve_parallel/SKILL.md
+++ b/.codex/skills/resolve_parallel/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: resolve_parallel
-description: Resolve all TODO comments using parallel processing
+name: resolve-parallel
+description: Resolve all TODO comments using parallel sub-agents for concurrent processing. Use when resolving PR review comments, clearing TODO backlogs, or batch-fixing code issues in parallel.
 argument-hint: '[optional: specific TODO pattern or file]'
 disable-model-invocation: true
 ---
@@ -21,7 +21,7 @@ Create a TodoWrite list of all unresolved items grouped by type.Make sure to loo
 
 Spawn a pr-comment-resolver agent for each unresolved item in parallel.
 
-So if there are 3 comments, it will spawn 3 pr-comment-resolver agents in parallel. liek this
+So if there are 3 comments, it will spawn 3 pr-comment-resolver agents in parallel. Like this:
 
 1. Task pr-comment-resolver(comment1)
 2. Task pr-comment-resolver(comment2)

--- a/.codex/skills/resolve_todo_parallel/SKILL.md
+++ b/.codex/skills/resolve_todo_parallel/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: resolve_todo_parallel
-description: Resolve all pending CLI todos using parallel processing
+name: resolve-todo-parallel
+description: Resolve all pending CLI todos from /todos/*.md using parallel sub-agents. Use when clearing todo backlogs, batch-resolving pending items, or processing todo lists concurrently.
 argument-hint: '[optional: specific todo ID or pattern]'
 ---
 
@@ -22,7 +22,7 @@ Create a TodoWrite list of all unresolved items grouped by type.Make sure to loo
 
 Spawn a pr-comment-resolver agent for each unresolved item in parallel.
 
-So if there are 3 comments, it will spawn 3 pr-comment-resolver agents in parallel. liek this
+So if there are 3 comments, it will spawn 3 pr-comment-resolver agents in parallel. Like this:
 
 1. Task pr-comment-resolver(comment1)
 2. Task pr-comment-resolver(comment2)

--- a/.codex/skills/security-sentinel/SKILL.md
+++ b/.codex/skills/security-sentinel/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-sentinel
-description: Performs security audits for vulnerabilities, input validation, auth/authz, hardcoded secrets, and OWASP compliance. Use when reviewing code for security issues or before deployment.
+description: Performs security audits scanning for SQL injection, XSS, input validation gaps, authentication and authorization flaws, hardcoded secrets, sensitive data exposure, and OWASP Top 10 compliance. Use when reviewing code for security issues, auditing API endpoints before deployment, or checking for vulnerabilities in authentication, payment processing, or user-facing input handling.
 model: inherit
 ---
 

--- a/.codex/skills/setup/SKILL.md
+++ b/.codex/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup
-description: Configure which review agents run for your project. Auto-detects stack and writes compound-engineering.local.md.
+description: Interactively configures which review agents run during /ce:review and /ce:work by auto-detecting the project stack (Rails, Python, TypeScript, or general) and writing compound-engineering.local.md. Supports auto-configure and custom modes with stack, focus area, and depth options. Use when setting up compound engineering for a new project or reconfiguring review agents. Trigger terms include "setup", "configure review agents", "setup compound engineering", "ce setup".
 disable-model-invocation: true
 ---
 

--- a/.codex/skills/skill-creator/SKILL.md
+++ b/.codex/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations.
+description: Guide for creating effective skills through a structured six-step process — understanding use cases, planning reusable contents, initializing with the template script, editing SKILL.md and bundled resources, packaging for distribution, and iterating. This skill should be used when users want to create a new skill, update an existing skill, or package a skill that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations.
 license: Complete terms in LICENSE.txt
 disable-model-invocation: true
 ---

--- a/.codex/skills/slfg/SKILL.md
+++ b/.codex/skills/slfg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slfg
-description: Full autonomous engineering workflow using swarm mode for parallel execution
+description: Executes a full autonomous engineering workflow with swarm-mode parallelism. Runs ce:plan and deepen-plan sequentially, then launches ce:work with parallel agent swarm, followed by concurrent review and browser testing, and finishes with todo resolution and feature video. Use when building a feature end-to-end with maximum parallelism. Trigger terms include "slfg", "swarm lfg", "parallel build", "swarm workflow".
 argument-hint: '[feature description]'
 disable-model-invocation: true
 ---

--- a/.codex/skills/start/SKILL.md
+++ b/.codex/skills/start/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Implements Manus-style file-based planning for complex tasks. Creates task_plan.md, findings.md, and progress.md. Use when starting complex multi-step tasks, research projects, or any task requiring >5 tool calls. Now with automatic session recovery after /clear
+description: Implements Manus-style file-based planning for complex tasks by invoking the planning-with-files skill. Creates structured planning documents for multi-step work. Use when starting complex multi-step tasks, research projects, or any task requiring more than 5 tool calls. Supports automatic session recovery after /clear. Trigger terms include "start", "begin task", "plan complex task", "file-based planning".
 disable-model-invocation: true
 name: start
 ---

--- a/.codex/skills/status/SKILL.md
+++ b/.codex/skills/status/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Show current planning status at a glance - phases, progress, and any logged errors.
+description: Displays current planning status at a glance by reading task_plan.md and summarizing phases, progress percentages, status icons, error counts, and file existence checks. Use when checking project planning progress, viewing phase status, or answering "where am I?" during a multi-phase workflow.
 name: status
 ---
 

--- a/.codex/skills/sync-testing-skill/SKILL.md
+++ b/.codex/skills/sync-testing-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sync-testing-skill
-description: 'Command: sync-testing-skill'
+description: Scans package test files and updates the testing skill with newly discovered patterns. Reads diverse spec files, identifies patterns not yet documented (imports, mocking, assertions, RTL usage), and updates the skill with concise, DRY examples. Use when a package has new test patterns that should be captured in the testing skill. Trigger terms include "sync testing", "update testing skill", "sync test patterns".
 ---
 
 Scan package tests, update @.claude/skills/testing/testing.mdc with new patterns. Follow writing-skills: DRY, ultra-concise, token-efficient.

--- a/.codex/skills/test-browser/SKILL.md
+++ b/.codex/skills/test-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-browser
-description: Run browser tests on pages affected by current PR or branch
+description: Runs end-to-end browser tests on pages affected by a PR or branch using the agent-browser CLI. Maps changed files to routes, detects the dev server port, navigates each affected page, checks for console errors and rendering issues, and produces a structured test summary. Use when validating UI changes, catching JavaScript integration bugs, or verifying layout regressions in a real browser. Trigger terms include "test browser", "browser test", "e2e test", "test UI", "test-browser".
 argument-hint: '[PR number, branch name, ''current'', or --port PORT]'
 ---
 

--- a/.codex/skills/test-xcode/SKILL.md
+++ b/.codex/skills/test-xcode/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-xcode
-description: Build and test iOS apps on simulator using XcodeBuildMCP
+description: Builds, installs, and tests iOS apps on the simulator using XcodeBuildMCP. Discovers projects and schemes, boots the simulator, captures screenshots and console logs, supports human verification for external flows, and produces a structured test summary. Use when testing iOS or macOS app changes on the simulator, verifying builds, or checking for crashes after code changes. Trigger terms include "test xcode", "xcode test", "iOS test", "simulator test", "build and test iOS".
 argument-hint: '[scheme name or ''current'' to use default]'
 disable-model-invocation: true
 ---

--- a/.codex/skills/testing/SKILL.md
+++ b/.codex/skills/testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing
-description: 'Skill: testing'
+description: Defines the testing strategy, conventions, and rules for the Plate editor monorepo. Covers three test layers (unit, contract, golden I/O), Bun-first tooling, seam selection (createEditor vs createSlateEditor vs createPlateEditor), file organization, fixture patterns, and per-package rules. Use when writing tests, reviewing test coverage, choosing test seams, or cleaning up test suites. Trigger terms include "testing", "write tests", "test strategy", "test conventions", "bun test".
 ---
 
 ## Testing Goal

--- a/.codex/skills/trace/SKILL.md
+++ b/.codex/skills/trace/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trace
-description: Use when errors occur deep in execution and you need to trace back to find the original trigger - systematically traces bugs backward through call stack, adding instrumentation when needed, to identify source of invalid data or incorrect behavior
+description: Systematically traces bugs backward through the call stack to find the original trigger rather than fixing at the symptom point. Adds console.error instrumentation when manual tracing stalls, then applies defense-in-depth validation at each layer. Use when errors occur deep in execution, stack traces show long call chains, invalid data origin is unclear, or you need to identify which test or code path triggers a problem.
 ---
 
 # Trace

--- a/.codex/skills/translate/SKILL.md
+++ b/.codex/skills/translate/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: translate
-description: 'Command: translate'
+description: >-
+  Translates and synchronizes English MDX documentation files to Chinese (cn) while
+  preserving Markdown formatting, code blocks, and JSX component tags. Only translates
+  the diff between source and existing translation — does not re-translate unchanged
+  content. Trigger terms: "translate", "sync translation", "MDX to Chinese",
+  "localize docs". Use when English .mdx files have changed and the corresponding
+  .cn.mdx files need updating.
 ---
 
 You are a professional translator. Translate/Synchronize the following MDX content from English to cn.

--- a/.codex/skills/triage/SKILL.md
+++ b/.codex/skills/triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage
-description: Triage and categorize findings for the CLI todo system
+description: Triages and categorizes findings (code review, security audit, performance analysis) for the CLI todo system. Presents each finding with severity, category, and proposed solution, then processes user decisions (approve, skip, customize) to manage todo files with proper status transitions. Use when processing review findings, audit results, or any batch of issues that need prioritization and tracking. Trigger terms include "triage", "categorize findings", "process review", "triage todos".
 argument-hint: '[findings list or source type]'
 disable-model-invocation: true
 ---

--- a/.codex/skills/update-app-design/SKILL.md
+++ b/.codex/skills/update-app-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
-allowed-tools: Read, Glob, Grep, Write, MultiEdit, TodoWrite, Bash
-description: Update existing app design document based on codebase changes and project evolution
 name: update-app-design
+description: Synchronizes the existing Application Design Document (1-app-design-document.mdc) with current codebase state by detecting new features, modified user flows, removed capabilities, and architecture evolution. Assesses whether the project stage has changed, updates priorities accordingly, and applies incremental edits that preserve document quality and tone. Trigger terms: "update app design", "sync design doc", "refresh design document", "update architecture doc". Use when the application has evolved and the design document needs to reflect current features, flows, and business logic.
+allowed-tools: Read, Glob, Grep, Write, MultiEdit, TodoWrite, Bash
 ---
 
 # Sync Application Design Document

--- a/.codex/skills/update-tech-stack/SKILL.md
+++ b/.codex/skills/update-tech-stack/SKILL.md
@@ -1,7 +1,7 @@
 ---
-allowed-tools: Read, Glob, Grep, Write, MultiEdit, TodoWrite, Bash
-description: Update tech stack documentation based on dependency changes and technical evolution
 name: update-tech-stack
+description: Updates existing Tech Stack documentation (2-tech-stack.mdc) by detecting dependency changes, version updates, new tool adoption, and infrastructure evolution since the last update. Compares current package.json and config files against the documented state, runs targeted Q&A for non-discoverable changes, and applies incremental updates with precise version numbers. Trigger terms: "update tech stack", "sync tech docs", "dependency updates", "refresh stack documentation". Use when dependencies, tools, or infrastructure have changed and the tech stack doc needs synchronization.
+allowed-tools: Read, Glob, Grep, Write, MultiEdit, TodoWrite, Bash
 ---
 
 # Update Tech Stack Documentation

--- a/.codex/skills/vercel-root-directory-cli/SKILL.md
+++ b/.codex/skills/vercel-root-directory-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vercel-root-directory-cli
-description: 'Skill: vercel-root-directory-cli'
+description: Diagnoses and resolves Vercel CLI deploy failures caused by a mismatch between the project Root Directory setting and the location of vercel.json in a monorepo. Walks through inspection, relocation, and verification steps. Use when vercel deploy fails with "vercel.json file should be inside of the provided root directory" or when dashboard builds succeed but CLI deploys fail. Trigger terms include "vercel deploy fail", "root directory mismatch", "vercel.json location", "vercel CLI error".
 ---
 
 # Vercel Root Directory vs CLI Deploy

--- a/.codex/skills/workflows-brainstorm/SKILL.md
+++ b/.codex/skills/workflows-brainstorm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflows-brainstorm
-description: '[DEPRECATED] Use /ce:brainstorm instead — renamed for clarity.'
+description: '[DEPRECATED] Redirects to /ce:brainstorm for feature brainstorming. This alias forwards all arguments and will be removed in a future version. Use when invoking the legacy /workflows:brainstorm command. Trigger terms include "workflows brainstorm", "brainstorm workflow".'
 argument-hint: '[feature idea or problem to explore]'
 disable-model-invocation: true
 ---

--- a/.codex/skills/workflows-compound/SKILL.md
+++ b/.codex/skills/workflows-compound/SKILL.md
@@ -1,10 +1,16 @@
 ---
 name: workflows-compound
-description: '[DEPRECATED] Use /ce:compound instead — renamed for clarity.'
+description: [DEPRECATED] Redirects to /ce:compound. This alias exists for backward compatibility and will be removed in a future version. Forwards all arguments to the ce:compound skill unchanged. Trigger terms: "workflows compound", "compound workflow". Use when invoked by name; prefer /ce:compound for new usage.
 argument-hint: '[optional: brief context about the fix]'
 disable-model-invocation: true
 ---
 
-NOTE: /workflows:compound is deprecated. Please use /ce:compound instead. This alias will be removed in a future version.
+# workflows-compound (Deprecated)
+
+**This command is deprecated.** Use `/ce:compound` instead.
+
+This alias forwards all arguments to `/ce:compound` and will be removed in a future version.
+
+## Redirect
 
 /ce:compound $ARGUMENTS

--- a/.codex/skills/workflows-plan/SKILL.md
+++ b/.codex/skills/workflows-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflows-plan
-description: '[DEPRECATED] Use /ce:plan instead — renamed for clarity.'
+description: '[DEPRECATED] Redirects to /ce:plan for feature planning. This alias forwards all arguments and will be removed in a future version. Use when invoking the legacy /workflows:plan command. Trigger terms include "workflows plan".'
 argument-hint: '[feature description, bug report, or improvement idea]'
 disable-model-invocation: true
 ---

--- a/.codex/skills/workflows-review/SKILL.md
+++ b/.codex/skills/workflows-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflows-review
-description: '[DEPRECATED] Use /ce:review instead — renamed for clarity.'
+description: '[DEPRECATED] Redirects to /ce:review for code review. This alias forwards all arguments and will be removed in a future version. Use when invoking the legacy /workflows:review command. Trigger terms include "workflows review".'
 argument-hint: '[PR number, GitHub URL, branch name, or latest]'
 disable-model-invocation: true
 ---

--- a/.codex/skills/workflows-work/SKILL.md
+++ b/.codex/skills/workflows-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflows-work
-description: '[DEPRECATED] Use /ce:work instead — renamed for clarity.'
+description: '[DEPRECATED] Redirects to /ce:work for plan execution. This alias forwards all arguments and will be removed in a future version. Use when invoking the legacy /workflows:work command. Trigger terms include "workflows work".'
 argument-hint: '[plan file, specification, or todo file path]'
 disable-model-invocation: true
 ---

--- a/.codex/skills/writing-changesets/SKILL.md
+++ b/.codex/skills/writing-changesets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-changesets
-description: Use when creating changeset files for Plate releases
+description: Creates changeset files for Plate package releases following strict conventions — one package per file, imperative voice, correct SemVer bump types, and Radix UI style prose. Use when writing .changeset/*.md files, documenting package changes for feat/fix/breaking releases, or updating docs/components/changelog.mdx for registry changes.
 ---
 
 # Writing Changesets


### PR DESCRIPTION
Hullo @zbeyens 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here are the ten most improved:

<img width="1312" height="1290" alt="score_card" src="https://github.com/user-attachments/assets/5688b317-1135-47a1-a22a-0ee9c94f0b15" />

Here's the full before/after in text form:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| heal-skill | 0% | 91% | +91% |
| proof | 0% | 90% | +90% |
| generate-command | 0% | 89% | +89% |
| internal-workspace-devdeps-hoist | 0% | 86% | +86% | | compound-docs | 0% | 84% | +84% |
| resolve-todo-parallel | 0% | 79% | +79% |
| translate | 22% | 86% | +64% |
| resolve-parallel | 0% | 63% | +63% |
| react | 0% | 61% | +61% |
| testing | 0% | 61% | +61% |
| lfg | 39% | 100% | +61% |
| workflows-compound | 36% | 95% | +59% |
| plan | 28% | 86% | +58% |
| ce-brainstorm | 43% | 100% | +57% |
| workflows-brainstorm | 39% | 95% | +56% |
| changeset | 32% | 83% | +51% |
| ce-work | 43% | 93% | +50% |
| docs-plugin | 39% | 89% | +50% |
| sync-testing-skill | 43% | 93% | +50% |
| deepen-plan | 38% | 83% | +45% |

84 skills improved across .claude/skills/ and .codex/skills/ — average score went from 47% to 81% (+34%).

Changes made:

Validation fixes (0% → 60-91%):
- Fixed allowed-tools field format: converted YAML arrays to comma-separated strings (compound-docs, heal-skill, proof)
- Fixed name field: replaced underscores with hyphens (generate-command, resolve-parallel, resolve-todo-parallel)
- Fixed double frontmatter in .codex/skills/react/SKILL.md

Description improvements (across 80+ skills):
- Replaced generic "Skill: name" placeholders with specific descriptions including concrete actions, trigger terms, and "Use when..." clauses
- Added explicit trigger terms users would naturally say when needing each skill
- Added clear scope boundaries to reduce skill conflict risk

Content improvements:
- Added brief overview sections to .claude/skills/ thin wrappers before @file.mdc references
- Improved workflow clarity and structure in lower-scoring skills
- Fixed typos and informal language

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - @popey - if you hit any snags.

Thanks in advance 🙏

**Checklist**

- [x] `pnpm typecheck`
- [x] `pnpm lint:fix`
- [x] `bun test`
- [x] `pnpm brl`
- [-] `pnpm changeset`
- [-] [ui changelog](docs/components/changelog.mdx)

### pnpm typecheck

```
 Tasks:    53 successful, 53 total
Cached:    0 cached, 53 total
  Time:    19.19s
```

### pnpm lint:fix

```
> plate@ lint:fix /Users/alan/Projects/auto-p-o/udecode/plate
> biome check . --fix

Checked 2691 files in 6s. Fixed 3 files.
```

### bun test

```
 2353 pass
 0 fail
 20 snapshots, 3992 expect() calls
Ran 2353 tests across 381 files. [3.90s]
```

### pnpm brl

```

 Tasks:    51 successful, 51 total
Cached:    0 cached, 51 total
  Time:    4.118s
```


