### PR TITLE
fix: redecorate code blocks on lang change

### DIFF
--- a/.changeset/brown-cats-act.md
+++ b/.changeset/brown-cats-act.md
@@ -1,0 +1,5 @@
+---
+"@platejs/code-block": patch
+---
+
+Redecorate code blocks when the language changes to avoid stale highlighting.

--- a/.claude/docs/plans/2026-03-26-fix-codeblock-language-rehighlight.md
+++ b/.claude/docs/plans/2026-03-26-fix-codeblock-language-rehighlight.md
@@ -1,0 +1,16 @@
+# Fix Code Block Language Rehighlight
+
+## Goal
+
+Make code-block syntax highlighting refresh for the whole block immediately after `lang` changes.
+
+## Plan
+
+- Add regression coverage around `withCodeBlock` language changes.
+- Update `withCodeBlock.apply` to detect real `lang` transitions, clear cache, then trigger `editor.api.redecorate()`.
+- Verify with targeted tests, package build, package typecheck, and `lint:fix`.
+
+## Notes
+
+- Package-level fix only.
+- No registry UI changes.

--- a/.claude/docs/solutions/logic-errors/2026-03-26-code-block-language-change-must-trigger-redecorate.md
+++ b/.claude/docs/solutions/logic-errors/2026-03-26-code-block-language-change-must-trigger-redecorate.md
@@ -1,0 +1,68 @@
+---
+module: Code Block
+date: 2026-03-26
+problem_type: logic_error
+component: editor_transforms
+symptoms:
+  - "Changing a code block language left old syntax highlighting on untouched lines"
+  - "Editing a line made highlighting catch up, which made the bug look like a partial render issue"
+root_cause: logic_error
+resolution_type: code_change
+severity: medium
+tags:
+  - code-block
+  - syntax-highlighting
+  - redecorate
+  - decorate
+  - slate
+  - react
+---
+
+# Code block language change must trigger redecorate
+
+## Problem
+
+Changing `code_block.lang` updated the node value, but syntax highlighting for the block did not fully refresh right away.
+
+Only after editing a line did the stale tokens disappear, so the bug looked like a per-line highlight problem instead of a decorate lifecycle gap.
+
+## Root cause
+
+`withCodeBlock.apply` cleared `CODE_LINE_TO_DECORATIONS` when `lang` changed, but it stopped there.
+
+That removed cached ranges, but Plate's React `decorate` function was still memoized behind `versionDecorate`. Without `editor.api.redecorate()`, Slate kept rendering with the old decoration pass until another change forced a fresh decorate cycle.
+
+The original check also only looked at truthy `operation.newProperties.lang`, which missed some real transitions such as clearing or resetting the language.
+
+## Fix
+
+Treat language changes as a two-step operation inside `withCodeBlock.apply`:
+
+1. Detect a real `lang` transition by comparing previous and next values.
+2. Clear cached line decorations before `apply(operation)`.
+3. Call `editor.api.redecorate?.()` after `apply(operation)` completes.
+
+That makes these transitions all behave the same way:
+
+- `javascript -> json`
+- `javascript -> plaintext`
+- `undefined -> javascript`
+- `javascript -> undefined`
+
+## Verification
+
+These checks passed:
+
+```bash
+bun test packages/code-block/src/lib/withCodeBlock.spec.tsx packages/code-block/src/lib/BaseCodeBlockPlugin.spec.ts packages/code-block/src/lib/setCodeBlockToDecorations.spec.ts
+pnpm install
+pnpm turbo build --filter=./packages/code-block
+pnpm turbo typecheck --filter=./packages/code-block
+pnpm lint:fix
+```
+
+## Prevention
+
+When a plugin caches decoration state outside Slate nodes, clearing the cache is not enough. Also verify what actually triggers the next decorate pass.
+
+For regressions around `decorate`, add one test that changes the underlying node data and asserts any explicit refresh hook is called. In this case, the stable seam is `withCodeBlock.apply`, not the UI combobox that calls `setNodes({ lang })`.

