### PR TITLE
fix(markdown): preserve table cells during MDX fallback

### DIFF
--- a/.changeset/green-plants-fix.md
+++ b/.changeset/green-plants-fix.md
@@ -1,0 +1,5 @@
+---
+"@platejs/markdown": patch
+---
+
+Fix MDX fallback deserialization for GFM tables containing plain less-than text.

--- a/packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.spec.tsx
+++ b/packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.spec.tsx
@@ -32,6 +32,22 @@ describe('markdownToSlateNodesSafely', () => {
     ]);
   });
 
+  it('keeps incomplete inline MDX text out of the previous marked text leaf', () => {
+    const editor = createTestEditor();
+
+    expect(markdownToSlateNodesSafely(editor, '**bold**<u>')).toEqual([
+      {
+        children: [
+          { bold: true, text: 'bold' },
+          {
+            text: '<u>',
+          },
+        ],
+        type: 'p',
+      },
+    ]);
+  });
+
   it('wraps incomplete inline MDX in a new paragraph when there are no complete blocks', () => {
     const editor = createTestEditor();
 

--- a/packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.spec.tsx
+++ b/packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.spec.tsx
@@ -48,6 +48,22 @@ describe('markdownToSlateNodesSafely', () => {
     ]);
   });
 
+  it('preserves marked leaves in the incomplete inline MDX fallback tail', () => {
+    const editor = createTestEditor();
+
+    expect(markdownToSlateNodesSafely(editor, 'plain <u> **bold**')).toEqual([
+      {
+        children: [
+          { text: 'plain' },
+          { text: '<u>' },
+          { text: ' ' },
+          { bold: true, text: 'bold' },
+        ],
+        type: 'p',
+      },
+    ]);
+  });
+
   it('wraps incomplete inline MDX in a new paragraph when there are no complete blocks', () => {
     const editor = createTestEditor();
 

--- a/packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.ts
+++ b/packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.ts
@@ -17,6 +17,14 @@ import { splitIncompleteMdx } from './splitIncompleteMdx';
 const isPlainTextNode = (node: unknown): node is { text: string } =>
   TextApi.isText(node) && Object.keys(node).every((key) => key === 'text');
 
+const isSplitInsideTableRow = (completeString: string) => {
+  const currentLine = completeString.slice(
+    completeString.lastIndexOf('\n') + 1
+  );
+
+  return currentLine.includes('|');
+};
+
 const appendInlineNodesToLastTextContainer = (
   editor: SlateEditor,
   node: unknown,
@@ -36,7 +44,7 @@ const appendInlineNodesToLastTextContainer = (
 
     if (
       isPlainTextNode(lastChild) &&
-      inlineNodes.every((inlineNode) => TextApi.isText(inlineNode))
+      inlineNodes.every((inlineNode) => isPlainTextNode(inlineNode))
     ) {
       lastChild.text += inlineNodes
         .map((inlineNode) => inlineNode.text)
@@ -105,33 +113,37 @@ export const markdownToSlateNodesSafely = (
   const tableType = getPluginType(editor, KEYS.table);
 
   if (ElementApi.isElement(lastBlock) && lastBlock.type === tableType) {
-    const withoutMdxNodes = markdownToSlateNodes(editor, data, {
-      ...options,
-      withoutMdx: true,
-    });
-    const tableOrdinal = completeNodes
-      .filter((node) => ElementApi.isElement(node) && node.type === tableType)
-      .indexOf(lastBlock);
-    let fallbackTableIndex = -1;
-    let seenTables = -1;
+    if (isSplitInsideTableRow(completeString)) {
+      const withoutMdxNodes = markdownToSlateNodes(editor, data, {
+        ...options,
+        withoutMdx: true,
+      });
+      const tableOrdinal = completeNodes
+        .filter((node) => ElementApi.isElement(node) && node.type === tableType)
+        .indexOf(lastBlock);
+      let fallbackTableIndex = -1;
+      let seenTables = -1;
 
-    for (const [index, node] of withoutMdxNodes.entries()) {
-      if (ElementApi.isElement(node) && node.type === tableType) {
-        seenTables += 1;
+      for (const [index, node] of withoutMdxNodes.entries()) {
+        if (ElementApi.isElement(node) && node.type === tableType) {
+          seenTables += 1;
 
-        if (seenTables === tableOrdinal) {
-          fallbackTableIndex = index;
-          break;
+          if (seenTables === tableOrdinal) {
+            fallbackTableIndex = index;
+            break;
+          }
         }
+      }
+
+      if (fallbackTableIndex !== -1) {
+        return [
+          ...completeNodes.slice(0, -1),
+          ...withoutMdxNodes.slice(fallbackTableIndex),
+        ];
       }
     }
 
-    if (fallbackTableIndex !== -1) {
-      return [
-        ...completeNodes.slice(0, -1),
-        ...withoutMdxNodes.slice(fallbackTableIndex),
-      ];
-    }
+    return [...completeNodes, newBlock];
   }
 
   if (

--- a/packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.ts
+++ b/packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.ts
@@ -1,4 +1,11 @@
-import { type SlateEditor, ElementApi, getPluginType, KEYS } from 'platejs';
+import {
+  type Descendant,
+  type SlateEditor,
+  ElementApi,
+  getPluginType,
+  KEYS,
+  TextApi,
+} from 'platejs';
 
 import {
   type DeserializeMdOptions,
@@ -6,6 +13,53 @@ import {
 } from '../deserializeMd';
 import { deserializeInlineMd } from './deserializeInlineMd';
 import { splitIncompleteMdx } from './splitIncompleteMdx';
+
+const appendInlineNodesToLastTextContainer = (
+  editor: SlateEditor,
+  node: unknown,
+  inlineNodes: Descendant[]
+): boolean => {
+  if (!ElementApi.isElement(node) || editor.api.isVoid(node)) {
+    return false;
+  }
+
+  const paragraphType = getPluginType(editor, KEYS.p);
+
+  if (
+    node.type === paragraphType ||
+    node.children.some((child) => TextApi.isText(child))
+  ) {
+    const lastChild = node.children.at(-1);
+
+    if (
+      TextApi.isText(lastChild) &&
+      inlineNodes.every((inlineNode) => TextApi.isText(inlineNode))
+    ) {
+      lastChild.text += inlineNodes
+        .map((inlineNode) => inlineNode.text)
+        .join('');
+
+      return true;
+    }
+
+    node.children.push(...inlineNodes);
+    return true;
+  }
+
+  for (let i = node.children.length - 1; i >= 0; i--) {
+    if (
+      appendInlineNodesToLastTextContainer(
+        editor,
+        node.children[i],
+        inlineNodes
+      )
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+};
 
 export const markdownToSlateNodesSafely = (
   editor: SlateEditor,
@@ -45,9 +99,26 @@ export const markdownToSlateNodesSafely = (
     return [...completeNodes, newBlock];
   }
 
-  // FIXME table column will fail, need recursive find the last p
-  if (ElementApi.isElement(lastBlock) && lastBlock?.children) {
-    lastBlock.children.push(...incompleteNodes);
+  const tableType = getPluginType(editor, KEYS.table);
+
+  if (ElementApi.isElement(lastBlock) && lastBlock.type === tableType) {
+    const withoutMdxNodes = markdownToSlateNodes(editor, data, {
+      ...options,
+      withoutMdx: true,
+    });
+    const fallbackTable = withoutMdxNodes
+      .filter((node) => ElementApi.isElement(node) && node.type === tableType)
+      .at(-1);
+
+    if (fallbackTable) {
+      return [...completeNodes.slice(0, -1), fallbackTable];
+    }
+  }
+
+  if (
+    ElementApi.isElement(lastBlock) &&
+    appendInlineNodesToLastTextContainer(editor, lastBlock, incompleteNodes)
+  ) {
     return completeNodes;
   }
 

--- a/packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.ts
+++ b/packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.ts
@@ -14,6 +14,9 @@ import {
 import { deserializeInlineMd } from './deserializeInlineMd';
 import { splitIncompleteMdx } from './splitIncompleteMdx';
 
+const isPlainTextNode = (node: unknown): node is { text: string } =>
+  TextApi.isText(node) && Object.keys(node).every((key) => key === 'text');
+
 const appendInlineNodesToLastTextContainer = (
   editor: SlateEditor,
   node: unknown,
@@ -32,7 +35,7 @@ const appendInlineNodesToLastTextContainer = (
     const lastChild = node.children.at(-1);
 
     if (
-      TextApi.isText(lastChild) &&
+      isPlainTextNode(lastChild) &&
       inlineNodes.every((inlineNode) => TextApi.isText(inlineNode))
     ) {
       lastChild.text += inlineNodes
@@ -106,12 +109,28 @@ export const markdownToSlateNodesSafely = (
       ...options,
       withoutMdx: true,
     });
-    const fallbackTable = withoutMdxNodes
+    const tableOrdinal = completeNodes
       .filter((node) => ElementApi.isElement(node) && node.type === tableType)
-      .at(-1);
+      .indexOf(lastBlock);
+    let fallbackTableIndex = -1;
+    let seenTables = -1;
 
-    if (fallbackTable) {
-      return [...completeNodes.slice(0, -1), fallbackTable];
+    for (const [index, node] of withoutMdxNodes.entries()) {
+      if (ElementApi.isElement(node) && node.type === tableType) {
+        seenTables += 1;
+
+        if (seenTables === tableOrdinal) {
+          fallbackTableIndex = index;
+          break;
+        }
+      }
+    }
+
+    if (fallbackTableIndex !== -1) {
+      return [
+        ...completeNodes.slice(0, -1),
+        ...withoutMdxNodes.slice(fallbackTableIndex),
+      ];
     }
   }
 

--- a/packages/markdown/src/lib/table.spec.ts
+++ b/packages/markdown/src/lib/table.spec.ts
@@ -122,6 +122,137 @@ describe('markdown tables', () => {
     ]);
   });
 
+  it('keeps blocks after a table cell that falls back from incomplete MDX', () => {
+    const editor = createTableEditor();
+    const input = [
+      '| Dimension | Basis |',
+      '| --- | --- |',
+      '| Volume trend | a<b |',
+      '',
+      'After',
+    ].join('\n');
+
+    const value = deserializeMd(editor, input);
+
+    expect(value).toMatchObject([
+      {
+        children: [
+          {
+            children: [
+              {
+                children: [{ type: 'p', children: [{ text: 'Dimension' }] }],
+                type: 'th',
+              },
+              {
+                children: [{ type: 'p', children: [{ text: 'Basis' }] }],
+                type: 'th',
+              },
+            ],
+            type: 'tr',
+          },
+          {
+            children: [
+              {
+                children: [{ type: 'p', children: [{ text: 'Volume trend' }] }],
+                type: 'td',
+              },
+              {
+                children: [{ type: 'p', children: [{ text: 'a<b' }] }],
+                type: 'td',
+              },
+            ],
+            type: 'tr',
+          },
+        ],
+        type: 'table',
+      },
+      {
+        children: [{ text: 'After' }],
+        type: 'p',
+      },
+    ]);
+  });
+
+  it('repairs the fallback table at the MDX split when a later table exists', () => {
+    const editor = createTableEditor();
+    const input = [
+      '| Dimension | Basis |',
+      '| --- | --- |',
+      '| Volume trend | a<b |',
+      '',
+      '| Name | Value |',
+      '| --- | --- |',
+      '| Later | Table |',
+    ].join('\n');
+
+    const value = deserializeMd(editor, input);
+
+    expect(value).toMatchObject([
+      {
+        children: [
+          {
+            children: [
+              {
+                children: [{ type: 'p', children: [{ text: 'Dimension' }] }],
+                type: 'th',
+              },
+              {
+                children: [{ type: 'p', children: [{ text: 'Basis' }] }],
+                type: 'th',
+              },
+            ],
+            type: 'tr',
+          },
+          {
+            children: [
+              {
+                children: [{ type: 'p', children: [{ text: 'Volume trend' }] }],
+                type: 'td',
+              },
+              {
+                children: [{ type: 'p', children: [{ text: 'a<b' }] }],
+                type: 'td',
+              },
+            ],
+            type: 'tr',
+          },
+        ],
+        type: 'table',
+      },
+      {
+        children: [
+          {
+            children: [
+              {
+                children: [{ type: 'p', children: [{ text: 'Name' }] }],
+                type: 'th',
+              },
+              {
+                children: [{ type: 'p', children: [{ text: 'Value' }] }],
+                type: 'th',
+              },
+            ],
+            type: 'tr',
+          },
+          {
+            children: [
+              {
+                children: [{ type: 'p', children: [{ text: 'Later' }] }],
+                type: 'td',
+              },
+              {
+                children: [{ type: 'p', children: [{ text: 'Table' }] }],
+                type: 'td',
+              },
+            ],
+            type: 'tr',
+          },
+        ],
+        type: 'table',
+      },
+    ]);
+  });
+
   it('serializes multi-paragraph table cells as html breaks inside one paragraph', () => {
     const editor = createTableEditor();
     const input = [

--- a/packages/markdown/src/lib/table.spec.ts
+++ b/packages/markdown/src/lib/table.spec.ts
@@ -253,6 +253,50 @@ describe('markdown tables', () => {
     ]);
   });
 
+  it('keeps a parsed table when incomplete MDX starts after the table', () => {
+    const editor = createTableEditor();
+    const input = ['| Content |', '| --- |', '| <u>ok</u> |', '', '<x>'].join(
+      '\n'
+    );
+
+    const value = deserializeMd(editor, input);
+
+    expect(value).toMatchObject([
+      {
+        children: [
+          {
+            children: [
+              {
+                children: [{ type: 'p', children: [{ text: 'Content' }] }],
+                type: 'th',
+              },
+            ],
+            type: 'tr',
+          },
+          {
+            children: [
+              {
+                children: [
+                  {
+                    type: 'p',
+                    children: [{ text: 'ok', underline: true }],
+                  },
+                ],
+                type: 'td',
+              },
+            ],
+            type: 'tr',
+          },
+        ],
+        type: 'table',
+      },
+      {
+        children: [{ text: '<x>' }],
+        type: 'p',
+      },
+    ]);
+  });
+
   it('serializes multi-paragraph table cells as html breaks inside one paragraph', () => {
     const editor = createTableEditor();
     const input = [

--- a/packages/markdown/src/lib/table.spec.ts
+++ b/packages/markdown/src/lib/table.spec.ts
@@ -80,6 +80,48 @@ describe('markdown tables', () => {
     expect(deserializeMd(editor, markdown)).toMatchObject(value);
   });
 
+  it('keeps unescaped less-than text inside table cells when MDX fallback is used', () => {
+    const editor = createTableEditor();
+    const input =
+      '| Dimension | Basis |\n| --- | --- |\n| Volume trend | a<b |\n';
+
+    const value = deserializeMd(editor, input);
+
+    expect(value).toMatchObject([
+      {
+        children: [
+          {
+            children: [
+              {
+                children: [{ type: 'p', children: [{ text: 'Dimension' }] }],
+                type: 'th',
+              },
+              {
+                children: [{ type: 'p', children: [{ text: 'Basis' }] }],
+                type: 'th',
+              },
+            ],
+            type: 'tr',
+          },
+          {
+            children: [
+              {
+                children: [{ type: 'p', children: [{ text: 'Volume trend' }] }],
+                type: 'td',
+              },
+              {
+                children: [{ type: 'p', children: [{ text: 'a<b' }] }],
+                type: 'td',
+              },
+            ],
+            type: 'tr',
+          },
+        ],
+        type: 'table',
+      },
+    ]);
+  });
+
   it('serializes multi-paragraph table cells as html breaks inside one paragraph', () => {
     const editor = createTableEditor();
     const input = [


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## Summary

Fixes #5006.

When MDX parsing fails on plain less-than text inside a GFM table cell, the safe Markdown fallback now keeps the table structure valid instead of appending fallback inline text directly under the table node. If the incomplete MDX tail belongs to a table, the fallback replaces the partial table with the non-MDX parsed table while preserving completed blocks before it.

## Testing

- `./node_modules/.bin/bun test packages/markdown/src/lib/table.spec.ts packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.spec.tsx` -> 7 passed
- `PATH="$PWD/node_modules/.bin:$PATH" pnpm --filter @platejs/markdown lint` -> passed
- `pnpm turbo build --filter=./packages/markdown` -> 11 tasks passed
- `./node_modules/.bin/biome check packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.ts packages/markdown/src/lib/table.spec.ts .changeset/green-plants-fix.md` -> passed
- `git diff --check` -> passed

## Notes

- Full `./node_modules/.bin/bun test packages/markdown/src/lib` reached 210 passing tests, then stopped on an existing local module-resolution issue for `@platejs/list-classic/react` in `standardList.spec.tsx`.
- `pnpm turbo typecheck --filter=./packages/markdown` also fails in this checkout on existing unresolved local workspace/test imports such as `@platejs/basic-nodes`, `@platejs/test-utils`, and `@platejs/table`, not on this change.
- Local `codex review --base origin/main` was not run because `codex` is not installed in this environment.

AI-assisted: yes. I understand the change and verified the focused regression locally.
