### PR TITLE
Fix // paste being autolinked in code blocks

### DIFF
--- a/.changeset/link-double-slash-patch.md
+++ b/.changeset/link-double-slash-patch.md
@@ -1,0 +1,5 @@
+---
+'@platejs/link': patch
+---
+
+- Fixed link validation so text starting with `//` is no longer treated as an internal path. This stops comment-style paste content from being autolinked by mistake, including inside code blocks.

--- a/.claude/docs/plans/2026-03-28-issue-4613-code-block-paste-must-not-autolink.md
+++ b/.claude/docs/plans/2026-03-28-issue-4613-code-block-paste-must-not-autolink.md
@@ -1,0 +1,36 @@
+# Issue 4613: code block paste must not autolink
+
+## Tracker
+
+- Source type: GitHub issue
+- Source id: `#4613`
+- Title: `Code with // comments pasted inside code blocks is incorrectly recognized as links`
+- URL: `https://github.com/udecode/plate/issues/4613`
+- Task type: bug
+- Expected outcome: pasting plain code into an existing code block keeps the pasted text as plain code lines, without link wrapping or markdown-style link transforms
+- Browser surface: likely no; the stable seam should be editor insert handlers and package tests
+
+## Relevant area
+
+- `packages/code-block/src/lib/withInsertDataCodeBlock.ts`
+- `packages/link/src/lib/withLink.ts`
+- `packages/core/src/lib/plugins/ParserPlugin.ts`
+- existing code-block and link paste specs
+
+## Learnings
+
+- Recent code-block regressions in this repo were caused by structural assumptions around `code_line` nodes and stale decorate lifecycles
+- This bug smells like the paste pipeline is still allowing link auto-insert logic to run while the selection is inside a code block
+
+## Plan
+
+1. Trace the paste path for plain-text clipboard data inside code blocks.
+2. Add the smallest regression test at the real seam.
+3. Implement the minimal guard or transform to keep code-block paste as plain text.
+4. Run targeted tests, then package build, typecheck, and `lint:fix`.
+
+## Progress
+
+- Fetched the issue and comments.
+- Read repo instructions, task skill, planning-with-files, learnings-researcher, and tdd skill docs.
+- Read recent local learnings for code-block redecorate and structural line regressions.

--- a/.claude/docs/solutions/logic-errors/2026-03-28-link-validation-must-not-treat-double-slash-as-internal-path.md
+++ b/.claude/docs/solutions/logic-errors/2026-03-28-link-validation-must-not-treat-double-slash-as-internal-path.md
@@ -1,0 +1,66 @@
+---
+module: Link
+date: 2026-03-28
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "Pasting code that starts with // could create a link node instead of plain text"
+  - "Code comments pasted into code blocks were rendered as links before code-block paste handling could run"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags:
+  - link
+  - autolink
+  - paste
+  - code-block
+  - validation
+  - url
+---
+
+# Link validation must not treat double-slash as an internal path
+
+## Problem
+
+The link validator treated any string starting with `/` as an internal path.
+
+That accidentally included protocol-relative and comment-style `//...` text, which let the link plugin autolink pasted code before the code-block plugin could normalize it into plain code lines.
+
+## Root cause
+
+`validateUrl` returned `true` immediately for `url.startsWith('/')`.
+
+That single-slash shortcut was meant for internal app paths like `/docs`, but it also matched `//example.com` and `// this is a comment`. Once that happened, `withLink.insertData` wrapped the pasted text in a link node and returned early, so the downstream code-block paste logic never ran.
+
+## Fix
+
+Only treat single-slash paths as internal links. Reject double-slash input from the internal-path fast path.
+
+```ts
+if (url.startsWith('/') && !url.startsWith('//')) {
+  return true;
+}
+```
+
+Regression coverage should live at two levels:
+
+- direct validator coverage for `//example.com`
+- paste coverage with `BaseCodeBlockPlugin` and `BaseLinkPlugin` together, asserting `//` comments stay plain code
+
+## Verification
+
+These checks passed:
+
+```bash
+bun test packages/code-block/src/lib/withInsertDataCodeBlock.spec.tsx packages/link/src/lib/utils/validateUrl.spec.ts
+pnpm install
+pnpm turbo build --filter=./packages/code-block --filter=./packages/link
+pnpm turbo typecheck --filter=./packages/code-block --filter=./packages/link
+pnpm lint:fix
+```
+
+## Prevention
+
+When link validation has shortcuts for internal routing, explicitly exclude lookalike external or non-link prefixes such as `//`.
+
+For paste regressions that combine plugins, add one integration-style test with the real plugin pair instead of only unit-testing the validator in isolation.

