### PR TITLE
Fix bounded editor scroll jumps in selection scrolling

### DIFF
--- a/.claude/docs/plans/2026-03-27-4589-scroll-jump.md
+++ b/.claude/docs/plans/2026-03-27-4589-scroll-jump.md
@@ -1,0 +1,52 @@
+# Issue 4589: scroll jump in bounded editors
+
+## Goal
+
+Fix the bounded-editor scroll jump reported in `https://github.com/udecode/plate/issues/4589` with a durable change in the scroll/selection pipeline, not a blockquote-specific workaround.
+
+## Source of truth
+
+- GitHub issue `#4589`
+- Repro on `https://platejs.org/editors`
+- Trigger pattern:
+  - bounded editor viewport
+  - edit inside a blockquote near the bottom
+  - split once in the middle of text
+  - move caret back to the earlier split point
+  - split again
+  - editor jumps upward and moves the active line off screen
+- Comments also report similar jumps on `Shift+Enter` and mobile
+
+## Relevant code
+
+- `packages/core/src/lib/plugins/dom/DOMPlugin.ts`
+- `packages/core/src/lib/plugins/dom/withScrolling.ts`
+- `packages/slate/src/internal/editor-extension/scrollIntoView.ts`
+- plate store refs: `useEditorScrollRef`, `useEditorContainerRef`
+
+## Existing learning
+
+- `.claude/docs/solutions/logic-errors/2026-03-24-withscrolling-must-map-temporary-options-to-domplugin-keys-and-always-restore-state.md`
+- Takeaway: DOM scrolling already had one subtle state bug; prefer a systemic fix plus direct coverage in this layer.
+
+## Hypotheses
+
+1. `DOMPlugin` picks the wrong op/path after break operations, so the scroll target is stale.
+2. `scrollIntoView` delegates to the browser without anchoring to the intended scroll container, so bounded editors can scroll the page or a higher ancestor.
+3. Async `requestAnimationFrame` scrolling is racing against selection/layout updates, especially across consecutive line splits.
+
+## Plan
+
+1. Read current DOM scrolling tests and related store/container code.
+2. Reproduce with a narrow automated seam if possible.
+3. Implement the smallest durable fix in the DOM scroll pipeline.
+4. Verify with targeted tests, package build-first typecheck, lint, and browser repro.
+
+## Verification gates
+
+- Targeted tests for the failing behavior
+- `pnpm install` only if needed
+- build-first typecheck for touched TS packages
+- `pnpm lint:fix`
+- browser verification with `dev-browser`
+- evaluate `ce-compound` after verification

