### PR TITLE
fix(core): restore markdown shortcuts and text substitutions after autoformat deprecation

### DIFF
--- a/.changeset/fix-configure-input-rules-mutation.md
+++ b/.changeset/fix-configure-input-rules-mutation.md
@@ -1,0 +1,7 @@
+---
+"@platejs/core": patch
+---
+
+Fix `.configure({ inputRules })` losing rules on subsequent editor instances
+
+The user's config object was shared across resolutions via closure; clearing `inputRules` on the first resolve left later editors (StrictMode remounts, HMR, multi-editor pages) with no configured rules.

--- a/.changeset/fix-text-substitution-trigger.md
+++ b/.changeset/fix-text-substitution-trigger.md
@@ -1,0 +1,5 @@
+---
+"@platejs/core": patch
+---
+
+Fix `createTextSubstitutionInputRule` not firing on the final character of flat matches (e.g. `->` → `→`, `(c)` → `©`)

--- a/packages/core/src/internal/plugin/resolvePlugin.spec.ts
+++ b/packages/core/src/internal/plugin/resolvePlugin.spec.ts
@@ -88,4 +88,22 @@ describe('resolvePlugin', () => {
       undefined
     );
   });
+
+  it('does not mutate the configured plugin between editor instances', () => {
+    const configured = createSlatePlugin({ key: 'p' }).configure({
+      inputRules: [
+        {
+          apply: () => true,
+          target: 'insertText',
+          trigger: ' ',
+        } as any,
+      ],
+    });
+
+    const e1 = createSlateEditor({ plugins: [configured] });
+    expect((e1.plugins.p as any).__configuredInputRules?.length).toBe(1);
+
+    const e2 = createSlateEditor({ plugins: [configured] });
+    expect((e2.plugins.p as any).__configuredInputRules?.length).toBe(1);
+  });
 });