--- a/packages/code-block/src/lib/withCodeBlock.spec.tsx
+++ b/packages/code-block/src/lib/withCodeBlock.spec.tsx
@@ -191,7 +191,7 @@ describe('tab', () => {
 });
 
 describe('apply', () => {
-  it('clears cached decorations when the code block language changes', () => {
+  it('clears cached decorations and redecorates when the code block language changes', () => {
     const input = (
       <editor>
         <hcodeblock>
@@ -217,6 +217,9 @@ describe('apply', () => {
       ],
     });
     const codeLine = editor.children[0].children[0] as any;
+    const redecorate = mock();
+
+    editor.api.redecorate = redecorate;
 
     CODE_LINE_TO_DECORATIONS.set(codeLine, [
       {
@@ -228,5 +231,92 @@ describe('apply', () => {
     editor.tf.setNodes({ lang: 'json' }, { at: [0] });
 
     expect(CODE_LINE_TO_DECORATIONS.get(codeLine)).toEqual([]);
+    expect(redecorate).toHaveBeenCalledTimes(1);
+  });
+
+  it('redecorates when language changes to plaintext', () => {
+    const input = (
+      <editor>
+        <hcodeblock lang="javascript">
+          <hcodeline>aa</hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any as SlateEditor;
+    const lowlight = {
+      highlight: mock(() => ({ value: [] })),
+      highlightAuto: mock(() => ({ value: [] })),
+      listLanguages: mock(() => ['javascript']),
+    };
+
+    const editor = createEditor({
+      input,
+      plugins: [
+        BaseParagraphPlugin,
+        BaseCodeBlockPlugin.configure({
+          options: {
+            lowlight: lowlight as any,
+          },
+        }),
+      ],
+    });
+    const codeLine = editor.children[0].children[0] as any;
+    const redecorate = mock();
+
+    editor.api.redecorate = redecorate;
+    CODE_LINE_TO_DECORATIONS.set(codeLine, [
+      {
+        anchor: { offset: 0, path: [0, 0, 0] },
+        className: 'token keyword',
+        focus: { offset: 2, path: [0, 0, 0] },
+      },
+    ] as any);
+
+    editor.tf.setNodes({ lang: 'plaintext' }, { at: [0] });
+
+    expect(CODE_LINE_TO_DECORATIONS.get(codeLine)).toEqual([]);
+    expect(redecorate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not redecorate for unrelated code block set_node changes', () => {
+    const input = (
+      <editor>
+        <hcodeblock lang="javascript">
+          <hcodeline>aa</hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any as SlateEditor;
+    const lowlight = {
+      highlight: mock(() => ({ value: [] })),
+      highlightAuto: mock(() => ({ value: [] })),
+      listLanguages: mock(() => ['javascript']),
+    };
+
+    const editor = createEditor({
+      input,
+      plugins: [
+        BaseParagraphPlugin,
+        BaseCodeBlockPlugin.configure({
+          options: {
+            lowlight: lowlight as any,
+          },
+        }),
+      ],
+    });
+    const codeLine = editor.children[0].children[0] as any;
+    const existingDecorations = [
+      {
+        anchor: { offset: 0, path: [0, 0, 0] },
+        className: 'token keyword',
+        focus: { offset: 2, path: [0, 0, 0] },
+      },
+    ] as any;
+    const redecorate = mock();
+
+    editor.api.redecorate = redecorate;
+    CODE_LINE_TO_DECORATIONS.set(codeLine, existingDecorations);
+
+    editor.tf.setNodes({ foo: 'bar' } as any, { at: [0] });
+
+    expect(redecorate).not.toHaveBeenCalled();
   });
 });

--- a/packages/code-block/src/lib/withCodeBlock.ts
+++ b/packages/code-block/src/lib/withCodeBlock.ts
@@ -20,16 +20,30 @@ export const withCodeBlock: OverrideEditor<CodeBlockConfig> = (ctx) => {
   return {
     transforms: {
       apply(operation) {
+        const editorApi = editor.api as typeof editor.api & {
+          redecorate?: () => void;
+        };
+        let shouldRedecorate = false;
+
         if (getOptions().lowlight && operation.type === 'set_node') {
           const entry = editor.api.node(operation.path);
+          const touchesLang =
+            'lang' in (operation.properties ?? {}) ||
+            'lang' in (operation.newProperties ?? {});
+          const langChanged =
+            operation.properties?.lang !== operation.newProperties?.lang;
 
-          if (entry?.[0].type === type && operation.newProperties?.lang) {
-            // Clear decorations for all code lines in this block
+          if (entry?.[0].type === type && touchesLang && langChanged) {
             resetCodeBlockDecorations(entry[0] as TCodeBlockElement);
+            shouldRedecorate = true;
           }
         }
 
         apply(operation);
+
+        if (shouldRedecorate) {
+          editorApi.redecorate?.();
+        }
       },
       insertBreak() {
         const apply = () => {


### PR DESCRIPTION
## Problem

Changing a code block language updated the node value, but the existing syntax highlighting stayed in place.

The new highlighting was only applied after editing individual code lines, which meant the block did not fully refresh on `lang` change.

## Summary

- fix stale syntax highlighting after changing a code block `lang`
- clear cached decorations for the block when `lang` actually changes
- trigger `editor.api.redecorate?.()` after the node update so the whole block re-highlights immediately
- add regression tests for `lang` changes and unrelated `set_node` updates

**Checklist**

- [x] `pnpm typecheck`
- [x] `pnpm lint:fix`
- [x] `bun test`
- [x] `pnpm brl`
- [x] `pnpm changeset`
- [x] [ui changelog](docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- pnpm brl: Required if adding, moving or removing a file in a package.
- pnpm changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/src/registry/components/changelog.mdx`.

-->