--- a/.claude/docs/solutions/ui-bugs/2026-03-27-bounded-editor-selection-scroll-must-use-plate-scroll-boundaries.md
+++ b/.claude/docs/solutions/ui-bugs/2026-03-27-bounded-editor-selection-scroll-must-use-plate-scroll-boundaries.md
@@ -1,0 +1,108 @@
+---
+title: Bounded editor selection scroll must use Plate scroll boundaries
+date: 2026-03-27
+category: ui-bugs
+module: core dom scrolling
+problem_type: ui_bug
+component: editor scrolling
+symptoms:
+  - Pressing Enter inside a blockquote in a bounded editor can jump the viewport upward and push the active line off screen.
+  - The same jump can show up on repeated soft-break flows such as Shift+Enter.
+  - The bug is easiest to reproduce in the docs editor previews where the editor lives inside a fixed-height scroll container.
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags:
+  - plate
+  - slate
+  - scrolling
+  - bounded-editor
+  - blockquote
+  - scrollSelectionIntoView
+  - scroll-boundary
+---
+
+# Bounded editor selection scroll must use Plate scroll boundaries
+
+## Problem
+
+Plate already tracked the correct bounded scroll container through `containerRef` and `scrollRef`, but selection scrolling never used that information. In the docs previews, repeated Enter inside a blockquote let the browser scroll the wrong ancestor, so the active edit point could jump upward and disappear from view.
+
+## Symptoms
+
+- On `platejs.org/editors`, open the AI editor preview and scroll down to the blockquote near the bottom.
+- Press Enter in the middle of the sentence, move the caret back to that split point, then press Enter again.
+- The bounded editor jumps upward instead of keeping the active blockquote lines in view.
+- The same class of jump can show up on soft-break paths such as Shift+Enter because the root bug is selection scrolling, not blockquote rules.
+
+## What Didn't Work
+
+- Treating this as a blockquote rule bug was a red herring. Blockquotes only made the repro easy because they use line-break behavior by default.
+- Looking only at `DOMPlugin.withScrolling(...)` was also incomplete. That path handles explicit Plate auto-scroll batches, but manual Enter in the editor still flowed through Slate React selection scrolling.
+
+## Solution
+
+Make Plate own selection scrolling in React, and make the shared scroll helper honor the editor's bounded scroll container.
+
+First, teach `scrollIntoView(...)` to use the store-backed `scrollRef` or `containerRef` as the `scroll-into-view-if-needed` boundary when one exists:
+
+```ts
+const getScrollBoundary = (editor: Editor) => {
+  const store = (editor as any).store;
+
+  if (!store?.get) return;
+
+  return store.get('scrollRef')?.current ?? store.get('containerRef')?.current;
+};
+
+const resolvedOptions =
+  typeof options === 'object' && options
+    ? {
+        ...options,
+        boundary: options.boundary ?? getScrollBoundary(editor),
+      }
+    : options;
+
+scrollIntoViewIfNeeded(leafEl, resolvedOptions);
+```
+
+Then stop relying on Slate React's default selection scrolling. In `useEditableProps(...)`, provide a default `scrollSelectionIntoView` handler that routes selection changes back through Plate's own API:
+
+```ts
+const scrollSelectionIntoView = React.useCallback(
+  (_editor, domRange) => {
+    editor.api.scrollIntoView(domRange);
+  },
+  [editor]
+);
+
+const _props: EditableProps = {
+  decorate,
+  renderChunk,
+  renderElement,
+  renderLeaf,
+  renderText,
+  scrollSelectionIntoView:
+    editableProps.scrollSelectionIntoView ?? scrollSelectionIntoView,
+};
+```
+
+That keeps both explicit Plate scrolling and normal caret-driven selection scrolling on the same bounded path.
+
+## Why This Works
+
+`scroll-into-view-if-needed` will happily walk up through scrollable ancestors unless you give it a boundary. Plate already knew which element should own scrolling, but that information stopped at the React store. Once selection scrolling started calling `editor.api.scrollIntoView(...)`, and that helper started defaulting to the store's bounded scroll root, the caret stayed inside the editor's real viewport instead of bubbling scroll decisions to the wrong ancestor.
+
+This is why the fix is durable: it solves the shared scroll contract instead of adding a special case for blockquotes, Enter, or one docs page.
+
+## Prevention
+
+- If Plate tracks a DOM ref for viewport ownership, selection scrolling should use it by default.
+- When a bug only reproduces inside fixed-height editors, check scroll boundaries before touching node-specific rules.
+- Keep one unit test on the React side proving `scrollSelectionIntoView` routes through Plate, and one low-level test proving `scrollIntoView(...)` respects `scrollRef` and `containerRef`.
+- If a caller passes an explicit boundary, preserve it. Plate should supply the safe default, not override deliberate caller behavior.
+
+## Related Issues
+
+- GitHub: `#4589`
+- Related learning: `.claude/docs/solutions/logic-errors/2026-03-24-withscrolling-must-map-temporary-options-to-domplugin-keys-and-always-restore-state.md`

--- a/packages/core/src/react/hooks/useEditableProps.spec.tsx
+++ b/packages/core/src/react/hooks/useEditableProps.spec.tsx
@@ -46,5 +46,54 @@ describe('useEditableProps', () => {
       result.current.decorate!(entry);
       expect(decorate).toHaveBeenCalledTimes(2);
     });
