### PR TITLE
fix(markdown): respect resourceLink for bare autolinks

### DIFF
--- a/.changeset/sharp-autolinks-respect-resource-links.md
+++ b/.changeset/sharp-autolinks-respect-resource-links.md
@@ -1,0 +1,5 @@
+---
+"@platejs/markdown": patch
+---
+
+Respect `resourceLink` when serializing bare autolink literals

--- a/docs/solutions/logic-errors/2026-04-03-gfm-extension-fallbacks-must-preserve-user-visible-syntax.md
+++ b/docs/solutions/logic-errors/2026-04-03-gfm-extension-fallbacks-must-preserve-user-visible-syntax.md
@@ -1,19 +1,22 @@
 ---
 module: Markdown
 date: 2026-04-03
+last_updated: 2026-05-11
 problem_type: logic_error
 component: markdown_serializer
 symptoms:
   - "Bare URL links serialized as bracket links instead of staying plain URLs."
+  - "Bare URL links ignored `remarkStringifyOptions.resourceLink = true`."
   - "Footnote references disappeared during markdown deserialization."
   - "Unsupported GFM constructs silently lost the user-visible syntax even when the text itself still mattered."
 root_cause: logic_error
-resolution_type: code_change
+resolution_type: code_fix
 severity: medium
 tags:
   - markdown
   - gfm
   - autolink
+  - resource-link
   - footnote
   - serializer
   - fallback
@@ -44,9 +47,17 @@ model yet, it still has to preserve the syntax users actually typed.
 ### Autolink literal
 
 When a link node is just a plain URL with identical text and href, serialize it
-as raw markdown text instead of a normal link node:
+as raw markdown text instead of a normal link node, unless the caller explicitly
+forces resource links:
 
 ```ts
+const isBareAutolinkLiteral =
+  children.length === 1 &&
+  children[0]?.type === 'text' &&
+  children[0].value === node.url &&
+  options.remarkStringifyOptions?.resourceLink !== true &&
+  BARE_AUTOLINK_PROTOCOL_REGEX.test(node.url ?? '');
+
 if (isBareAutolinkLiteral) {
   return {
     type: 'html',
@@ -62,6 +73,13 @@ https://platejs.org
 ```
 
 instead of degrading to:
+
+```md
+[https://platejs.org](https://platejs.org)
+```
+
+But when the caller sets `remarkStringifyOptions.resourceLink = true`, return
+the normal mdast `link` node and let `remark-stringify` emit:
 
 ```md
 [https://platejs.org](https://platejs.org)
@@ -96,16 +114,24 @@ If full support is not there yet, fallback still needs to preserve what the
 user sees and typed. Losing the marker or rewriting a URL into a different link
 form is data drift, not a harmless implementation detail.
 
+Serializer fallbacks also have to stay below caller-controlled stringify
+options. If an option like `resourceLink` exists specifically to force a
+markdown wire shape, the Plate shortcut should yield the normal mdast node and
+let `remark-stringify` honor that setting.
+
 ## Prevention
 
 - For every unsupported or partially supported markdown extension, define an
   explicit fallback contract.
 - Fallback contracts should preserve user-visible syntax before they preserve
   internal shape convenience.
+- Before returning raw markdown/html from a serializer shortcut, check whether
+  `remarkStringifyOptions` already exposes the caller's requested wire shape.
 - Add package-surface tests for:
   - parse
   - serialize
   - deserialize after serialize
+  - explicit `remarkStringifyOptions` overrides for the same surface
 - Do not accept "the text is still there somewhere" as good enough when the
   syntax itself carries meaning.
 
@@ -115,5 +141,15 @@ These checks passed:
 
 ```bash
 bun test packages/markdown/src/lib/gfmSurface.spec.ts packages/markdown/src/lib/commonmarkSurface.spec.ts packages/markdown/src/lib/defaultRules.spec.ts apps/www/src/__tests__/package-integration/markdown-rich/defaultRule.spec.ts packages/link/src/lib/withLink.spec.tsx
+pnpm lint:fix
+```
+
+Additional resource-link regression:
+
+```bash
+pnpm exec bun test packages/markdown/src/lib/gfmSurface.spec.ts
+pnpm turbo build --filter=./packages/markdown
+pnpm build
+pnpm turbo typecheck --filter=./packages/markdown
 pnpm lint:fix
 ```

--- a/packages/markdown/src/lib/gfmSurface.spec.ts
+++ b/packages/markdown/src/lib/gfmSurface.spec.ts
@@ -53,6 +53,29 @@ describe('gfm package surfaces', () => {
     expect(deserializeMd(editor, markdown)).toMatchObject(value);
   });
 
+  it('respects resourceLink when serializing bare autolink literals', () => {
+    const editor = createTestEditor();
+    const value = [
+      {
+        children: [
+          {
+            children: [{ text: 'https://platejs.org' }],
+            type: 'a',
+            url: 'https://platejs.org',
+          },
+        ],
+        type: 'p',
+      },
+    ];
+
+    expect(
+      serializeMd(editor, {
+        remarkStringifyOptions: { resourceLink: true },
+        value: value as any,
+      })
+    ).toBe('[https://platejs.org](https://platejs.org)\n');
+  });
+
   it('round-trips footnote references and definitions as dedicated nodes', () => {
     const editor = createTestEditor();
     const input = '[^1]\n\n[^1]: Footnote text';

--- a/packages/markdown/src/lib/rules/defaultRules.ts
+++ b/packages/markdown/src/lib/rules/defaultRules.ts
@@ -152,6 +152,7 @@ export const defaultRules: MdRules = {
         children.length === 1 &&
         children[0]?.type === 'text' &&
         children[0].value === node.url &&
+        options.remarkStringifyOptions?.resourceLink !== true &&
         BARE_AUTOLINK_PROTOCOL_REGEX.test(node.url ?? '');
 
       if (isBareAutolinkLiteral) {


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

Fix markdown serialization so bare autolink literals respect `remarkStringifyOptions.resourceLink`. When callers force resource links, Plate now returns the normal mdast link and lets `remark-stringify` emit `[url](url)` instead of short-circuiting to raw autolink text.

Adds a regression test for the `resourceLink: true` case, updates the markdown solution note, and includes a patch changeset for `@platejs/markdown`.

Testing: fully tested

- `CI=true pnpm install`
- `pnpm exec bun test packages/markdown/src/lib/gfmSurface.spec.ts`
- `pnpm turbo build --filter=./packages/markdown`
- `pnpm turbo typecheck --filter=./packages/markdown`
- `pnpm lint:fix`

AI-assisted: yes. I understand what the change does.
