### PR TITLE
Fix release PR auto-merge checks

### DIFF
--- a/.github/workflows/changeset-auto-release.yml
+++ b/.github/workflows/changeset-auto-release.yml
@@ -31,7 +31,7 @@ jobs:
             ).href;
             const {
               getChangesetReleaseType,
-              hasChangesetFile,
+              shouldManageAutoReleaseBlock,
               upsertAutoReleaseBlock,
             } = await import(helperUrl);
 
@@ -43,8 +43,13 @@ jobs:
               per_page: 100,
             });
 
-            const hasChangeset = hasChangesetFile(files);
-            const releaseType = getChangesetReleaseType(files);
+            const hasChangeset = shouldManageAutoReleaseBlock({
+              files,
+              title: pullRequest.title ?? '',
+            });
+            const releaseType = hasChangeset
+              ? getChangesetReleaseType(files)
+              : null;
             const currentBody = pullRequest.body ?? '';
             const nextBody = upsertAutoReleaseBlock(currentBody, {
               defaultChecked: releaseType === 'patch',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,11 +58,10 @@ jobs:
     name: CI
     runs-on: ubuntu-latest
     if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.title != '[Release] Version packages') &&
-      (github.event_name != 'push' || (
+      github.event_name != 'push' || (
         github.event.head_commit.message != 'Version Packages' &&
         !contains(github.event.head_commit.message, '[skip ci]')
-      ))
+      )
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/plans/2026-04-25-release-pr-auto-release-fix.md
+++ b/docs/plans/2026-04-25-release-pr-auto-release-fix.md
@@ -1,0 +1,39 @@
+# Release PR Auto-Release Fix
+
+## Goal
+
+Fix the follow-up release PR behavior after PR #4957:
+
+- Do not add the managed `Auto release` checkbox to PRs whose title contains `Version packages`.
+- Unblock generated release PR auto-merge by letting the required `CI` check run instead of skipping it.
+- Remove the stray checkbox from PR #4961.
+
+## Findings
+
+- PR #4961 title is `[Release] Version packages`.
+- PR #4961 has auto-merge enabled, but `mergeStateStatus` is `BLOCKED`.
+- The active ruleset for `main` requires `CI` and `Vercel`.
+- PR #4961 has `Vercel` success and `CI` skipped.
+- `.github/workflows/ci.yml` skips pull requests whose title is exactly `[Release] Version packages`.
+- `.github/workflows/changeset-auto-release.yml` currently manages any PR with a `.changeset/*.md` filename, including generated release PRs that delete changesets.
+- `bun test tooling/scripts/auto-release-pr.test.mjs` failed before the helper export existed, then passed after adding the title guard helper.
+- Editing PR #4961 before this workflow fix lands triggers the old `Sync auto-release checkbox` workflow, which re-adds the block because it still runs on `[Release] Version packages`.
+
+## Plan
+
+1. [complete] Confirm the root cause with PR metadata and repo rulesets.
+2. [complete] Add helper coverage for release PR title detection and block removal.
+3. [complete] Skip checkbox management for `Version packages` PR titles.
+4. [complete] Let CI run on release PR pull_request events.
+5. [complete] Verify with targeted tests and repo checks.
+6. [in_progress] Commit, push, open PR.
+7. [pending] Clean up PR #4961 body after the workflow fix lands.
+
+## Verification
+
+- `bun test tooling/scripts/auto-release-pr.test.mjs` failed before implementation, then passed after the helper/workflow fix.
+- `node --check tooling/scripts/auto-release-pr.mjs && node --check tooling/scripts/auto-release-pr.test.mjs` passed.
+- `ruby -e 'require "yaml"; ...' .github/workflows/ci.yml .github/workflows/changeset-auto-release.yml` passed.
+- `git diff --check` passed.
+- `pnpm lint:fix` passed with no fixes.
+- `pnpm check` passed. Existing warning: `apps/www/src/registry/ui/footnote-node.tsx` hook dependency warning.

--- a/docs/solutions/workflow-issues/2026-04-24-changeset-pr-auto-release-checkbox.md
+++ b/docs/solutions/workflow-issues/2026-04-24-changeset-pr-auto-release-checkbox.md
@@ -8,6 +8,7 @@ component: development_workflow
 symptoms:
   - Changeset PRs require a manual follow-up merge of the Version Packages PR.
   - Release intent is easy to miss when it only lives in chat or reviewer memory.
+  - Auto-merge can be enabled but stay blocked when a required check is skipped.
 root_cause: missing_workflow_step
 resolution_type: workflow_improvement
 severity: medium
@@ -31,6 +32,7 @@ Changeset PRs create a follow-up `[Release] Version packages` PR after merge. Wh
 - Putting a static checkbox in the PR template would show up on every PR, including PRs with no changeset.
 - Adding only a comment would be easy to miss and harder to treat as the source of truth.
 - Auto-merging the release PR with the default `GITHUB_TOKEN` is risky because GitHub suppresses workflow runs triggered by that token, which can prevent the publish workflow from firing after the release PR merge.
+- Skipping CI for `[Release] Version packages` PRs leaves the required `CI` check skipped, so GitHub auto-merge stays blocked.
 
 ## Solution
 
@@ -42,6 +44,8 @@ Use a managed PR-body checkbox plus release workflow enforcement:
 4. In the release workflow, inspect the merged PR associated with the push to `main`.
 5. If the merged PR has a checked managed checkbox and a changeset file, enable auto-merge on the generated release PR.
 6. Use `API_TOKEN_GITHUB` for the merge path so the follow-up publish workflow can run.
+7. Do not add the managed checkbox to PRs whose title contains `Version packages`.
+8. Let required checks run on release PRs; a skipped required check is not a mergeable check.
 
 ```yaml
 env:
@@ -61,10 +65,14 @@ The PR body is the right place for human release intent because it is visible be
 
 Using the PAT is the critical bit. The release PR merge must create the normal push event that runs the publish path.
 
+Generated release PRs are the output of that intent, not a new decision point. They should not get their own `Auto release` checkbox. If branch rules require `CI`, release PRs need a successful `CI` run rather than a skipped one.
+
 ## Prevention
 
 - Keep dynamic release intent in a managed PR-body block, not only in comments.
 - Default low-risk patch release PRs to checked, but make `minor` and `major` releases an explicit opt-in.
+- Exclude PR titles containing `Version packages` from checkbox management.
+- Do not skip checks that branch rules require for release PR auto-merge.
 - For `pull_request_target`, only run trusted base-repo code and read untrusted PR data through the GitHub API.
 - Do not use default `GITHUB_TOKEN` for workflow-triggering release merges.
 - Add helper tests for checkbox preservation, changeset-file detection, and ignoring stray checkbox text outside the managed block.

--- a/tooling/scripts/auto-release-pr.mjs
+++ b/tooling/scripts/auto-release-pr.mjs
@@ -12,6 +12,7 @@ const checkedAutoReleasePattern =
   /-\s*\[[xX]\]\s*(?:Auto release|Auto-merge the Version Packages PR after this PR lands\.)/;
 const changesetFrontmatterPattern = /^---\r?\n([\s\S]*?)\r?\n---/;
 const changesetReleaseTypePattern = /:\s*(major|minor|patch)\b/g;
+const versionPackagesTitlePattern = /\bVersion Packages\b/i;
 
 export function hasChangesetFile(files) {
   return files.some((file) => {
@@ -41,6 +42,14 @@ export function isAutoReleaseChecked(body = '') {
   const block = getAutoReleaseBlock(body);
 
   return checkedAutoReleasePattern.test(block);
+}
+
+export function isVersionPackagesTitle(title = '') {
+  return versionPackagesTitlePattern.test(title);
+}
+
+export function shouldManageAutoReleaseBlock({ files, title }) {
+  return !isVersionPackagesTitle(title) && hasChangesetFile(files);
 }
 
 export function upsertAutoReleaseBlock(

--- a/tooling/scripts/auto-release-pr.test.mjs
+++ b/tooling/scripts/auto-release-pr.test.mjs
@@ -7,6 +7,8 @@ import {
   getChangesetReleaseType,
   hasChangesetFile,
   isAutoReleaseChecked,
+  isVersionPackagesTitle,
+  shouldManageAutoReleaseBlock,
   upsertAutoReleaseBlock,
 } from './auto-release-pr.mjs';
 
@@ -20,6 +22,29 @@ test('detects real changeset files', () => {
   assert.equal(
     hasChangesetFile(['.changeset/README.md', 'packages/media/src/index.ts']),
     false
+  );
+});
+
+test('detects Version packages release PR titles', () => {
+  assert.equal(isVersionPackagesTitle('[Release] Version packages'), true);
+  assert.equal(isVersionPackagesTitle('chore: Version Packages'), true);
+  assert.equal(isVersionPackagesTitle('Fix media parser'), false);
+});
+
+test('does not manage auto-release blocks on Version packages PRs', () => {
+  assert.equal(
+    shouldManageAutoReleaseBlock({
+      files: ['.changeset/media-redos.md'],
+      title: '[Release] Version packages',
+    }),
+    false
+  );
+  assert.equal(
+    shouldManageAutoReleaseBlock({
+      files: ['.changeset/media-redos.md'],
+      title: 'Fix media parser',
+    }),
+    true
   );
 });
 


### PR DESCRIPTION
## Summary

- Skip managed `Auto release` checkbox management for PR titles containing `Version packages`.
- Let release PR pull_request runs produce the required `CI` check instead of a skipped required check.
- Add helper coverage and document the release-PR ruleset trap.

## Verification

- `bun test tooling/scripts/auto-release-pr.test.mjs`
- `node --check tooling/scripts/auto-release-pr.mjs && node --check tooling/scripts/auto-release-pr.test.mjs`
- `ruby -e 'require "yaml"; ...' .github/workflows/ci.yml .github/workflows/changeset-auto-release.yml`
- `git diff --check`
- `pnpm lint:fix`
- `pnpm check`

## Note

PR #4961 already has auto-merge enabled. It is blocked because `CI` is a required check and the current workflow marks it skipped for `[Release] Version packages` PRs.