+
+    it('uses editor.api.scrollIntoView for selection scrolling by default', () => {
+      const editor = createPlateEditor();
+      const domRange = {
+        getBoundingClientRect: mock(() => ({
+          bottom: 1,
+          height: 1,
+          left: 0,
+          right: 1,
+          top: 0,
+          width: 1,
+        })),
+        startContainer: { parentElement: document.createElement('span') },
+      } as any;
+      const scrollIntoView = mock();
+
+      editor.api.scrollIntoView = scrollIntoView as any;
+
+      const wrapper = ({ children }: any) => (
+        <Plate editor={editor}>{children}</Plate>
+      );
+      const { result } = renderHook(() => useEditableProps(), {
+        wrapper,
+      });
+
+      result.current.scrollSelectionIntoView?.(editor as any, domRange);
+
+      expect(scrollIntoView).toHaveBeenCalledWith(domRange);
+    });
+
+    it('keeps an explicit scrollSelectionIntoView override', () => {
+      const editor = createPlateEditor();
+      const override = mock();
+
+      const wrapper = ({ children }: any) => (
+        <Plate editor={editor}>{children}</Plate>
+      );
+      const { result } = renderHook(
+        () =>
+          useEditableProps({
+            scrollSelectionIntoView: override as any,
+          }),
+        {
+          wrapper,
+        }
+      );
+
+      expect(result.current.scrollSelectionIntoView).toBe(override);
+    });
   });
 });