--- a/.tmp/prepare-release-changesets-status.json
+++ b/.tmp/prepare-release-changesets-status.json
@@ -36,27 +36,21 @@
       "name": "@platejs/code-block",
       "type": "patch",
       "oldVersion": "52.3.15",
-      "changesets": [
-        "code-block-patch"
-      ],
+      "changesets": ["code-block-patch"],
       "newVersion": "52.3.16"
     },
     {
       "name": "@platejs/dnd",
       "type": "patch",
       "oldVersion": "52.3.15",
-      "changesets": [
-        "dnd-patch-check"
-      ],
+      "changesets": ["dnd-patch-check"],
       "newVersion": "52.3.16"
     },
     {
       "name": "@platejs/core",
       "type": "patch",
       "oldVersion": "52.3.15",
-      "changesets": [
-        "fuzzy-garlics-argue"
-      ],
+      "changesets": ["fuzzy-garlics-argue"],
       "newVersion": "52.3.16"
     },
     {

--- a/packages/code-block/src/lib/withInsertDataCodeBlock.spec.tsx
+++ b/packages/code-block/src/lib/withInsertDataCodeBlock.spec.tsx
@@ -2,6 +2,7 @@
 
 import type { SlateEditor } from 'platejs';
 
+import { BaseLinkPlugin } from '@platejs/link';
 import { createDataTransfer, jsxt } from '@platejs/test-utils';
 import { BaseParagraphPlugin, createSlateEditor } from 'platejs';
 
@@ -12,6 +13,13 @@ jsxt;
 const createEditor = (input: SlateEditor) =>
   createSlateEditor({
     plugins: [BaseParagraphPlugin, BaseCodeBlockPlugin],
+    selection: input.selection,
+    value: input.children,
+  });
+
+const createEditorWithLink = (input: SlateEditor) =>
+  createSlateEditor({
+    plugins: [BaseParagraphPlugin, BaseCodeBlockPlugin, BaseLinkPlugin],
     selection: input.selection,
     value: input.children,
   });
@@ -124,6 +132,42 @@ describe('when pasting text into a code block', () => {
     ) as any as SlateEditor;
 
     const editor = createEditor(input);
+
+    editor.tf.insertData(data);
+
+    expect(editor.children).toEqual(expected.children);
+  });
+
+  it('keeps pasted // comments as plain code when link plugin is present', () => {
+    const input = (
+      <editor>
+        <hcodeblock>
+          <hcodeline>
+            <cursor />
+          </hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any as SlateEditor;
+
+    const data = createDataTransfer(
+      new Map([
+        ['text/plain', '// this is a comment\nconsole.log("hello world");'],
+      ])
+    );
+
+    const expected = (
+      <editor>
+        <hcodeblock>
+          <hcodeline>// this is a comment</hcodeline>
+          <hcodeline>
+            console.log("hello world");
+            <cursor />
+          </hcodeline>
+        </hcodeblock>
+      </editor>
+    ) as any as SlateEditor;
+
+    const editor = createEditorWithLink(input);
 
     editor.tf.insertData(data);
 

--- a/packages/link/src/lib/utils/validateUrl.spec.ts
+++ b/packages/link/src/lib/utils/validateUrl.spec.ts
@@ -15,6 +15,11 @@ describe('validateUrl', () => {
       expect(validateUrl(editor, '/internal/path')).toBe(true);
     });
 
+    it('does not validate protocol-relative URLs starting with //', () => {
+      const editor = createTestEditor();
+      expect(validateUrl(editor, '//example.com')).toBe(false);
+    });
+
     it('validate anchor links starting with #', () => {
       const editor = createTestEditor();
       expect(validateUrl(editor, '#section-name')).toBe(true);

--- a/packages/link/src/lib/utils/validateUrl.ts
+++ b/packages/link/src/lib/utils/validateUrl.ts
@@ -10,7 +10,7 @@ export const validateUrl = (editor: SlateEditor, url: string): boolean => {
     editor.getOptions(BaseLinkPlugin);
 
   // Allow internal links starting with /
-  if (url.startsWith('/')) {
+  if (url.startsWith('/') && !url.startsWith('//')) {
     return true;
   }
 


### PR DESCRIPTION
## Summary
- stop treating `//...` as internal links during link validation
- add regression coverage for validator behavior and code-block paste with link plugin enabled
- add the required changeset and a solution note

Closes #4613.

## Testing
- bun test packages/code-block/src/lib/withInsertDataCodeBlock.spec.tsx packages/link/src/lib/utils/validateUrl.spec.ts
- pnpm install
- pnpm turbo build --filter=./packages/code-block --filter=./packages/link
- pnpm turbo typecheck --filter=./packages/code-block --filter=./packages/link
- pnpm lint:fix
- pnpm check