--- a/packages/core/src/internal/plugin/resolvePlugin.ts
+++ b/packages/core/src/internal/plugin/resolvePlugin.ts
@@ -42,14 +42,17 @@ export const resolvePlugin = <P extends AnySlatePlugin>(
 
   // Apply the stored configuration first
   if (plugin.__configuration) {
-    const configResult = plugin.__configuration(
+    const rawConfigResult = plugin.__configuration(
       getEditorPlugin(editor, plugin as any)
     ) as any;
+    // Copy before mutating: the user's config object is captured by closure
+    // and reused across editor instances, so mutating it would clear
+    // inputRules on subsequent resolutions.
+    const { inputRules: configInputRules, ...configResult } = rawConfigResult;
 
-    if (configResult.inputRules !== undefined) {
-      const normalizedInputRules = normalizeConfiguredInputRules(
-        configResult.inputRules
-      );
+    if (configInputRules !== undefined) {
+      const normalizedInputRules =
+        normalizeConfiguredInputRules(configInputRules);
 
       (plugin as any).__configuredInputRules = [
         ...normalizeConfiguredInputRules(
@@ -57,7 +60,6 @@ export const resolvePlugin = <P extends AnySlatePlugin>(
         ),
         ...normalizedInputRules,
       ];
-      configResult.inputRules = undefined;
     }
 
     plugin = mergePlugins(plugin, configResult);

--- a/packages/core/src/lib/plugins/input-rules/createInputRules.ts
+++ b/packages/core/src/lib/plugins/input-rules/createInputRules.ts
@@ -446,17 +446,15 @@ const getTextSubstitutionMatchRange = ({
   match: string;
   trigger?: readonly string[] | string;
 }) => {
-  const start = match;
-  const reversed = start.split('').reverse().join('');
   const triggers = trigger
     ? Array.isArray(trigger)
       ? [...trigger]
       : [trigger]
-    : [reversed.slice(-1)];
+    : [match.slice(-1)];
 
   return {
-    end: trigger ? reversed : reversed.slice(0, -1),
-    start,
+    end: trigger ? match : match.slice(0, -1),
+    start: match,
     triggers,
   };
 };
@@ -507,38 +505,22 @@ const getTextSubstitutionMatchPoints = (
   };
 };
 
-const getTextSubstitutionTriggers = (patterns: TextSubstitutionPattern[]) =>
-  Array.from(
-    new Set(
-      patterns.flatMap((pattern) => {
-        const matches = Array.isArray(pattern.match)
-          ? [...pattern.match]
-          : [pattern.match];
+type CompiledPattern = {
+  end: string;
+  pattern: TextSubstitutionPattern;
+  start: string;
+};
 
-        return matches.flatMap(
-          (match) =>
-            getTextSubstitutionMatchRange({
-              match,
-              trigger: pattern.trigger,
-            }).triggers
-        );
-      })
-    )
-  );
+const compilePatternsByTrigger = (
+  patterns: TextSubstitutionPattern[]
+): Map<string, CompiledPattern[]> => {
+  const byTrigger = new Map<string, CompiledPattern[]>();
 
-const resolveTextSubstitution = ({
-  editor,
-  patterns,
-  text,
-}: {
-  editor: SlateEditor;
-  patterns: TextSubstitutionPattern[];
-  text: string;
-}): TextSubstitutionMatch | undefined => {
   for (const pattern of patterns) {
     const matches = Array.isArray(pattern.match)
-      ? [...pattern.match]
+      ? pattern.match
       : [pattern.match];
+    const isPaired = Array.isArray(pattern.format);
 
     for (const match of matches) {
       const { end, start, triggers } = getTextSubstitutionMatchRange({
@@ -546,21 +528,45 @@ const resolveTextSubstitution = ({
         trigger: pattern.trigger,
       });
 
-      if (!triggers.includes(text)) continue;
-
-      const points = getTextSubstitutionMatchPoints(editor, {
-        end: Array.isArray(pattern.format) ? '' : end,
-        start,
-      });
-
-      if (!points) continue;
-
-      return {
-        end: Array.isArray(pattern.format) ? '' : end,
+      const compiled: CompiledPattern = {
+        end: isPaired ? '' : end,
         pattern,
-        points,
+        start: isPaired ? start : '',
       };
+
+      for (const trigger of triggers) {
+        let list = byTrigger.get(trigger);
+
+        if (!list) {
+          list = [];
+          byTrigger.set(trigger, list);
+        }
+
+        list.push(compiled);
+      }
     }
+  }
+
+  return byTrigger;
+};
+
+const resolveTextSubstitution = ({
+  candidates,
+  editor,
+}: {
+  candidates: CompiledPattern[];
+  editor: SlateEditor;
+}): TextSubstitutionMatch | undefined => {
+  for (const { end, pattern, start } of candidates) {
+    const points = getTextSubstitutionMatchPoints(editor, { end, start });
+
+    if (!points) continue;
+
+    return {
+      end,
+      pattern,
+      points,
+    };
   }
 };
 
@@ -610,21 +616,25 @@ export const createTextSubstitutionInputRule = ({
   enabled,
   patterns,
   priority,
-}: TextSubstitutionInputRuleConfig) =>
-  defineInputRule({
+}: TextSubstitutionInputRuleConfig) => {
+  const patternsByTrigger = compilePatternsByTrigger(patterns);
+  const triggers = Array.from(patternsByTrigger.keys());
+
+  return defineInputRule({
     enabled,
     priority,
     target: 'insertText',
-    trigger: getTextSubstitutionTriggers(patterns),
+    trigger: triggers,
     resolve: ({ editor, text }) => {
       if (!editor.selection || !editor.api.isCollapsed()) return;
 
-      return resolveTextSubstitution({
-        editor,
-        patterns,
-        text,
-      });
+      const candidates = patternsByTrigger.get(text);
+
+      if (!candidates) return;
+
+      return resolveTextSubstitution({ candidates, editor });
     },
     apply: ({ editor }, match: TextSubstitutionMatch) =>
       applyTextSubstitution(editor, match),
   });
+};

--- a/packages/core/src/lib/plugins/input-rules/createTextSubstitutionInputRule.spec.ts
+++ b/packages/core/src/lib/plugins/input-rules/createTextSubstitutionInputRule.spec.ts
@@ -1,0 +1,85 @@
+import { createSlateEditor } from '../../editor';
+import { createSlatePlugin } from '../../plugin';
+import { createTextSubstitutionInputRule } from './createInputRules';
+
+const createEditor = (
+  rule: ReturnType<typeof createTextSubstitutionInputRule>
+) =>
+  createSlateEditor({
+    plugins: [createSlatePlugin({ key: 'shortcuts', inputRules: [rule] })],
+    selection: {
+      anchor: { offset: 0, path: [0, 0] },
+      focus: { offset: 0, path: [0, 0] },
+    },
+    value: [{ children: [{ text: '' }], type: 'p' }],
+  } as any);
+
+describe('createTextSubstitutionInputRule', () => {
+  it('substitutes a flat match on its final character (`->` → `→`)', () => {
+    const rule = createTextSubstitutionInputRule({
+      patterns: [{ format: '→', match: '->' }],
+    });
+    const editor = createEditor(rule);
+
+    editor.tf.insertText('-');
+    editor.tf.insertText('>');
+
+    expect(editor.children).toEqual([{ children: [{ text: '→' }], type: 'p' }]);
+  });
+
+  it('keeps the literal text when only the leading character is typed', () => {
+    const rule = createTextSubstitutionInputRule({
+      patterns: [{ format: '→', match: '->' }],
+    });
+    const editor = createEditor(rule);
+
+    editor.tf.insertText('-');
+
+    expect(editor.children).toEqual([{ children: [{ text: '-' }], type: 'p' }]);
+  });
+
+  it('substitutes multi-character flat matches (`(c)` → `©`)', () => {
+    const rule = createTextSubstitutionInputRule({
+      patterns: [{ format: '©', match: '(c)' }],
+    });
+    const editor = createEditor(rule);
+
+    editor.tf.insertText('(');
+    editor.tf.insertText('c');
+    editor.tf.insertText(')');
+
+    expect(editor.children).toEqual([{ children: [{ text: '©' }], type: 'p' }]);
+  });
+
+  it('wraps paired delimiters on the closing character (smart quotes)', () => {
+    const rule = createTextSubstitutionInputRule({
+      patterns: [{ format: ['“', '”'], match: '"' }],
+    });
+    const editor = createEditor(rule);
+
+    editor.tf.insertText('"');
+    editor.tf.insertText('h');
+    editor.tf.insertText('i');
+    editor.tf.insertText('"');
+
+    expect(editor.children).toEqual([
+      { children: [{ text: '“hi”' }], type: 'p' },
+    ]);
+  });
+
+  it('fires on the explicit trigger when provided', () => {
+    const rule = createTextSubstitutionInputRule({
+      patterns: [{ format: 'FOO', match: 'foo', trigger: ' ' }],
+    });
+    const editor = createEditor(rule);
+
+    editor.tf.insertText('f');
+    editor.tf.insertText('o');
+    editor.tf.insertText('o');
+    editor.tf.insertText(' ');
+
+    expect(editor.children).toEqual([
+      { children: [{ text: 'FOO' }], type: 'p' },
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

Closes #4968 

**Checklist**

- [x] `pnpm typecheck`
- [x] `pnpm lint:fix`
- [x] `bun test`
- [x] `pnpm brl`
- [x] `pnpm changeset`

## Summary

This PR fixes two regressions introduced with the `@platejs/autoformat` → per-plugin `inputRules` migration in v53. Either alone is enough to make the examples in docs feel broken; together they explain every variant of "shortcuts stopped working" being reported.

1. **`createTextSubstitutionInputRule` mis-derives the trigger character.** Inline patterns like `->` → `→`, `(c)` → `©`, arrows, fractions, sub/superscripts all silently no-op on every keystroke.
2. **`resolvePlugin` mutates the user's plugin config object.** Any second editor instance built from the same kit array (StrictMode remount, HMR, multi-editor page) loses every `.configure({ inputRules: [...] })` rule — heading/list/blockquote/mark shortcuts stop firing entirely.


## Bug 1 - text substitutions never fire on the right trigger

**Where:** `packages/core/src/lib/plugins/input-rules/createInputRules.ts` (`getTextSubstitutionMatchRange`)

**Root cause:** the v53 rewrite collapsed v52's `{ end: match, start: '' }` non-paired branch and the paired single-char branch into one path that always reverses the match string. For non-paired patterns the slice math then inverts:

```ts
// v53 (buggy)
const reversed = match.split('').reverse().join('');
const triggers = trigger ? ... : [reversed.slice(-1)]; // FIRST char of match
return { end: trigger ? reversed : reversed.slice(0, -1), ... }; // LAST char of match
```

For `match: '->'` the trigger becomes `'-'` and the search string becomes `'>'`, so the rule registers under the wrong key and, even when it fires, searches for `>` in the doc before the cursor — which can never be there because the user just typed it. Single-char paired patterns (smart quotes) accidentally worked because `reversed === match` collapses both branches to the same result.

**Fix:** drop the reversal entirely.

```ts
const triggers = trigger ? ... : [match.slice(-1)];           // last char triggers
return { end: trigger ? match : match.slice(0, -1), start: match, triggers };
```

Then mirror the existing `end: isPaired ? '' : end` override with `start: isPaired ? start : ''` in `resolveTextSubstitution`, so non-paired patterns don't try to find an opening delimiter that doesn't exist.

**Drive-by perf refactor (in the same function):** `resolveTextSubstitution` was rebuilding the `{ end, start, triggers }` tuple for every pattern on every keystroke (~50 patterns in `AutoformatKit`), then doing a linear `triggers.includes(text)` scan to filter. The result is deterministic per pattern, so I lift it into `compilePatternsByTrigger(patterns)` once at rule construction:

| | Before | After |
| --- | --- | --- |
| Per-keystroke work | `O(P)` string allocs + scans, where `P` = total patterns across the rule | `O(1)` `Map.get(text)` + iterate only patterns whose trigger equals `text` |
| Branching | `Array.isArray(pattern.format) ? ... : ...` twice per pattern per keystroke | once per pattern at construction |
| Allocations on insertText | one tuple object + one triggers array per pattern | none |
| Memory at rest | unchanged | one `Map<string, CompiledPattern[]>` per rule + one `CompiledPattern` per match string |

The `Map` lookup also means typing any character that isn't a trigger short-circuits to zero work, instead of iterating every pattern.

## Bug 2 - `.configure({ inputRules })` loses its rules on second resolve

**Where:** `packages/core/src/internal/plugin/resolvePlugin.ts`

**Root cause:** `plugin.configure(config)` stores a closure that returns the user's `config` object by reference:

```ts
// createSlatePlugin.ts:148
newPlugin.__configuration = (ctx) =>
  isFunction(config) ? config(ctx) : config; // same `config` ref every call
```

Then `resolvePlugin` consumes `inputRules` by mutating that exact object:

```ts
// resolvePlugin.ts (before)
const configResult = plugin.__configuration(...);
if (configResult.inputRules !== undefined) {
  (plugin as any).__configuredInputRules = [...];
  configResult.inputRules = undefined; // ← writes back into the user's config
}
```

On the **first** editor creation, `__configuredInputRules` is populated correctly. On the **second** editor creation using the same kit array, the closure returns the same `config` object — but now its `inputRules` is `undefined`, the `if` is skipped, and the plugin gets no configured rules. Verified with a `Proxy` and direct property inspection:

```
BEFORE editor 1: __configuration() returns { inputRules: [...1] }
AFTER  editor 1: __configuration() returns { inputRules: undefined }  ← mutation
```

This is what the user observed on `/editors`: the AI block iframe mounts twice (React StrictMode + iframe load behavior), so the second editor it builds from `EditorKit` has zero configured rules for `h1..h6`, `blockquote`, `bold`, `italic`, `list`, etc. The basic editor next to it only mounts once, so its rules survive.

**Fix:** rest-destructure instead of mutating.

```ts
const rawConfigResult = plugin.__configuration(...) as any;
// Copy before mutating: the user's config object is captured by closure
// and reused across editor instances, so mutating it would clear
// inputRules on subsequent resolutions.
const { inputRules: configInputRules, ...configResult } = rawConfigResult;

if (configInputRules !== undefined) {
  (plugin as any).__configuredInputRules = [
    ...normalizeConfiguredInputRules((plugin as any).__configuredInputRules),
    ...normalizeConfiguredInputRules(configInputRules),
  ];
}

plugin = mergePlugins(plugin, configResult);
```

Same allocation cost as the previous code (which already created `configResult`), zero added work in the steady state. Local copy is the only `inputRules` reference we mutate; the user's object stays intact.