--- a/packages/core/src/react/hooks/useEditableProps.ts
+++ b/packages/core/src/react/hooks/useEditableProps.ts
@@ -74,6 +74,12 @@ export const useEditableProps = ({
     () => pipeRenderText(editor, storeRenderText ?? editableProps?.renderText),
     [editableProps?.renderText, editor, storeRenderText]
   );
+  const scrollSelectionIntoView = React.useCallback(
+    (_: unknown, domRange: Parameters<typeof editor.api.scrollIntoView>[0]) => {
+      editor.api.scrollIntoView(domRange);
+    },
+    [editor]
+  );
 
   const props: EditableProps = useDeepCompareMemo(() => {
     const _props: EditableProps = {
@@ -82,6 +88,8 @@ export const useEditableProps = ({
       renderElement,
       renderLeaf,
       renderText,
+      scrollSelectionIntoView:
+        editableProps.scrollSelectionIntoView ?? scrollSelectionIntoView,
     };
 
     DOM_HANDLERS.forEach((handlerKey) => {
@@ -100,6 +108,7 @@ export const useEditableProps = ({
     renderElement,
     renderLeaf,
     renderText,
+    scrollSelectionIntoView,
   ]);
 
   return useDeepCompareMemo(

--- a/packages/slate/src/internal/editor-extension/scrollIntoView.spec.ts
+++ b/packages/slate/src/internal/editor-extension/scrollIntoView.spec.ts
@@ -117,4 +117,113 @@ describe('scrollIntoView', () => {
     });
     expect(leafEl.getBoundingClientRect).toBeUndefined();
   });
+
+  it('uses the editor scrollRef as the scrolling boundary when available', () => {
+    const leafEl: any = {};
+    const boundary = document.createElement('section');
+    const domRange = {
+      getBoundingClientRect: () => ({
+        bottom: 1,
+        height: 1,
+        left: 0,
+        right: 1,
+        top: 0,
+        width: 1,
+      }),
+      startContainer: { parentElement: leafEl },
+    };
+    const editor = {
+      api: {
+        toDOMRange: mock(() => domRange),
+      },
+      store: {
+        get: mock((key: string) =>
+          key === 'scrollRef'
+            ? { current: boundary }
+            : { current: document.createElement('div') }
+        ),
+      },
+    } as any;
+
+    scrollIntoView(editor, { offset: 0, path: [0, 0] });
+
+    expect(scrollIntoViewIfNeeded).toHaveBeenCalledWith(leafEl, {
+      boundary,
+      scrollMode: 'if-needed',
+    });
+  });
+
+  it('falls back to the editor containerRef boundary when scrollRef is empty', () => {
+    const leafEl: any = {};
+    const boundary = document.createElement('div');
+    const domRange = {
+      getBoundingClientRect: () => ({
+        bottom: 1,
+        height: 1,
+        left: 0,
+        right: 1,
+        top: 0,
+        width: 1,
+      }),
+      startContainer: { parentElement: leafEl },
+    };
+    const editor = {
+      api: {
+        toDOMRange: mock(() => domRange),
+      },
+      store: {
+        get: mock((key: string) =>
+          key === 'scrollRef' ? { current: null } : { current: boundary }
+        ),
+      },
+    } as any;
+
+    scrollIntoView(editor, { offset: 0, path: [0, 0] });
+
+    expect(scrollIntoViewIfNeeded).toHaveBeenCalledWith(leafEl, {
+      boundary,
+      scrollMode: 'if-needed',
+    });
+  });
+
+  it('does not override an explicit boundary option', () => {
+    const leafEl: any = {};
+    const explicitBoundary = document.createElement('article');
+    const storeBoundary = document.createElement('section');
+    const domRange = {
+      getBoundingClientRect: () => ({
+        bottom: 1,
+        height: 1,
+        left: 0,
+        right: 1,
+        top: 0,
+        width: 1,
+      }),
+      startContainer: { parentElement: leafEl },
+    };
+    const editor = {
+      api: {
+        toDOMRange: mock(() => domRange),
+      },
+      store: {
+        get: mock((key: string) =>
+          key === 'scrollRef'
+            ? { current: storeBoundary }
+            : { current: document.createElement('div') }
+        ),
+      },
+    } as any;
+
+    scrollIntoView(editor, { offset: 0, path: [0, 0] }, {
+      block: 'nearest',
+      boundary: explicitBoundary,
+      scrollMode: 'if-needed',
+    } as any);
+
+    expect(scrollIntoViewIfNeeded).toHaveBeenCalledWith(leafEl, {
+      block: 'nearest',
+      boundary: explicitBoundary,
+      scrollMode: 'if-needed',
+    });
+  });
 });

--- a/packages/slate/src/internal/editor-extension/scrollIntoView.ts
+++ b/packages/slate/src/internal/editor-extension/scrollIntoView.ts
@@ -9,6 +9,14 @@ const defaultOptions: ScrollIntoViewOptions = {
   scrollMode: 'if-needed',
 };
 
+const getScrollBoundary = (editor: Editor) => {
+  const store = (editor as any).store;
+
+  if (!store?.get) return;
+
+  return store.get('scrollRef')?.current ?? store.get('containerRef')?.current;
+};
+
 // TODO: move to slate
 export function scrollIntoView(
   editor: Editor,
@@ -32,10 +40,18 @@ export function scrollIntoView(
     if (!domRange) return;
 
     const leafEl = domRange.startContainer.parentElement!;
+    const boundary = getScrollBoundary(editor);
+    const resolvedOptions =
+      typeof options === 'object' && options
+        ? {
+            ...options,
+            boundary: options.boundary ?? boundary,
+          }
+        : options;
 
     leafEl.getBoundingClientRect =
       domRange.getBoundingClientRect.bind(domRange);
-    scrollIntoViewIfNeeded(leafEl, options);
+    scrollIntoViewIfNeeded(leafEl, resolvedOptions);
 
     setTimeout(() => {
       (leafEl as any).getBoundingClientRect = undefined;


### PR DESCRIPTION
## Summary

Fixes the bounded-editor scroll jump from #4589 by routing selection scrolling through Plate and constraining scroll-into-view to the editor's own scroll boundary.

## What changed

- add a default `scrollSelectionIntoView` in `useEditableProps` so Slate selection scrolling uses `editor.api.scrollIntoView(...)`
- make `scrollIntoView(...)` use `scrollRef` first and `containerRef` second as the default boundary when Plate store refs exist
- add regression coverage for both the React selection path and the low-level bounded scroll helper
- document the root cause in `.claude/docs/solutions/`

## Verification

- `bun test packages/slate/src/internal/editor-extension/scrollIntoView.spec.ts packages/core/src/react/hooks/useEditableProps.spec.tsx packages/core/src/lib/plugins/dom/DOMPlugin.spec.ts packages/core/src/lib/plugins/dom/withScrolling.spec.ts`
- `pnpm install`
- `pnpm turbo build --filter=./packages/core --filter=./packages/slate`
- `pnpm turbo typecheck --filter=./packages/core --filter=./packages/slate`
- `pnpm lint:fix`
- `pnpm check`
- browser repro on local `http://localhost:3002/editors` using `dev-browser`; after the second Enter the blockquote stayed visible and the inner editor scroll position stayed flat (`scrollTop: 383 -> 383`)
