### PR TITLE
fix(dnd): clear stale drop indicator in editor whitespace

### DIFF
--- a/.changeset/clever-walls-drag.md
+++ b/.changeset/clever-walls-drag.md
@@ -1,0 +1,5 @@
+---
+'@platejs/dnd': patch
+---
+
+Clear stale DnD drop indicators when dragging from a block into editor whitespace.

--- a/packages/dnd/src/DndPlugin.slow.tsx
+++ b/packages/dnd/src/DndPlugin.slow.tsx
@@ -94,9 +94,14 @@ describe('DndPlugin', () => {
     const setOption = mock();
     const editorNode = document.createElement('div');
     const inside = document.createElement('div');
+    const block = document.createElement('div');
+    const blockText = document.createElement('span');
     const outside = document.createElement('div');
 
+    block.dataset.blockId = 'block-1';
+    block.append(blockText);
     editorNode.append(inside);
+    editorNode.append(block);
     document.body.append(editorNode, outside);
     editor.api.toDOMNode = mock(() => editorNode);
 
@@ -107,6 +112,15 @@ describe('DndPlugin', () => {
     };
 
     const view = render(<TestComponent />);
+    const dragLeaveEvent = (relatedTarget: EventTarget | null) => {
+      const event = new Event('dragleave', { bubbles: true });
+
+      Object.defineProperty(event, 'relatedTarget', {
+        value: relatedTarget,
+      });
+
+      return event;
+    };
 
     outside.dispatchEvent(new Event('dragleave', { bubbles: true }));
 
@@ -114,6 +128,24 @@ describe('DndPlugin', () => {
 
     setOption.mockClear();
     inside.dispatchEvent(new Event('dragleave', { bubbles: true }));
+
+    expect(setOption).not.toHaveBeenCalled();
+
+    block.dispatchEvent(dragLeaveEvent(editorNode));
+
+    expect(setOption).toHaveBeenCalledWith('dropTarget', undefined);
+
+    setOption.mockClear();
+    blockText.dispatchEvent(dragLeaveEvent(inside));
+
+    expect(setOption).toHaveBeenCalledWith('dropTarget', undefined);
+
+    setOption.mockClear();
+    const nextBlock = document.createElement('div');
+    nextBlock.dataset.blockId = 'block-2';
+    editorNode.append(nextBlock);
+
+    block.dispatchEvent(dragLeaveEvent(nextBlock));
 
     expect(setOption).not.toHaveBeenCalled();
 

--- a/packages/dnd/src/DndPlugin.tsx
+++ b/packages/dnd/src/DndPlugin.tsx
@@ -94,10 +94,30 @@ export const DndPlugin = createTPlatePlugin<DndConfig>({
         if (e.target instanceof Node) {
           const editorDOMNode = editor.api.toDOMNode(editor);
 
-          if (
-            editorDOMNode &&
-            !(e.target === editorDOMNode || editorDOMNode.contains(e.target))
-          ) {
+          if (!editorDOMNode) return;
+
+          const targetElement =
+            e.target instanceof HTMLElement ? e.target : e.target.parentElement;
+          const relatedTarget = e.relatedTarget;
+          const relatedElement =
+            relatedTarget instanceof HTMLElement
+              ? relatedTarget
+              : relatedTarget instanceof Node
+                ? relatedTarget.parentElement
+                : null;
+          const targetBlock = targetElement?.closest('[data-block-id]');
+          const relatedBlock = relatedElement?.closest('[data-block-id]');
+          const isLeavingEditor = !(
+            e.target === editorDOMNode || editorDOMNode.contains(e.target)
+          );
+          const isLeavingBlockForEditorWhitespace =
+            !!targetBlock &&
+            !relatedBlock &&
+            (!relatedTarget ||
+              (relatedTarget instanceof Node &&
+                editorDOMNode.contains(relatedTarget)));
+
+          if (isLeavingEditor || isLeavingBlockForEditorWhitespace) {
             setOption('dropTarget', undefined);
           }
         }


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

Fixes #5000.

## What changed
- Clear the stored DnD `dropTarget` when a drag leaves a block and enters editor whitespace.
- Preserve existing behavior when moving from one block to another so the next hover target owns the indicator.
- Add slow DnD hook coverage for block -> editor whitespace, text node -> editor whitespace, block -> block, outside-editor dragleave, and document drop cleanup.

## AI disclosure
AI-assisted: yes. Codex helped inspect the issue and draft the patch. I reviewed the implementation, adjusted the tests, and ran verification locally.

Prompt summary: fix the Plate DnD indicator that appears below the last line even though dropping there does nothing.

I understand the code: the stored drop line is cleared when the pointer leaves a real block target for editor whitespace, because React DnD will not receive a valid block drop target there.

## Testing
- [x] `pnpm --filter @platejs/dnd test` - 42 passing
- [x] `pnpm exec bun test --preload ./tooling/config/bunTestSetup.ts ./packages/dnd/src/DndPlugin.slow.tsx` - 4 passing
- [x] `pnpm --filter @platejs/dnd lint`
- [x] `pnpm --filter @platejs/dnd lint:fix` - no fixes applied
- [x] `pnpm --filter @platejs/dnd build`
- [x] `pnpm turbo typecheck --filter=./packages/dnd`
- [x] `pnpm changeset status --since origin/main`
- [x] `git diff --check`
- [ ] `pnpm brl` - not run; no package files were added, moved, or removed
- [ ] `codex review --base origin/main` - not run; local `codex` CLI is not installed
- [ ] UI changelog - not applicable; no registry changes
