### PR TITLE
feat(docx-io): forward pageSize and document font in exportToDocx

### DIFF
--- a/.changeset/docx-io-forward-pagesize.md
+++ b/.changeset/docx-io-forward-pagesize.md
@@ -1,0 +1,5 @@
+---
+'@platejs/docx-io': minor
+---
+
+Add a `pageSize` option to `exportToDocx`. The underlying html-to-docx engine already accepts a page size, but `exportToDocx` only forwarded `margins` and `orientation`, so the exported document was always the default (US Letter). You can now pass e.g. `pageSize: { width: 11906, height: 16838 }` to export A4.

--- a/.changeset/docx-io-forward-pagesize.md
+++ b/.changeset/docx-io-forward-pagesize.md
@@ -2,4 +2,7 @@
 '@platejs/docx-io': minor
 ---
 
-Add a `pageSize` option to `exportToDocx`. The underlying html-to-docx engine already accepts a page size, but `exportToDocx` only forwarded `margins` and `orientation`, so the exported document was always the default (US Letter). You can now pass e.g. `pageSize: { width: 11906, height: 16838 }` to export A4.
+Forward two dropped options in `exportToDocx`:
+
+- **`pageSize`** — the html-to-docx engine accepts a page size, but `exportToDocx` only forwarded `margins` and `orientation`, so the document was always the default (US Letter). You can now pass e.g. `pageSize: { width: 11906, height: 16838 }` to export A4.
+- **`fontFamily`** — it was only applied to the serialized HTML (and only when an `EditorStaticComponent` was provided), so the document default font was never set and Word fell back to Times New Roman. It now also sets the document default font (`documentOptions.font`).

--- a/packages/docx-io/src/lib/docx-export-plugin.tsx
+++ b/packages/docx-io/src/lib/docx-export-plugin.tsx
@@ -44,7 +44,7 @@ import { serializeHtml } from 'platejs/static';
 
 import juice from 'juice';
 
-import type { DocumentMargins } from './html-to-docx';
+import type { DocumentMargins, PageSize } from './html-to-docx';
 
 import { htmlToDocxBlob } from './html-to-docx';
 
@@ -202,6 +202,17 @@ export type DocxExportOperationOptions = {
    * @default 'portrait'
    */
   orientation?: DocxExportOrientation;
+
+  /**
+   * Page size in twentieths of a point (twips). Defaults to the html-to-docx
+   * default (US Letter) when omitted.
+   *
+   * @example
+   * ```typescript
+   * pageSize: { width: 11906, height: 16838 } // A4 portrait
+   * ```
+   */
+  pageSize?: PageSize;
 
   /**
    * Document title (for metadata purposes).
@@ -418,6 +429,7 @@ async function exportToDocxInternal(
     fontFamily,
     margins = DEFAULT_DOCX_MARGINS,
     orientation = 'portrait',
+    pageSize,
     value,
   } = options;
 
@@ -447,6 +459,7 @@ async function exportToDocxInternal(
       ...margins,
     },
     orientation,
+    pageSize,
   });
 
   return blob;

--- a/packages/docx-io/src/lib/docx-export-plugin.tsx
+++ b/packages/docx-io/src/lib/docx-export-plugin.tsx
@@ -176,12 +176,12 @@ export type DocxExportOperationOptions = {
   customStyles?: string;
 
   /**
-   * Font family for the document body.
-   * This overrides the default Calibri font.
+   * Font family for the document body. Sets the document default font; when
+   * omitted the document falls back to the docx default (Times New Roman).
    *
    * @example
    * ```typescript
-   * fontFamily: 'Times New Roman'
+   * fontFamily: 'Calibri'
    * ```
    */
   fontFamily?: string;
@@ -454,6 +454,7 @@ async function exportToDocxInternal(
 
   // Convert to DOCX using browser-compatible implementation
   const blob = await htmlToDocxBlob(inlinedHtml, {
+    font: fontFamily,
     margins: {
       ...DEFAULT_DOCX_MARGINS,
       ...margins,


### PR DESCRIPTION
<!-- auto-release:start -->
- [ ] Auto release
<!-- auto-release:end -->

## Description

`exportToDocx` silently dropped two options that the underlying html-to-docx engine already supports:

1. **`pageSize`** — `exportToDocxInternal` only forwarded `margins` and `orientation`, so the exported document always used the engine default page size (US Letter), with no way to export A4 or other formats.
2. **`fontFamily`** — it was only applied to the serialized HTML (and only when an `EditorStaticComponent` was provided), so the document default font was never set and Word fell back to **Times New Roman**, regardless of `fontFamily`.

This forwards both to html-to-docx: `pageSize` to the page geometry and `fontFamily` to `documentOptions.font` (the document default). When omitted, behavior is unchanged.

```ts
await exportToDocx(value, {
  fontFamily: 'Calibri',
  pageSize: { width: 11906, height: 16838 }, // A4 portrait (twips)
});
```

Also corrects the `fontFamily` doc comment (it claimed the default was Calibri; the engine default is Times New Roman).

Closes #4996

## Changeset

`minor` for `@platejs/docx-io` (two forwarded options).
