### PR TITLE
fix(docx-io): drop leading blank paragraphs in exportToDocx

### DIFF
--- a/.changeset/docx-export-leading-blanks.md
+++ b/.changeset/docx-export-leading-blanks.md
@@ -1,0 +1,5 @@
+---
+'@platejs/docx-io': patch
+---
+
+Fix `exportToDocx` adding blank paragraphs at the top of the document. `wrapHtmlForDocx` emitted a `<!DOCTYPE html>` and indented the template; html-to-docx (html-to-vdom) keeps the DOCTYPE and the whitespace-only text nodes between tags and renders each as a blank paragraph. The wrapper now emits tight markup with no DOCTYPE.

--- a/packages/docx-io/src/lib/docx-export-plugin.tsx
+++ b/packages/docx-io/src/lib/docx-export-plugin.tsx
@@ -381,18 +381,13 @@ function wrapHtmlForDocx(bodyHtml: string, customStyles?: string): string {
     ? `${DOCX_EXPORT_STYLES}\n${customStyles}`
     : DOCX_EXPORT_STYLES;
 
-  return `<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <style>
-${styles}
-    </style>
-  </head>
-  <body>
-${bodyHtml}
-  </body>
-</html>`;
+  // No DOCTYPE and no inter-tag whitespace. html-to-docx parses the whole
+  // document with html-to-vdom, which keeps the DOCTYPE and the whitespace-only
+  // text nodes between <html>/<head>/<body> and turns each into a blank
+  // paragraph at the top of the generated document. Keeping the markup tight
+  // avoids those leading blank lines. The `\n` inside <style> is harmless since
+  // <head> is skipped by the converter.
+  return `<html lang="en"><head><meta charset="utf-8" /><style>${styles}</style></head><body>${bodyHtml}</body></html>`;
 }
 
 /**


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## Summary

`exportToDocx` / `htmlToDocxBlob` produce a DOCX whose first page starts with ~6 empty paragraphs before any content, even when the source has no leading blanks.

## Cause

`wrapHtmlForDocx` emits a `<!DOCTYPE html>` and indents the document template. `@turbodocx/html-to-docx` parses the full document with `html-to-vdom`, which keeps the DOCTYPE node and the whitespace-only text nodes between `<html>` / `<head>` / `<body>` and the content. `convertVTreeToXML` turns each top-level text node into a paragraph (`buildParagraph`), so they become empty `<w:p>` elements at the top of the document.

## Fix

Emit tight markup with no DOCTYPE and no inter-tag whitespace. `<head>` is skipped by the converter, so the `\n` inside `<style>` is harmless.

## Evidence

Converting the same body via `htmlToDocxBlob` and counting `<w:p>` in `word/document.xml`:

| wrapper | paragraphs |
|---|---|
| current (`<!DOCTYPE…>` + indentation) | 9 (2 with text, 7 empty) |
| no inter-tag whitespace, with `<!DOCTYPE>` | 3 (1 leading empty) |
| **no DOCTYPE, no whitespace (this PR)** | **2 (clean)** |

The `<!DOCTYPE html>` alone accounts for the last remaining leading empty paragraph: with it present html-to-vdom emits a leading blank paragraph; removing it (keeping `<head>`/`<style>`) removes it.

Closes #4990

## Notes

Added a changeset (`@platejs/docx-io` patch). Styling is unaffected (still inlined via `juice` from the `<style>` block).
