### PR TITLE
fix(table): remove table when deleting final column

### DIFF
--- a/.changeset/tidy-tables-remove-last-column.md
+++ b/.changeset/tidy-tables-remove-last-column.md
@@ -1,0 +1,5 @@
+---
+"@platejs/table": patch
+---
+
+Remove the table when deleting its final column.

--- a/packages/table/src/lib/merge/deleteColumn.ts
+++ b/packages/table/src/lib/merge/deleteColumn.ts
@@ -13,6 +13,7 @@ import { BaseTablePlugin } from '../BaseTablePlugin';
 import { deleteColumnWhenExpanded } from './deleteColumnWhenExpanded';
 import { findCellByIndexes } from './findCellByIndexes';
 import { getCellPath } from './getCellPath';
+import { getTableMergedColumnCount } from './getTableMergedColumnCount';
 
 export const deleteTableMergeColumn = (editor: SlateEditor) => {
   const type = editor.getType(KEYS.table);
@@ -43,6 +44,12 @@ export const deleteTableMergeColumn = (editor: SlateEditor) => {
 
     const { col: deletingColIndex } = getCellIndices(editor, selectedCell);
     const colsDeleteNumber = api.table.getColSpan(selectedCell);
+
+    if (getTableMergedColumnCount(table) <= colsDeleteNumber) {
+      editor.tf.removeNodes({ at: tableEntry[1] });
+
+      return;
+    }
 
     const endingColIndex = deletingColIndex + colsDeleteNumber - 1;
 

--- a/packages/table/src/lib/transforms/deleteColumn.spec.tsx
+++ b/packages/table/src/lib/transforms/deleteColumn.spec.tsx
@@ -11,6 +11,49 @@ import { deleteColumn } from './deleteColumn';
 jsxt;
 
 describe('deleteColumn', () => {
+  it.each([
+    { disableMerge: true },
+    { disableMerge: false },
+  ])('removes the table when deleting its last column (disableMerge: $disableMerge)', ({
+    disableMerge,
+  }) => {
+    const input = (
+      <editor>
+        <hp>before</hp>
+        <htable>
+          <htr>
+            <htd>
+              <hp>
+                11
+                <cursor />
+              </hp>
+            </htd>
+          </htr>
+          <htr>
+            <htd>
+              <hp>21</hp>
+            </htd>
+          </htr>
+        </htable>
+        <hp>after</hp>
+      </editor>
+    ) as any as SlateEditor;
+
+    const editor = createSlateEditor({
+      nodeId: true,
+      plugins: getTestTablePlugins({ disableMerge }),
+      selection: input.selection,
+      value: input.children,
+    });
+
+    deleteColumn(editor);
+
+    expect(editor.children).toMatchObject([
+      { children: [{ text: 'before' }], type: 'p' },
+      { children: [{ text: 'after' }], type: 'p' },
+    ]);
+  });
+
   describe('when 2x2', () => {
     it.each([
       { disableMerge: true },

--- a/packages/table/src/lib/transforms/deleteColumn.ts
+++ b/packages/table/src/lib/transforms/deleteColumn.ts
@@ -6,6 +6,7 @@ import type { TableConfig } from '../BaseTablePlugin';
 
 import { deleteTableMergeColumn } from '../merge/deleteColumn';
 import { deleteColumnWhenExpanded } from '../merge/deleteColumnWhenExpanded';
+import { getTableColumnCount } from '../queries';
 import { getCellTypes } from '../utils';
 
 export const deleteColumn = (editor: SlateEditor) => {
@@ -35,6 +36,12 @@ export const deleteColumn = (editor: SlateEditor) => {
     const trEntry = editor.api.above({
       match: { type: editor.getType(KEYS.tr) },
     });
+
+    if (tdEntry && trEntry && getTableColumnCount(tableEntry[0]) <= 1) {
+      editor.tf.removeNodes({ at: tableEntry[1] });
+
+      return;
+    }
 
     if (
       tdEntry &&


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## Summary
- remove the current table when deleting the last remaining table column
- apply the behavior in both merge and non-merge table delete-column paths
- add regression coverage for preserving surrounding blocks after the table is removed

Fixes #4993.

## AI-assisted
- AI-assisted: yes
- Testing level: tested locally
- I reviewed the patch and understand what it changes

## Tests
- `pnpm exec bun tooling/scripts/test-fast.mjs packages/table/src/lib/transforms/deleteColumn.spec.tsx packages/table/src/lib/merge/deleteColumn.spec.tsx`
- `pnpm --filter @platejs/table test`
- `pnpm --filter @platejs/table build`
- `pnpm --filter @platejs/table lint`
- `pnpm lint:fix`
- `git diff --check`

## Notes
- `pnpm turbo typecheck --filter=./packages/table` is blocked locally by existing table test/slow-file JSX typing setup errors, starting with missing `@platejs/test-utils` declarations and `JSX.IntrinsicElements` errors in untouched table test files.
