### PR TITLE
Fix shadcn editor kit install paths

### DIFF
--- a/apps/www/scripts/check-registry-source.mts
+++ b/apps/www/scripts/check-registry-source.mts
@@ -8,6 +8,8 @@ import {
 } from './registry-dependencies.mts';
 
 const ABSOLUTE_URL_REGEX = /^https?:\/\//;
+const EDITOR_COMPONENT_PATH_SEGMENT = 'components/editor/';
+const EDITOR_COMPONENT_TARGET_PREFIX = '@components/editor/';
 const PLATE_PUBLIC_REGISTRY_BASE_URL = 'https://platejs.org/r';
 
 const sourceRegistry = createPlateRegistry('https://platejs.org');
@@ -61,6 +63,17 @@ function assert(condition: unknown, message: string) {
   }
 }
 
+function toEditorComponentTarget(filePath: string) {
+  const segmentIndex = filePath.indexOf(EDITOR_COMPONENT_PATH_SEGMENT);
+
+  assert(
+    segmentIndex !== -1,
+    `Expected ${filePath} to include ${EDITOR_COMPONENT_PATH_SEGMENT}`
+  );
+
+  return `${EDITOR_COMPONENT_TARGET_PREFIX}${filePath.slice(segmentIndex + EDITOR_COMPONENT_PATH_SEGMENT.length)}`;
+}
+
 assert(itemsByName.has('plate-ui'), 'Expected plate-ui registry item');
 assert(itemsByName.has('editor-basic'), 'Expected editor-basic registry item');
 
@@ -88,6 +101,70 @@ const runtimeEditorBasic = runtimeItemsByName.get('editor-basic');
 assert(
   runtimeEditorBasic?.registryDependencies?.includes('@plate/plate-ui'),
   'Expected runtime editor-basic to depend on namespaced plate-ui'
+);
+
+for (const item of normalizedRegistry.items) {
+  for (const file of item.files ?? []) {
+    if (!file.path.includes(EDITOR_COMPONENT_PATH_SEGMENT)) {
+      continue;
+    }
+
+    assert(
+      file.target === toEditorComponentTarget(file.path),
+      `Expected ${item.name} file ${file.path} to install under the configured components alias for relative editor imports`
+    );
+  }
+}
+
+const editorBaseKit = itemsByName.get('editor-base-kit');
+const editorBaseKitFile = editorBaseKit?.files?.[0];
+assert(
+  editorBaseKitFile?.target === '@components/editor/editor-base-kit.tsx',
+  'Expected editor-base-kit to install in the configured components editor directory so its relative plugin imports resolve'
+);
+
+for (const dependency of editorBaseKit?.registryDependencies ?? []) {
+  if (!dependency.startsWith('@plate/') || !dependency.endsWith('-kit')) {
+    continue;
+  }
+
+  const dependencyName = dependency.slice('@plate/'.length);
+  const dependencyItem = itemsByName.get(dependencyName);
+  const dependencyFile = dependencyItem?.files?.[0];
+
+  assert(
+    dependencyFile?.path &&
+      dependencyFile.target === toEditorComponentTarget(dependencyFile.path) &&
+      dependencyFile.target.startsWith('@components/editor/plugins/'),
+    `Expected editor-base-kit dependency ${dependency} to install under the configured components editor plugins directory`
+  );
+}
+
+const editorAi = itemsByName.get('editor-ai');
+assert(
+  editorAi?.files?.some(
+    (file) =>
+      file.path === 'blocks/editor-ai/components/editor/plate-editor.tsx' &&
+      file.target === '@components/editor/plate-editor.tsx'
+  ),
+  'Expected editor-ai plate-editor to install under the configured components editor directory'
+);
+assert(
+  editorAi?.files?.some(
+    (file) =>
+      file.path === 'blocks/editor-ai/components/editor/editor-kit.tsx' &&
+      file.target === '@components/editor/editor-kit.tsx'
+  ),
+  'Expected editor-ai editor-kit to install under the configured components editor directory'
+);
+
+assert(
+  editorBasic?.files?.some(
+    (file) =>
+      file.path === 'blocks/editor-basic/components/editor/plate-editor.tsx' &&
+      file.target === '@components/editor/plate-editor.tsx'
+  ),
+  'Expected editor-basic plate-editor to install under the configured components editor directory'
 );
 
 const excalidrawNode = itemsByName.get('excalidraw-node');

--- a/apps/www/src/app/registry/changelog/[event]/route.test.ts
+++ b/apps/www/src/app/registry/changelog/[event]/route.test.ts
@@ -6,20 +6,18 @@ describe('/registry/changelog/[event].json', () => {
   it('serves a registry changelog event by JSON filename', async () => {
     const response = await GET(new Request('http://localhost'), {
       params: Promise.resolve({
-        event: '2026-06-03-show-code-block-language-labels-read-only-mode.json',
+        event: '2026-06-14-editor-install-kit-files-through.json',
       }),
     });
     const data = await response.json();
 
     expect(response.status).toBe(200);
     expect(data).toMatchObject({
-      id: '2026-06-03-show-code-block-language-labels-read-only-mode',
-      release: { status: 'latest', source: 'open-pull-request' },
+      id: '2026-06-14-editor-install-kit-files-through',
+      release: { status: 'unresolved' },
       change: {
-        pullRequest: {
-          number: 4989,
-          state: 'OPEN',
-        },
+        date: '2026-06-14',
+        type: 'source',
       },
     });
   });
@@ -36,9 +34,12 @@ describe('/registry/changelog/[event].json', () => {
     const events = generateStaticParams().map((param) => param.event);
 
     expect(events.length).toBeGreaterThanOrEqual(19);
+    expect(events).toContain(
+      '2026-06-14-editor-install-kit-files-through.json'
+    );
     expect(events).toContain('2026-06-10-attach-column-drop-target-ref.json');
     expect(events).toContain(
-      '2026-06-03-show-code-block-language-labels-read-only-mode.json'
+      '2026-06-13-show-code-block-language-labels-read-only-mode.json'
     );
     expect(events).toContain('2025-11-20-biome-ultracite.json');
   });

--- a/apps/www/src/app/registry/changelog/[event]/route.test.ts
+++ b/apps/www/src/app/registry/changelog/[event]/route.test.ts
@@ -6,18 +6,18 @@ describe('/registry/changelog/[event].json', () => {
   it('serves a registry changelog event by JSON filename', async () => {
     const response = await GET(new Request('http://localhost'), {
       params: Promise.resolve({
-        event: '2026-06-14-editor-install-kit-files-through.json',
+        event: '2026-06-14-fix-shadcn-editor-kit-install-paths.json',
       }),
     });
     const data = await response.json();
 
     expect(response.status).toBe(200);
     expect(data).toMatchObject({
-      id: '2026-06-14-editor-install-kit-files-through',
-      release: { status: 'unresolved' },
+      id: '2026-06-14-fix-shadcn-editor-kit-install-paths',
+      release: { status: 'latest', source: 'open-pull-request' },
       change: {
         date: '2026-06-14',
-        type: 'source',
+        type: 'pull_request',
       },
     });
   });
@@ -35,7 +35,7 @@ describe('/registry/changelog/[event].json', () => {
 
     expect(events.length).toBeGreaterThanOrEqual(19);
     expect(events).toContain(
-      '2026-06-14-editor-install-kit-files-through.json'
+      '2026-06-14-fix-shadcn-editor-kit-install-paths.json'
     );
     expect(events).toContain('2026-06-10-attach-column-drop-target-ref.json');
     expect(events).toContain(

--- a/apps/www/src/app/registry/changelog/components.json/route.test.ts
+++ b/apps/www/src/app/registry/changelog/components.json/route.test.ts
@@ -10,7 +10,10 @@ describe('/registry/changelog/components.json', () => {
     expect(response.status).toBe(200);
     expect(data.schemaVersion).toBe(1);
     expect(data.components['code-block-node']).toContain(
-      '2026-06-03-show-code-block-language-labels-read-only-mode'
+      '2026-06-13-show-code-block-language-labels-read-only-mode'
+    );
+    expect(data.components['editor-base-kit']).toContain(
+      '2026-06-14-editor-install-kit-files-through'
     );
     expect(data.components['huge-document-demo']).toEqual([
       '2026-06-02-improve-large-document-editing',

--- a/apps/www/src/app/registry/changelog/components.json/route.test.ts
+++ b/apps/www/src/app/registry/changelog/components.json/route.test.ts
@@ -13,7 +13,7 @@ describe('/registry/changelog/components.json', () => {
       '2026-06-13-show-code-block-language-labels-read-only-mode'
     );
     expect(data.components['editor-base-kit']).toContain(
-      '2026-06-14-editor-install-kit-files-through'
+      '2026-06-14-fix-shadcn-editor-kit-install-paths'
     );
     expect(data.components['huge-document-demo']).toEqual([
       '2026-06-02-improve-large-document-editing',

--- a/apps/www/src/app/registry/changelog/index.json/route.test.ts
+++ b/apps/www/src/app/registry/changelog/index.json/route.test.ts
@@ -13,14 +13,12 @@ describe('/registry/changelog/index.json', () => {
     expect(data.schemaVersion).toBe(1);
     expect(data.events.length).toBeGreaterThanOrEqual(19);
     expect(data.events[0]).toMatchObject({
-      href: '/registry/changelog/2026-06-10-attach-column-drop-target-ref.json',
-      id: '2026-06-10-attach-column-drop-target-ref',
-      release: { status: 'latest', source: 'post-release-no-changeset' },
+      href: '/registry/changelog/2026-06-14-editor-install-kit-files-through.json',
+      id: '2026-06-14-editor-install-kit-files-through',
+      release: { status: 'unresolved' },
       change: {
-        pullRequest: {
-          number: 5003,
-          state: 'MERGED',
-        },
+        date: '2026-06-14',
+        type: 'source',
       },
     });
     expect(data.events.map((event) => event.id)).toContain(

--- a/apps/www/src/app/registry/changelog/index.json/route.test.ts
+++ b/apps/www/src/app/registry/changelog/index.json/route.test.ts
@@ -13,12 +13,12 @@ describe('/registry/changelog/index.json', () => {
     expect(data.schemaVersion).toBe(1);
     expect(data.events.length).toBeGreaterThanOrEqual(19);
     expect(data.events[0]).toMatchObject({
-      href: '/registry/changelog/2026-06-14-editor-install-kit-files-through.json',
-      id: '2026-06-14-editor-install-kit-files-through',
-      release: { status: 'unresolved' },
+      href: '/registry/changelog/2026-06-14-fix-shadcn-editor-kit-install-paths.json',
+      id: '2026-06-14-fix-shadcn-editor-kit-install-paths',
+      release: { status: 'latest', source: 'open-pull-request' },
       change: {
         date: '2026-06-14',
-        type: 'source',
+        type: 'pull_request',
       },
     });
     expect(data.events.map((event) => event.id)).toContain(

--- a/apps/www/src/registry/changelog/2025-10-17-fix-react-decouple.json
+++ b/apps/www/src/registry/changelog/2025-10-17-fix-react-decouple.json
@@ -222,7 +222,7 @@
   ],
   "entries": [
     {
-      "id": "2025-10-17-26-9-039",
+      "id": "2025-10-17-26-9-block-list-import-path-copied-components-21efe1ce",
       "kind": "wiring",
       "summary": "Use the `platejs/static` import path in copied static rendering components.",
       "details": [],

--- a/apps/www/src/registry/changelog/2025-10-17-fix-react-decouple.json
+++ b/apps/www/src/registry/changelog/2025-10-17-fix-react-decouple.json
@@ -222,7 +222,7 @@
   ],
   "entries": [
     {
-      "id": "2025-10-17-26-9-038",
+      "id": "2025-10-17-26-9-039",
       "kind": "wiring",
       "summary": "Use the `platejs/static` import path in copied static rendering components.",
       "details": [],
@@ -261,8 +261,8 @@
         "toggle-node-static"
       ],
       "source": {
-        "line": 117,
-        "row": 38,
+        "line": 120,
+        "row": 39,
         "legacyRelease": {
           "date": "2025-10-17",
           "entry": "26.9",

--- a/apps/www/src/registry/changelog/2025-10-21-add-rejectaisuggestions.json
+++ b/apps/www/src/registry/changelog/2025-10-21-add-rejectaisuggestions.json
@@ -78,7 +78,7 @@
   ],
   "entries": [
     {
-      "id": "2025-10-21-26-10-036",
+      "id": "2025-10-21-26-10-037",
       "kind": "behavior",
       "summary": "Use `SuggestionLineBreak` instead of `BlockSuggestion` for suggestion styling.",
       "details": [],
@@ -87,8 +87,8 @@
       ],
       "targets": ["suggestion-kit", "suggestion-node", "block-discussion"],
       "source": {
-        "line": 112,
-        "row": 36,
+        "line": 115,
+        "row": 37,
         "legacyRelease": {
           "date": "2025-10-21",
           "entry": "26.10",
@@ -97,15 +97,15 @@
       }
     },
     {
-      "id": "2025-10-21-26-10-037",
+      "id": "2025-10-21-26-10-038",
       "kind": "behavior",
       "summary": "Keep AI comments visible after the stream finishes.",
       "details": [],
       "migrationNotes": [],
       "targets": ["ai-api"],
       "source": {
-        "line": 113,
-        "row": 37,
+        "line": 116,
+        "row": 38,
         "legacyRelease": {
           "date": "2025-10-21",
           "entry": "26.10",

--- a/apps/www/src/registry/changelog/2025-10-21-add-rejectaisuggestions.json
+++ b/apps/www/src/registry/changelog/2025-10-21-add-rejectaisuggestions.json
@@ -78,7 +78,7 @@
   ],
   "entries": [
     {
-      "id": "2025-10-21-26-10-037",
+      "id": "2025-10-21-26-10-suggestion-instead-styling-7fb36069",
       "kind": "behavior",
       "summary": "Use `SuggestionLineBreak` instead of `BlockSuggestion` for suggestion styling.",
       "details": [],
@@ -97,7 +97,7 @@
       }
     },
     {
-      "id": "2025-10-21-26-10-038",
+      "id": "2025-10-21-26-10-ai-api-keep-comments-visible-after-61174ea8",
       "kind": "behavior",
       "summary": "Keep AI comments visible after the stream finishes.",
       "details": [],

--- a/apps/www/src/registry/changelog/2025-11-20-biome-ultracite.json
+++ b/apps/www/src/registry/changelog/2025-11-20-biome-ultracite.json
@@ -492,7 +492,7 @@
   ],
   "entries": [
     {
-      "id": "2025-11-20-26-11-032",
+      "id": "2025-11-20-26-11-033",
       "kind": "behavior",
       "summary": "Format copied AI registry files for Biome and Ultracite compatibility.",
       "details": [],
@@ -506,8 +506,8 @@
         "cursor-overlay"
       ],
       "source": {
-        "line": 103,
-        "row": 32,
+        "line": 106,
+        "row": 33,
         "legacyRelease": {
           "date": "2025-11-20",
           "entry": "26.11",
@@ -516,7 +516,7 @@
       }
     },
     {
-      "id": "2025-11-20-26-11-033",
+      "id": "2025-11-20-26-11-034",
       "kind": "behavior",
       "summary": "Format copied editor kits and transforms for Biome and Ultracite compatibility.",
       "details": [],
@@ -531,8 +531,8 @@
         "markdown-joiner-transform"
       ],
       "source": {
-        "line": 104,
-        "row": 33,
+        "line": 107,
+        "row": 34,
         "legacyRelease": {
           "date": "2025-11-20",
           "entry": "26.11",
@@ -541,7 +541,7 @@
       }
     },
     {
-      "id": "2025-11-20-26-11-034",
+      "id": "2025-11-20-26-11-035",
       "kind": "fix",
       "summary": "Format copied UI components for Biome and Ultracite compatibility.",
       "details": [],
@@ -592,8 +592,8 @@
         "toolbar"
       ],
       "source": {
-        "line": 105,
-        "row": 34,
+        "line": 108,
+        "row": 35,
         "legacyRelease": {
           "date": "2025-11-20",
           "entry": "26.11",
@@ -602,7 +602,7 @@
       }
     },
     {
-      "id": "2025-11-20-26-11-035",
+      "id": "2025-11-20-26-11-036",
       "kind": "behavior",
       "summary": "Format copied registry demos and block examples for Biome and Ultracite compatibility.",
       "details": [],
@@ -622,8 +622,8 @@
         "mdx-plate-components"
       ],
       "source": {
-        "line": 106,
-        "row": 35,
+        "line": 109,
+        "row": 36,
         "legacyRelease": {
           "date": "2025-11-20",
           "entry": "26.11",

--- a/apps/www/src/registry/changelog/2025-11-20-biome-ultracite.json
+++ b/apps/www/src/registry/changelog/2025-11-20-biome-ultracite.json
@@ -492,7 +492,7 @@
   ],
   "entries": [
     {
-      "id": "2025-11-20-26-11-033",
+      "id": "2025-11-20-26-11-ai-api-format-copied-registry-files-dad0c3be",
       "kind": "behavior",
       "summary": "Format copied AI registry files for Biome and Ultracite compatibility.",
       "details": [],
@@ -516,7 +516,7 @@
       }
     },
     {
-      "id": "2025-11-20-26-11-034",
+      "id": "2025-11-20-26-11-block-placeholder-format-copied-editor-kits-8cfd039a",
       "kind": "behavior",
       "summary": "Format copied editor kits and transforms for Biome and Ultracite compatibility.",
       "details": [],
@@ -541,7 +541,7 @@
       }
     },
     {
-      "id": "2025-11-20-26-11-035",
+      "id": "2025-11-20-26-11-block-discussion-format-copied-ui-components-07b227ef",
       "kind": "fix",
       "summary": "Format copied UI components for Biome and Ultracite compatibility.",
       "details": [],
@@ -602,7 +602,7 @@
       }
     },
     {
-      "id": "2025-11-20-26-11-036",
+      "id": "2025-11-20-26-11-ai-format-copied-registry-demos-697d1f15",
       "kind": "behavior",
       "summary": "Format copied registry demos and block examples for Biome and Ultracite compatibility.",
       "details": [],

--- a/apps/www/src/registry/changelog/2025-12-14-fix-combobox-opening-popover-all-users-collaboration.json
+++ b/apps/www/src/registry/changelog/2025-12-14-fix-combobox-opening-popover-all-users-collaboration.json
@@ -52,7 +52,7 @@
   ],
   "entries": [
     {
-      "id": "2025-12-14-27-1-031",
+      "id": "2025-12-14-27-1-032",
       "kind": "behavior",
       "summary": "Scope Yjs combobox popovers to the user who typed the trigger.",
       "details": [
@@ -63,8 +63,8 @@
       ],
       "targets": ["inline-combobox"],
       "source": {
-        "line": 96,
-        "row": 31,
+        "line": 99,
+        "row": 32,
         "legacyRelease": {
           "date": "2025-12-14",
           "entry": "27.1",

--- a/apps/www/src/registry/changelog/2025-12-14-fix-combobox-opening-popover-all-users-collaboration.json
+++ b/apps/www/src/registry/changelog/2025-12-14-fix-combobox-opening-popover-all-users-collaboration.json
@@ -52,7 +52,7 @@
   ],
   "entries": [
     {
-      "id": "2025-12-14-27-1-032",
+      "id": "2025-12-14-27-1-inline-combobox-scope-yjs-popovers-user-6fdd33e6",
       "kind": "behavior",
       "summary": "Scope Yjs combobox popovers to the user who typed the trigger.",
       "details": [

--- a/apps/www/src/registry/changelog/2025-12-15-add-option-editor-collaborative-features.json
+++ b/apps/www/src/registry/changelog/2025-12-15-add-option-editor-collaborative-features.json
@@ -60,7 +60,7 @@
   ],
   "entries": [
     {
-      "id": "2025-12-15-27-2-030",
+      "id": "2025-12-15-27-2-031",
       "kind": "behavior",
       "summary": "Read collaborative trigger ownership from `editor.meta.userId`.",
       "details": [
@@ -71,8 +71,8 @@
       ],
       "targets": ["inline-combobox", "mention-kit"],
       "source": {
-        "line": 91,
-        "row": 30,
+        "line": 94,
+        "row": 31,
         "legacyRelease": {
           "date": "2025-12-15",
           "entry": "27.2",

--- a/apps/www/src/registry/changelog/2025-12-15-add-option-editor-collaborative-features.json
+++ b/apps/www/src/registry/changelog/2025-12-15-add-option-editor-collaborative-features.json
@@ -60,7 +60,7 @@
   ],
   "entries": [
     {
-      "id": "2025-12-15-27-2-031",
+      "id": "2025-12-15-27-2-inline-combobox-collaborative-trigger-ownership-from-f8b64879",
       "kind": "behavior",
       "summary": "Read collaborative trigger ownership from `editor.meta.userId`.",
       "details": [

--- a/apps/www/src/registry/changelog/2026-01-09-support-using-ai-features-tables-improve-prompts.json
+++ b/apps/www/src/registry/changelog/2026-01-09-support-using-ai-features-tables-improve-prompts.json
@@ -76,15 +76,15 @@
   ],
   "entries": [
     {
-      "id": "2026-01-09-28-1-028",
+      "id": "2026-01-09-28-1-029",
       "kind": "behavior",
       "summary": "Upgrade copied AI command routes and chat UI for AI SDK v6 with split prompt helpers and table-cell editing prompts.",
       "details": [],
       "migrationNotes": [],
       "targets": ["ai-api", "ai-menu", "use-chat"],
       "source": {
-        "line": 84,
-        "row": 28,
+        "line": 87,
+        "row": 29,
         "legacyRelease": {
           "date": "2026-01-09",
           "entry": "28.1",
@@ -93,15 +93,15 @@
       }
     },
     {
-      "id": "2026-01-09-28-1-029",
+      "id": "2026-01-09-28-1-030",
       "kind": "behavior",
       "summary": "Sync cursor overlay behavior with the AI SDK v6 interaction path.",
       "details": [],
       "migrationNotes": [],
       "targets": ["cursor-overlay"],
       "source": {
-        "line": 85,
-        "row": 29,
+        "line": 88,
+        "row": 30,
         "legacyRelease": {
           "date": "2026-01-09",
           "entry": "28.1",

--- a/apps/www/src/registry/changelog/2026-01-09-support-using-ai-features-tables-improve-prompts.json
+++ b/apps/www/src/registry/changelog/2026-01-09-support-using-ai-features-tables-improve-prompts.json
@@ -76,7 +76,7 @@
   ],
   "entries": [
     {
-      "id": "2026-01-09-28-1-029",
+      "id": "2026-01-09-28-1-ai-api-upgrade-copied-command-routes-1306d0ec",
       "kind": "behavior",
       "summary": "Upgrade copied AI command routes and chat UI for AI SDK v6 with split prompt helpers and table-cell editing prompts.",
       "details": [],
@@ -93,7 +93,7 @@
       }
     },
     {
-      "id": "2026-01-09-28-1-030",
+      "id": "2026-01-09-28-1-cursor-overlay-sync-behavior-ai-sdk-f014616f",
       "kind": "behavior",
       "summary": "Sync cursor overlay behavior with the AI SDK v6 interaction path.",
       "details": [],

--- a/apps/www/src/registry/changelog/2026-01-20-add-docx-file-import-word-export-support.json
+++ b/apps/www/src/registry/changelog/2026-01-20-add-docx-file-import-word-export-support.json
@@ -132,7 +132,7 @@
   ],
   "entries": [
     {
-      "id": "2026-01-20-28-2-027",
+      "id": "2026-01-20-28-2-docx-export-import-registry-wiring-4a8f6756",
       "kind": "new",
       "summary": "Add DOCX import and export registry wiring.",
       "details": [],
@@ -153,7 +153,7 @@
       }
     },
     {
-      "id": "2026-01-20-28-2-028",
+      "id": "2026-01-20-28-2-block-list-docx-friendly-updates-e8df822b",
       "kind": "behavior",
       "summary": "Add DOCX-friendly static rendering updates.",
       "details": [],

--- a/apps/www/src/registry/changelog/2026-01-20-add-docx-file-import-word-export-support.json
+++ b/apps/www/src/registry/changelog/2026-01-20-add-docx-file-import-word-export-support.json
@@ -132,7 +132,7 @@
   ],
   "entries": [
     {
-      "id": "2026-01-20-28-2-026",
+      "id": "2026-01-20-28-2-027",
       "kind": "new",
       "summary": "Add DOCX import and export registry wiring.",
       "details": [],
@@ -143,8 +143,8 @@
         "export-toolbar-button"
       ],
       "source": {
-        "line": 79,
-        "row": 26,
+        "line": 82,
+        "row": 27,
         "legacyRelease": {
           "date": "2026-01-20",
           "entry": "28.2",
@@ -153,7 +153,7 @@
       }
     },
     {
-      "id": "2026-01-20-28-2-027",
+      "id": "2026-01-20-28-2-028",
       "kind": "behavior",
       "summary": "Add DOCX-friendly static rendering updates.",
       "details": [],
@@ -172,8 +172,8 @@
         "toc-node"
       ],
       "source": {
-        "line": 80,
-        "row": 27,
+        "line": 83,
+        "row": 28,
         "legacyRelease": {
           "date": "2026-01-20",
           "entry": "28.2",

--- a/apps/www/src/registry/changelog/2026-01-28-add-code-drawing-node.json
+++ b/apps/www/src/registry/changelog/2026-01-28-add-code-drawing-node.json
@@ -113,7 +113,7 @@
   ],
   "entries": [
     {
-      "id": "2026-01-28-28-3-024",
+      "id": "2026-01-28-28-3-025",
       "kind": "new",
       "summary": "Add inline code drawing for Mermaid, PlantUML, Graphviz, and Flowchart diagrams.",
       "details": [],
@@ -125,8 +125,8 @@
         "code-drawing-demo"
       ],
       "source": {
-        "line": 74,
-        "row": 24,
+        "line": 77,
+        "row": 25,
         "legacyRelease": {
           "date": "2026-01-28",
           "entry": "28.3",
@@ -135,7 +135,7 @@
       }
     },
     {
-      "id": "2026-01-28-28-3-025",
+      "id": "2026-01-28-28-3-026",
       "kind": "wiring",
       "summary": "Register code drawing in editor kits, insert actions, slash actions, block menu actions, and transforms.",
       "details": [],
@@ -151,8 +151,8 @@
         "transforms"
       ],
       "source": {
-        "line": 75,
-        "row": 25,
+        "line": 78,
+        "row": 26,
         "legacyRelease": {
           "date": "2026-01-28",
           "entry": "28.3",

--- a/apps/www/src/registry/changelog/2026-01-28-add-code-drawing-node.json
+++ b/apps/www/src/registry/changelog/2026-01-28-add-code-drawing-node.json
@@ -113,7 +113,7 @@
   ],
   "entries": [
     {
-      "id": "2026-01-28-28-3-025",
+      "id": "2026-01-28-28-3-code-drawing-inline-mermaid-plantuml-graphviz-605121a0",
       "kind": "new",
       "summary": "Add inline code drawing for Mermaid, PlantUML, Graphviz, and Flowchart diagrams.",
       "details": [],
@@ -135,7 +135,7 @@
       }
     },
     {
-      "id": "2026-01-28-28-3-026",
+      "id": "2026-01-28-28-3-editor-register-code-drawing-kits-b61b770d",
       "kind": "wiring",
       "summary": "Register code drawing in editor kits, insert actions, slash actions, block menu actions, and transforms.",
       "details": [],

--- a/apps/www/src/registry/changelog/2026-03-19-improve-non-react-test-coverage-ci-workflow-hygiene.json
+++ b/apps/www/src/registry/changelog/2026-03-19-improve-non-react-test-coverage-ci-workflow-hygiene.json
@@ -52,7 +52,7 @@
   ],
   "entries": [
     {
-      "id": "2026-03-19-29-1-024",
+      "id": "2026-03-19-29-1-font-color-toolbar-keep-typing-compatible-non-9d59a1d9",
       "kind": "behavior",
       "summary": "Keep color toolbar typing compatible with the non-React test and TypeScript cleanup.",
       "details": [],

--- a/apps/www/src/registry/changelog/2026-03-19-improve-non-react-test-coverage-ci-workflow-hygiene.json
+++ b/apps/www/src/registry/changelog/2026-03-19-improve-non-react-test-coverage-ci-workflow-hygiene.json
@@ -52,15 +52,15 @@
   ],
   "entries": [
     {
-      "id": "2026-03-19-29-1-023",
+      "id": "2026-03-19-29-1-024",
       "kind": "behavior",
       "summary": "Keep color toolbar typing compatible with the non-React test and TypeScript cleanup.",
       "details": [],
       "migrationNotes": [],
       "targets": ["font-color-toolbar-button"],
       "source": {
-        "line": 68,
-        "row": 23,
+        "line": 71,
+        "row": 24,
         "legacyRelease": {
           "date": "2026-03-19",
           "entry": "29.1",

--- a/apps/www/src/registry/changelog/2026-03-22-table-improve-selection-bug-fixed-insert-issue.json
+++ b/apps/www/src/registry/changelog/2026-03-22-table-improve-selection-bug-fixed-insert-issue.json
@@ -58,7 +58,7 @@
   ],
   "entries": [
     {
-      "id": "2026-03-22-29-2-022",
+      "id": "2026-03-22-29-2-table-move-large-selection-state-b0991d6a",
       "kind": "behavior",
       "summary": "Move large-table selection state to root-level DOM sync and editor selectors to reduce selection latency.",
       "details": [],
@@ -77,7 +77,7 @@
       }
     },
     {
-      "id": "2026-03-22-29-2-023",
+      "id": "2026-03-22-29-2-font-color-toolbar-sync-typing-table-selection-ab918188",
       "kind": "behavior",
       "summary": "Sync toolbar typing with the table-selection update.",
       "details": [],

--- a/apps/www/src/registry/changelog/2026-03-22-table-improve-selection-bug-fixed-insert-issue.json
+++ b/apps/www/src/registry/changelog/2026-03-22-table-improve-selection-bug-fixed-insert-issue.json
@@ -58,7 +58,7 @@
   ],
   "entries": [
     {
-      "id": "2026-03-22-29-2-021",
+      "id": "2026-03-22-29-2-022",
       "kind": "behavior",
       "summary": "Move large-table selection state to root-level DOM sync and editor selectors to reduce selection latency.",
       "details": [],
@@ -67,8 +67,8 @@
       ],
       "targets": ["table-node"],
       "source": {
-        "line": 63,
-        "row": 21,
+        "line": 66,
+        "row": 22,
         "legacyRelease": {
           "date": "2026-03-22",
           "entry": "29.2",
@@ -77,15 +77,15 @@
       }
     },
     {
-      "id": "2026-03-22-29-2-022",
+      "id": "2026-03-22-29-2-023",
       "kind": "behavior",
       "summary": "Sync toolbar typing with the table-selection update.",
       "details": [],
       "migrationNotes": [],
       "targets": ["font-color-toolbar-button"],
       "source": {
-        "line": 64,
-        "row": 22,
+        "line": 67,
+        "row": 23,
         "legacyRelease": {
           "date": "2026-03-22",
           "entry": "29.2",

--- a/apps/www/src/registry/changelog/2026-03-25-upgrade-typescript-6.json
+++ b/apps/www/src/registry/changelog/2026-03-25-upgrade-typescript-6.json
@@ -52,15 +52,15 @@
   ],
   "entries": [
     {
-      "id": "2026-03-25-29-3-020",
+      "id": "2026-03-25-29-3-021",
       "kind": "behavior",
       "summary": "Keep the code drawing registry template compatible with the TypeScript 6 check path.",
       "details": [],
       "migrationNotes": [],
       "targets": ["code-drawing-node"],
       "source": {
-        "line": 59,
-        "row": 20,
+        "line": 62,
+        "row": 21,
         "legacyRelease": {
           "date": "2026-03-25",
           "entry": "29.3",

--- a/apps/www/src/registry/changelog/2026-03-25-upgrade-typescript-6.json
+++ b/apps/www/src/registry/changelog/2026-03-25-upgrade-typescript-6.json
@@ -52,7 +52,7 @@
   ],
   "entries": [
     {
-      "id": "2026-03-25-29-3-021",
+      "id": "2026-03-25-29-3-code-drawing-keep-registry-template-compatible-dac6991c",
       "kind": "behavior",
       "summary": "Keep the code drawing registry template compatible with the TypeScript 6 check path.",
       "details": [],

--- a/apps/www/src/registry/changelog/2026-03-27-snapshot-ai-streaming-preview-task-pr-flow.json
+++ b/apps/www/src/registry/changelog/2026-03-27-snapshot-ai-streaming-preview-task-pr-flow.json
@@ -64,7 +64,7 @@
   ],
   "entries": [
     {
-      "id": "2026-03-27-29-4-019",
+      "id": "2026-03-27-29-4-ai-snapshot-insert-mode-preview-f53422b5",
       "kind": "behavior",
       "summary": "Snapshot insert-mode AI preview state so streamed chunks stay out of undo history and accept, undo, and redo preserve selection.",
       "details": [],
@@ -81,7 +81,7 @@
       }
     },
     {
-      "id": "2026-03-27-29-4-020",
+      "id": "2026-03-27-29-4-ai-sync-demo-insert-mode-054db6db",
       "kind": "behavior",
       "summary": "Sync the AI demo with the insert-mode preview history flow.",
       "details": [],

--- a/apps/www/src/registry/changelog/2026-03-27-snapshot-ai-streaming-preview-task-pr-flow.json
+++ b/apps/www/src/registry/changelog/2026-03-27-snapshot-ai-streaming-preview-task-pr-flow.json
@@ -64,15 +64,15 @@
   ],
   "entries": [
     {
-      "id": "2026-03-27-29-4-018",
+      "id": "2026-03-27-29-4-019",
       "kind": "behavior",
       "summary": "Snapshot insert-mode AI preview state so streamed chunks stay out of undo history and accept, undo, and redo preserve selection.",
       "details": [],
       "migrationNotes": [],
       "targets": ["ai-kit"],
       "source": {
-        "line": 54,
-        "row": 18,
+        "line": 57,
+        "row": 19,
         "legacyRelease": {
           "date": "2026-03-27",
           "entry": "29.4",
@@ -81,15 +81,15 @@
       }
     },
     {
-      "id": "2026-03-27-29-4-019",
+      "id": "2026-03-27-29-4-020",
       "kind": "behavior",
       "summary": "Sync the AI demo with the insert-mode preview history flow.",
       "details": [],
       "migrationNotes": [],
       "targets": ["ai-demo"],
       "source": {
-        "line": 55,
-        "row": 19,
+        "line": 58,
+        "row": 20,
         "legacyRelease": {
           "date": "2026-03-27",
           "entry": "29.4",

--- a/apps/www/src/registry/changelog/2026-03-28-render-url-videos-media-node.json
+++ b/apps/www/src/registry/changelog/2026-03-28-render-url-videos-media-node.json
@@ -82,15 +82,15 @@
   ],
   "entries": [
     {
-      "id": "2026-03-28-29-5-016",
+      "id": "2026-03-28-29-5-017",
       "kind": "behavior",
       "summary": "Render plain video URLs with `ReactPlayer` when the node has a `url` and no upload flag.",
       "details": [],
       "migrationNotes": [],
       "targets": ["media-video-node"],
       "source": {
-        "line": 49,
-        "row": 16,
+        "line": 52,
+        "row": 17,
         "legacyRelease": {
           "date": "2026-03-28",
           "entry": "29.5",
@@ -99,15 +99,15 @@
       }
     },
     {
-      "id": "2026-03-28-29-5-017",
+      "id": "2026-03-28-29-5-018",
       "kind": "behavior",
       "summary": "Sync registry blocks with the URL video rendering path.",
       "details": [],
       "migrationNotes": [],
       "targets": ["editor-ai", "editor-basic", "slate-to-html"],
       "source": {
-        "line": 50,
-        "row": 17,
+        "line": 53,
+        "row": 18,
         "legacyRelease": {
           "date": "2026-03-28",
           "entry": "29.5",

--- a/apps/www/src/registry/changelog/2026-03-28-render-url-videos-media-node.json
+++ b/apps/www/src/registry/changelog/2026-03-28-render-url-videos-media-node.json
@@ -82,7 +82,7 @@
   ],
   "entries": [
     {
-      "id": "2026-03-28-29-5-017",
+      "id": "2026-03-28-29-5-media-video-render-plain-urls-when-bf870e04",
       "kind": "behavior",
       "summary": "Render plain video URLs with `ReactPlayer` when the node has a `url` and no upload flag.",
       "details": [],
@@ -99,7 +99,7 @@
       }
     },
     {
-      "id": "2026-03-28-29-5-018",
+      "id": "2026-03-28-29-5-editor-ai-sync-registry-blocks-url-9e2b12ab",
       "kind": "behavior",
       "summary": "Sync registry blocks with the URL video rendering path.",
       "details": [],

--- a/apps/www/src/registry/changelog/2026-03-31-resolve-merged-border-neighbors.json
+++ b/apps/www/src/registry/changelog/2026-03-31-resolve-merged-border-neighbors.json
@@ -64,15 +64,15 @@
   ],
   "entries": [
     {
-      "id": "2026-03-31-29-6-015",
+      "id": "2026-03-31-29-6-016",
       "kind": "behavior",
       "summary": "Update table border demos for merged-cell neighbor resolution so border toggles target the visual adjacent cell.",
       "details": [],
       "migrationNotes": [],
       "targets": ["table-demo", "table-nomerge-demo"],
       "source": {
-        "line": 45,
-        "row": 15,
+        "line": 48,
+        "row": 16,
         "legacyRelease": {
           "date": "2026-03-31",
           "entry": "29.6",

--- a/apps/www/src/registry/changelog/2026-03-31-resolve-merged-border-neighbors.json
+++ b/apps/www/src/registry/changelog/2026-03-31-resolve-merged-border-neighbors.json
@@ -64,7 +64,7 @@
   ],
   "entries": [
     {
-      "id": "2026-03-31-29-6-016",
+      "id": "2026-03-31-29-6-table-update-border-demos-merged-37e9916c",
       "kind": "behavior",
       "summary": "Update table border demos for merged-cell neighbor resolution so border toggles target the visual adjacent cell.",
       "details": [],

--- a/apps/www/src/registry/changelog/2026-04-23-redesign-blockquotes-container-blocks.json
+++ b/apps/www/src/registry/changelog/2026-04-23-redesign-blockquotes-container-blocks.json
@@ -125,31 +125,14 @@
   ],
   "entries": [
     {
-      "id": "2026-04-08-30-2-008",
+      "id": "2026-04-08-30-2-009",
       "kind": "new",
       "summary": "Add GFM footnotes with reference, definition, and input plugins plus UI — hover preview, navigation flash, multi-reference picker, and duplicate-definition recovery.",
       "details": [],
       "migrationNotes": [],
       "targets": ["footnote-kit"],
       "source": {
-        "line": 33,
-        "row": 8,
-        "legacyRelease": {
-          "date": "2026-04-08",
-          "entry": "30.2",
-          "section": "April 2026 #30"
-        }
-      }
-    },
-    {
-      "id": "2026-04-08-30-2-009",
-      "kind": "new",
-      "summary": "Add static footnote rendering for SSR and markdown pipelines.",
-      "details": [],
-      "migrationNotes": [],
-      "targets": ["footnote-base-kit"],
-      "source": {
-        "line": 34,
+        "line": 36,
         "row": 9,
         "legacyRelease": {
           "date": "2026-04-08",
@@ -161,12 +144,12 @@
     {
       "id": "2026-04-08-30-2-010",
       "kind": "new",
-      "summary": "Register the new footnote kits.",
+      "summary": "Add static footnote rendering for SSR and markdown pipelines.",
       "details": [],
-      "migrationNotes": ["Register the new footnote kits."],
-      "targets": ["editor-kit", "editor-base-kit"],
+      "migrationNotes": [],
+      "targets": ["footnote-base-kit"],
       "source": {
-        "line": 35,
+        "line": 37,
         "row": 10,
         "legacyRelease": {
           "date": "2026-04-08",
@@ -177,15 +160,13 @@
     },
     {
       "id": "2026-04-08-30-2-011",
-      "kind": "wiring",
-      "summary": "Register the base footnote plugins and add `remark-emoji` so GFM footnotes and emoji shortcodes round-trip.",
+      "kind": "new",
+      "summary": "Register the new footnote kits.",
       "details": [],
-      "migrationNotes": [
-        "Register the base footnote plugins and add `remark-emoji` so GFM footnotes and emoji shortcodes round-trip."
-      ],
-      "targets": ["markdown-kit"],
+      "migrationNotes": ["Register the new footnote kits."],
+      "targets": ["editor-kit", "editor-base-kit"],
       "source": {
-        "line": 36,
+        "line": 38,
         "row": 11,
         "legacyRelease": {
           "date": "2026-04-08",
@@ -196,17 +177,15 @@
     },
     {
       "id": "2026-04-08-30-2-012",
-      "kind": "behavior",
-      "summary": "Add a Footnote insert entry wired to `action_footnote`.",
+      "kind": "wiring",
+      "summary": "Register the base footnote plugins and add `remark-emoji` so GFM footnotes and emoji shortcodes round-trip.",
       "details": [],
-      "migrationNotes": [],
-      "targets": [
-        "insert-toolbar-button",
-        "insert-toolbar-classic-button",
-        "slash-node"
+      "migrationNotes": [
+        "Register the base footnote plugins and add `remark-emoji` so GFM footnotes and emoji shortcodes round-trip."
       ],
+      "targets": ["markdown-kit"],
       "source": {
-        "line": 37,
+        "line": 39,
         "row": 12,
         "legacyRelease": {
           "date": "2026-04-08",
@@ -217,15 +196,17 @@
     },
     {
       "id": "2026-04-08-30-2-013",
-      "kind": "wiring",
-      "summary": "Map `action_footnote` to `insertFootnote(editor, { select: true })`.",
+      "kind": "behavior",
+      "summary": "Add a Footnote insert entry wired to `action_footnote`.",
       "details": [],
-      "migrationNotes": [
-        "Map `action_footnote` to `insertFootnote(editor, { select: true })`."
+      "migrationNotes": [],
+      "targets": [
+        "insert-toolbar-button",
+        "insert-toolbar-classic-button",
+        "slash-node"
       ],
-      "targets": ["transforms", "transforms-classic"],
       "source": {
-        "line": 38,
+        "line": 40,
         "row": 13,
         "legacyRelease": {
           "date": "2026-04-08",
@@ -236,14 +217,33 @@
     },
     {
       "id": "2026-04-08-30-2-014",
+      "kind": "wiring",
+      "summary": "Map `action_footnote` to `insertFootnote(editor, { select: true })`.",
+      "details": [],
+      "migrationNotes": [
+        "Map `action_footnote` to `insertFootnote(editor, { select: true })`."
+      ],
+      "targets": ["transforms", "transforms-classic"],
+      "source": {
+        "line": 41,
+        "row": 14,
+        "legacyRelease": {
+          "date": "2026-04-08",
+          "entry": "30.2",
+          "section": "April 2026 #30"
+        }
+      }
+    },
+    {
+      "id": "2026-04-08-30-2-015",
       "kind": "behavior",
       "summary": "Reduce to symbol substitutions (arrows, fractions, legal, punctuation, smart quotes, sub/superscript). Markdown shortcuts move to the feature kits below. Add link automd so `[text](url)` closing on `)` resolves to a structured link.",
       "details": [],
       "migrationNotes": [],
       "targets": ["autoformat-kit"],
       "source": {
-        "line": 39,
-        "row": 14,
+        "line": 42,
+        "row": 15,
         "legacyRelease": {
           "date": "2026-04-08",
           "entry": "30.2",

--- a/apps/www/src/registry/changelog/2026-04-23-redesign-blockquotes-container-blocks.json
+++ b/apps/www/src/registry/changelog/2026-04-23-redesign-blockquotes-container-blocks.json
@@ -125,7 +125,7 @@
   ],
   "entries": [
     {
-      "id": "2026-04-08-30-2-009",
+      "id": "2026-04-08-30-2-footnote-gfm-footnotes-reference-definition-bac13652",
       "kind": "new",
       "summary": "Add GFM footnotes with reference, definition, and input plugins plus UI — hover preview, navigation flash, multi-reference picker, and duplicate-definition recovery.",
       "details": [],
@@ -142,7 +142,7 @@
       }
     },
     {
-      "id": "2026-04-08-30-2-010",
+      "id": "2026-04-08-30-2-footnote-ssr-markdown-pipelines-d92e65f4",
       "kind": "new",
       "summary": "Add static footnote rendering for SSR and markdown pipelines.",
       "details": [],
@@ -159,7 +159,7 @@
       }
     },
     {
-      "id": "2026-04-08-30-2-011",
+      "id": "2026-04-08-30-2-editor-register-footnote-kits-c0b7736b",
       "kind": "new",
       "summary": "Register the new footnote kits.",
       "details": [],
@@ -176,7 +176,7 @@
       }
     },
     {
-      "id": "2026-04-08-30-2-012",
+      "id": "2026-04-08-30-2-markdown-register-base-footnote-plugins-remark-emoji-975854b1",
       "kind": "wiring",
       "summary": "Register the base footnote plugins and add `remark-emoji` so GFM footnotes and emoji shortcodes round-trip.",
       "details": [],
@@ -195,7 +195,7 @@
       }
     },
     {
-      "id": "2026-04-08-30-2-013",
+      "id": "2026-04-08-30-2-insert-toolbar-footnote-entry-wired-action-footnote-ca66c2d3",
       "kind": "behavior",
       "summary": "Add a Footnote insert entry wired to `action_footnote`.",
       "details": [],
@@ -216,7 +216,7 @@
       }
     },
     {
-      "id": "2026-04-08-30-2-014",
+      "id": "2026-04-08-30-2-transforms-map-action-footnote-3d2ad293",
       "kind": "wiring",
       "summary": "Map `action_footnote` to `insertFootnote(editor, { select: true })`.",
       "details": [],
@@ -235,7 +235,7 @@
       }
     },
     {
-      "id": "2026-04-08-30-2-015",
+      "id": "2026-04-08-30-2-autoformat-reduce-symbol-substitutions-arrows-7173ec42",
       "kind": "behavior",
       "summary": "Reduce to symbol substitutions (arrows, fractions, legal, punctuation, smart quotes, sub/superscript). Markdown shortcuts move to the feature kits below. Add link automd so `[text](url)` closing on `)` resolves to a structured link.",
       "details": [],

--- a/apps/www/src/registry/changelog/2026-04-29-codex-fix-discussion-suggestion-regressions.json
+++ b/apps/www/src/registry/changelog/2026-04-29-codex-fix-discussion-suggestion-regressions.json
@@ -168,15 +168,15 @@
   ],
   "entries": [
     {
-      "id": "2026-04-29-30-3-005",
+      "id": "2026-04-29-30-3-006",
       "kind": "behavior",
       "summary": "Rebuild discussion indexes from editor state so accept and reject updates, inline text summaries, and deleted comments stay current.",
       "details": [],
       "migrationNotes": [],
       "targets": ["block-discussion", "discussion-kit", "comment-kit"],
       "source": {
-        "line": 27,
-        "row": 5,
+        "line": 30,
+        "row": 6,
         "legacyRelease": {
           "date": "2026-04-29",
           "entry": "30.3",
@@ -185,7 +185,7 @@
       }
     },
     {
-      "id": "2026-04-29-30-3-006",
+      "id": "2026-04-29-30-3-007",
       "kind": "fix",
       "summary": "Fix block and inline suggestion regressions around inline voids, links, line breaks, block voids, and trailing-block normalization.",
       "details": [],
@@ -197,8 +197,8 @@
         "suggestion-node"
       ],
       "source": {
-        "line": 28,
-        "row": 6,
+        "line": 31,
+        "row": 7,
         "legacyRelease": {
           "date": "2026-04-29",
           "entry": "30.3",
@@ -207,7 +207,7 @@
       }
     },
     {
-      "id": "2026-04-29-30-3-007",
+      "id": "2026-04-29-30-3-008",
       "kind": "behavior",
       "summary": "Keep Slate children mount points and suggestion wrappers stable for static and media-style nodes.",
       "details": [],
@@ -227,8 +227,8 @@
         "link-node"
       ],
       "source": {
-        "line": 29,
-        "row": 7,
+        "line": 32,
+        "row": 8,
         "legacyRelease": {
           "date": "2026-04-29",
           "entry": "30.3",

--- a/apps/www/src/registry/changelog/2026-04-29-codex-fix-discussion-suggestion-regressions.json
+++ b/apps/www/src/registry/changelog/2026-04-29-codex-fix-discussion-suggestion-regressions.json
@@ -168,7 +168,7 @@
   ],
   "entries": [
     {
-      "id": "2026-04-29-30-3-006",
+      "id": "2026-04-29-30-3-block-discussion-rebuild-indexes-from-editor-1f58b253",
       "kind": "behavior",
       "summary": "Rebuild discussion indexes from editor state so accept and reject updates, inline text summaries, and deleted comments stay current.",
       "details": [],
@@ -185,7 +185,7 @@
       }
     },
     {
-      "id": "2026-04-29-30-3-007",
+      "id": "2026-04-29-30-3-suggestion-fix-block-inline-regressions-53f39ba6",
       "kind": "fix",
       "summary": "Fix block and inline suggestion regressions around inline voids, links, line breaks, block voids, and trailing-block normalization.",
       "details": [],
@@ -207,7 +207,7 @@
       }
     },
     {
-      "id": "2026-04-29-30-3-008",
+      "id": "2026-04-29-30-3-block-list-keep-slate-children-mount-75c8351f",
       "kind": "behavior",
       "summary": "Keep Slate children mount points and suggestion wrappers stable for static and media-style nodes.",
       "details": [],

--- a/apps/www/src/registry/changelog/2026-06-02-improve-large-document-editing.json
+++ b/apps/www/src/registry/changelog/2026-06-02-improve-large-document-editing.json
@@ -64,15 +64,15 @@
   ],
   "entries": [
     {
-      "id": "2026-05-31-31-1-003",
+      "id": "2026-05-31-31-1-004",
       "kind": "new",
       "summary": "Add a 10k-block Plate and Slate comparison demo with performance controls and benchmark links.",
       "details": [],
       "migrationNotes": [],
       "targets": ["huge-document-demo"],
       "source": {
-        "line": 20,
-        "row": 3,
+        "line": 23,
+        "row": 4,
         "legacyRelease": {
           "date": "2026-05-31",
           "entry": "31.1",
@@ -81,15 +81,15 @@
       }
     },
     {
-      "id": "2026-05-31-31-1-004",
+      "id": "2026-05-31-31-1-005",
       "kind": "rename",
       "summary": "Rename to `huge-document-demo`.",
       "details": [],
       "migrationNotes": ["Rename to `huge-document-demo`."],
       "targets": ["hundreds-blocks-demo"],
       "source": {
-        "line": 21,
-        "row": 4,
+        "line": 24,
+        "row": 5,
         "legacyRelease": {
           "date": "2026-05-31",
           "entry": "31.1",

--- a/apps/www/src/registry/changelog/2026-06-02-improve-large-document-editing.json
+++ b/apps/www/src/registry/changelog/2026-06-02-improve-large-document-editing.json
@@ -64,7 +64,7 @@
   ],
   "entries": [
     {
-      "id": "2026-05-31-31-1-004",
+      "id": "2026-05-31-31-1-huge-document-10k-block-plate-slate-acc08681",
       "kind": "new",
       "summary": "Add a 10k-block Plate and Slate comparison demo with performance controls and benchmark links.",
       "details": [],
@@ -81,7 +81,7 @@
       }
     },
     {
-      "id": "2026-05-31-31-1-005",
+      "id": "2026-05-31-31-1-hundreds-blocks-rename-huge-document-3d2ca91a",
       "kind": "rename",
       "summary": "Rename to `huge-document-demo`.",
       "details": [],

--- a/apps/www/src/registry/changelog/2026-06-10-attach-column-drop-target-ref.json
+++ b/apps/www/src/registry/changelog/2026-06-10-attach-column-drop-target-ref.json
@@ -28,8 +28,7 @@
     }
   },
   "release": {
-    "status": "latest",
-    "source": "post-release-no-changeset"
+    "status": "unresolved"
   },
   "kind": "fix",
   "summary": "fix(dnd): attach column drop target ref",
@@ -43,15 +42,15 @@
   ],
   "entries": [
     {
-      "id": "2026-06-10-32-2-001",
+      "id": "2026-06-10-32-2-002",
       "kind": "fix",
       "summary": "Fix column drag and drop by attaching the DnD drop target ref to the rendered column element so horizontal drop lines can resolve a valid target.",
       "details": [],
       "migrationNotes": [],
       "targets": ["column-node"],
       "source": {
-        "line": 10,
-        "row": 1,
+        "line": 13,
+        "row": 2,
         "legacyRelease": {
           "date": "2026-06-10",
           "entry": "32.2",

--- a/apps/www/src/registry/changelog/2026-06-10-attach-column-drop-target-ref.json
+++ b/apps/www/src/registry/changelog/2026-06-10-attach-column-drop-target-ref.json
@@ -42,7 +42,7 @@
   ],
   "entries": [
     {
-      "id": "2026-06-10-32-2-002",
+      "id": "2026-06-10-32-2-column-fix-drag-drop-by-fa41961e",
       "kind": "fix",
       "summary": "Fix column drag and drop by attaching the DnD drop target ref to the rendered column element so horizontal drop lines can resolve a valid target.",
       "details": [],

--- a/apps/www/src/registry/changelog/2026-06-13-show-code-block-language-labels-read-only-mode.json
+++ b/apps/www/src/registry/changelog/2026-06-13-show-code-block-language-labels-read-only-mode.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "2026-06-03-show-code-block-language-labels-read-only-mode",
+  "id": "2026-06-13-show-code-block-language-labels-read-only-mode",
   "status": "draft",
   "source": {
     "kind": "legacy-mdx",
@@ -8,7 +8,7 @@
   },
   "change": {
     "type": "pull_request",
-    "date": "2026-06-03",
+    "date": "2026-06-13",
     "commits": [
       {
         "sha": "a471d051d2b32c494a94e8218ce1a8462aa26463",
@@ -22,13 +22,13 @@
     "pullRequest": {
       "number": 4989,
       "url": "https://github.com/udecode/plate/pull/4989",
-      "state": "OPEN",
-      "title": "Show code block language labels in read-only mode"
+      "state": "MERGED",
+      "title": "Show code block language labels in read-only mode",
+      "mergedAt": "2026-06-13T21:22:24Z"
     }
   },
   "release": {
-    "status": "latest",
-    "source": "open-pull-request"
+    "status": "unresolved"
   },
   "kind": "behavior",
   "summary": "Show code block language labels in read-only mode",
@@ -48,7 +48,7 @@
   ],
   "entries": [
     {
-      "id": "2026-06-03-32-1-002",
+      "id": "2026-06-03-32-1-003",
       "kind": "behavior",
       "summary": "Show the selected language label in read-only and static rendering. Set `showLanguageLabel={false}` on the component to hide it.",
       "details": [],
@@ -57,8 +57,8 @@
       ],
       "targets": ["code-block-node", "code-block-node-static"],
       "source": {
-        "line": 14,
-        "row": 2,
+        "line": 17,
+        "row": 3,
         "legacyRelease": {
           "date": "2026-06-03",
           "entry": "32.1",
@@ -72,11 +72,6 @@
       "severity": "warning",
       "code": "release-missing",
       "message": "No generated release-index entry found for PR 4989."
-    },
-    {
-      "severity": "warning",
-      "code": "pull-request-not-merged",
-      "message": "Matched PR 4989, but it is OPEN."
     }
   ]
 }

--- a/apps/www/src/registry/changelog/2026-06-13-show-code-block-language-labels-read-only-mode.json
+++ b/apps/www/src/registry/changelog/2026-06-13-show-code-block-language-labels-read-only-mode.json
@@ -48,7 +48,7 @@
   ],
   "entries": [
     {
-      "id": "2026-06-03-32-1-003",
+      "id": "2026-06-03-32-1-code-block-language-label-e8dfda31",
       "kind": "behavior",
       "summary": "Show the selected language label in read-only and static rendering. Set `showLanguageLabel={false}` on the component to hide it.",
       "details": [],

--- a/apps/www/src/registry/changelog/2026-06-14-editor-install-kit-files-through.json
+++ b/apps/www/src/registry/changelog/2026-06-14-editor-install-kit-files-through.json
@@ -1,0 +1,67 @@
+{
+  "schemaVersion": 1,
+  "id": "2026-06-14-editor-install-kit-files-through",
+  "status": "draft",
+  "source": {
+    "kind": "legacy-mdx",
+    "path": "tooling/data/plate-ui-changelog.mdx"
+  },
+  "change": {
+    "type": "source",
+    "date": "2026-06-14",
+    "commits": []
+  },
+  "release": {
+    "status": "unresolved"
+  },
+  "kind": "behavior",
+  "summary": "Install editor kit files through the configured components alias so relative `./plugins/*` imports resolve after shadcn CLI adds.",
+  "targets": [
+    {
+      "name": "editor-base-kit",
+      "files": ["apps/www/src/registry/components/editor/editor-base-kit.tsx"],
+      "definitionFiles": ["apps/www/src/registry/registry-kits.ts"],
+      "diagnostics": []
+    },
+    {
+      "name": "editor-kit",
+      "files": [
+        "apps/www/src/registry/blocks/editor-ai/components/editor/editor-kit.tsx",
+        "apps/www/src/registry/components/editor/editor-kit.tsx"
+      ],
+      "definitionFiles": ["apps/www/src/registry/registry-kits.ts"],
+      "diagnostics": []
+    }
+  ],
+  "entries": [
+    {
+      "id": "2026-06-14-32-3-001",
+      "kind": "behavior",
+      "summary": "Install editor kit files through the configured components alias so relative `./plugins/*` imports resolve after shadcn CLI adds.",
+      "details": [],
+      "migrationNotes": [],
+      "targets": ["editor-base-kit", "editor-kit"],
+      "source": {
+        "line": 9,
+        "row": 1,
+        "legacyRelease": {
+          "date": "2026-06-14",
+          "entry": "32.3",
+          "section": "June 2026 #32"
+        }
+      }
+    }
+  ],
+  "diagnostics": [
+    {
+      "severity": "warning",
+      "code": "release-missing",
+      "message": "No generated release-index entry found for source-only change on 2026-06-14."
+    },
+    {
+      "severity": "warning",
+      "code": "warning",
+      "message": "No blame commit found for tooling/data/plate-ui-changelog.mdx:9."
+    }
+  ]
+}

--- a/apps/www/src/registry/changelog/2026-06-14-fix-shadcn-editor-kit-install-paths.json
+++ b/apps/www/src/registry/changelog/2026-06-14-fix-shadcn-editor-kit-install-paths.json
@@ -1,21 +1,37 @@
 {
   "schemaVersion": 1,
-  "id": "2026-06-14-editor-install-kit-files-through",
+  "id": "2026-06-14-fix-shadcn-editor-kit-install-paths",
   "status": "draft",
   "source": {
     "kind": "legacy-mdx",
     "path": "tooling/data/plate-ui-changelog.mdx"
   },
   "change": {
-    "type": "source",
+    "type": "pull_request",
     "date": "2026-06-14",
-    "commits": []
+    "commits": [
+      {
+        "sha": "129a4b4644b17db4ba5adef56a43233dc24e5be6",
+        "shortSha": "129a4b4644",
+        "url": "https://github.com/udecode/plate/commit/129a4b4644b17db4ba5adef56a43233dc24e5be6",
+        "date": "2026-06-14",
+        "committedAt": "2026-06-14T14:08:43+02:00",
+        "subject": "Fix shadcn editor kit install paths"
+      }
+    ],
+    "pullRequest": {
+      "number": 5013,
+      "url": "https://github.com/udecode/plate/pull/5013",
+      "state": "OPEN",
+      "title": "Fix shadcn editor kit install paths"
+    }
   },
   "release": {
-    "status": "unresolved"
+    "status": "latest",
+    "source": "open-pull-request"
   },
   "kind": "behavior",
-  "summary": "Install editor kit files through the configured components alias so relative `./plugins/*` imports resolve after shadcn CLI adds.",
+  "summary": "Fix shadcn editor kit install paths",
   "targets": [
     {
       "name": "editor-base-kit",
@@ -35,7 +51,7 @@
   ],
   "entries": [
     {
-      "id": "2026-06-14-32-3-001",
+      "id": "2026-06-14-32-3-editor-install-kit-files-through-fbf1a92f",
       "kind": "behavior",
       "summary": "Install editor kit files through the configured components alias so relative `./plugins/*` imports resolve after shadcn CLI adds.",
       "details": [],
@@ -56,12 +72,12 @@
     {
       "severity": "warning",
       "code": "release-missing",
-      "message": "No generated release-index entry found for source-only change on 2026-06-14."
+      "message": "No generated release-index entry found for PR 5013."
     },
     {
       "severity": "warning",
-      "code": "warning",
-      "message": "No blame commit found for tooling/data/plate-ui-changelog.mdx:9."
+      "code": "pull-request-not-merged",
+      "message": "Matched PR 5013, but it is OPEN."
     }
   ]
 }

--- a/apps/www/src/registry/changelog/components.json
+++ b/apps/www/src/registry/changelog/components.json
@@ -2,11 +2,11 @@
   "schemaVersion": 1,
   "components": {
     "editor-base-kit": [
-      "2026-06-14-editor-install-kit-files-through",
+      "2026-06-14-fix-shadcn-editor-kit-install-paths",
       "2026-04-23-redesign-blockquotes-container-blocks"
     ],
     "editor-kit": [
-      "2026-06-14-editor-install-kit-files-through",
+      "2026-06-14-fix-shadcn-editor-kit-install-paths",
       "2026-04-23-redesign-blockquotes-container-blocks",
       "2026-01-28-add-code-drawing-node"
     ],

--- a/apps/www/src/registry/changelog/components.json
+++ b/apps/www/src/registry/changelog/components.json
@@ -1,20 +1,29 @@
 {
   "schemaVersion": 1,
   "components": {
-    "column-node": [
-      "2026-06-10-attach-column-drop-target-ref",
-      "2026-01-20-add-docx-file-import-word-export-support",
-      "2025-11-20-biome-ultracite",
-      "2025-10-17-fix-react-decouple"
+    "editor-base-kit": [
+      "2026-06-14-editor-install-kit-files-through",
+      "2026-04-23-redesign-blockquotes-container-blocks"
+    ],
+    "editor-kit": [
+      "2026-06-14-editor-install-kit-files-through",
+      "2026-04-23-redesign-blockquotes-container-blocks",
+      "2026-01-28-add-code-drawing-node"
     ],
     "code-block-node": [
-      "2026-06-03-show-code-block-language-labels-read-only-mode",
+      "2026-06-13-show-code-block-language-labels-read-only-mode",
       "2026-01-20-add-docx-file-import-word-export-support",
       "2025-11-20-biome-ultracite",
       "2025-10-17-fix-react-decouple"
     ],
     "code-block-node-static": [
-      "2026-06-03-show-code-block-language-labels-read-only-mode"
+      "2026-06-13-show-code-block-language-labels-read-only-mode"
+    ],
+    "column-node": [
+      "2026-06-10-attach-column-drop-target-ref",
+      "2026-01-20-add-docx-file-import-word-export-support",
+      "2025-11-20-biome-ultracite",
+      "2025-10-17-fix-react-decouple"
     ],
     "huge-document-demo": ["2026-06-02-improve-large-document-editing"],
     "hundreds-blocks-demo": [
@@ -107,11 +116,6 @@
     ],
     "footnote-kit": ["2026-04-23-redesign-blockquotes-container-blocks"],
     "footnote-base-kit": ["2026-04-23-redesign-blockquotes-container-blocks"],
-    "editor-kit": [
-      "2026-04-23-redesign-blockquotes-container-blocks",
-      "2026-01-28-add-code-drawing-node"
-    ],
-    "editor-base-kit": ["2026-04-23-redesign-blockquotes-container-blocks"],
     "markdown-kit": ["2026-04-23-redesign-blockquotes-container-blocks"],
     "insert-toolbar-button": [
       "2026-04-23-redesign-blockquotes-container-blocks",

--- a/apps/www/src/registry/changelog/index.json
+++ b/apps/www/src/registry/changelog/index.json
@@ -2,18 +2,34 @@
   "schemaVersion": 1,
   "events": [
     {
-      "id": "2026-06-14-editor-install-kit-files-through",
-      "href": "/registry/changelog/2026-06-14-editor-install-kit-files-through.json",
+      "id": "2026-06-14-fix-shadcn-editor-kit-install-paths",
+      "href": "/registry/changelog/2026-06-14-fix-shadcn-editor-kit-install-paths.json",
       "status": "draft",
       "kind": "behavior",
-      "summary": "Install editor kit files through the configured components alias so relative `./plugins/*` imports resolve after shadcn CLI adds.",
+      "summary": "Fix shadcn editor kit install paths",
       "change": {
-        "type": "source",
+        "type": "pull_request",
         "date": "2026-06-14",
-        "commits": []
+        "commits": [
+          {
+            "sha": "129a4b4644b17db4ba5adef56a43233dc24e5be6",
+            "shortSha": "129a4b4644",
+            "url": "https://github.com/udecode/plate/commit/129a4b4644b17db4ba5adef56a43233dc24e5be6",
+            "date": "2026-06-14",
+            "committedAt": "2026-06-14T14:08:43+02:00",
+            "subject": "Fix shadcn editor kit install paths"
+          }
+        ],
+        "pullRequest": {
+          "number": 5013,
+          "url": "https://github.com/udecode/plate/pull/5013",
+          "state": "OPEN",
+          "title": "Fix shadcn editor kit install paths"
+        }
       },
       "release": {
-        "status": "unresolved"
+        "status": "latest",
+        "source": "open-pull-request"
       },
       "targets": ["editor-base-kit", "editor-kit"],
       "entries": 1,
@@ -23,7 +39,7 @@
           "severity": "warning"
         },
         {
-          "code": "warning",
+          "code": "pull-request-not-merged",
           "severity": "warning"
         }
       ]

--- a/apps/www/src/registry/changelog/index.json
+++ b/apps/www/src/registry/changelog/index.json
@@ -2,6 +2,72 @@
   "schemaVersion": 1,
   "events": [
     {
+      "id": "2026-06-14-editor-install-kit-files-through",
+      "href": "/registry/changelog/2026-06-14-editor-install-kit-files-through.json",
+      "status": "draft",
+      "kind": "behavior",
+      "summary": "Install editor kit files through the configured components alias so relative `./plugins/*` imports resolve after shadcn CLI adds.",
+      "change": {
+        "type": "source",
+        "date": "2026-06-14",
+        "commits": []
+      },
+      "release": {
+        "status": "unresolved"
+      },
+      "targets": ["editor-base-kit", "editor-kit"],
+      "entries": 1,
+      "diagnostics": [
+        {
+          "code": "release-missing",
+          "severity": "warning"
+        },
+        {
+          "code": "warning",
+          "severity": "warning"
+        }
+      ]
+    },
+    {
+      "id": "2026-06-13-show-code-block-language-labels-read-only-mode",
+      "href": "/registry/changelog/2026-06-13-show-code-block-language-labels-read-only-mode.json",
+      "status": "draft",
+      "kind": "behavior",
+      "summary": "Show code block language labels in read-only mode",
+      "change": {
+        "type": "pull_request",
+        "date": "2026-06-13",
+        "commits": [
+          {
+            "sha": "a471d051d2b32c494a94e8218ce1a8462aa26463",
+            "shortSha": "a471d051d2",
+            "url": "https://github.com/udecode/plate/commit/a471d051d2b32c494a94e8218ce1a8462aa26463",
+            "date": "2026-06-03",
+            "committedAt": "2026-06-03T13:20:44+02:00",
+            "subject": "fix code block language labels"
+          }
+        ],
+        "pullRequest": {
+          "number": 4989,
+          "url": "https://github.com/udecode/plate/pull/4989",
+          "state": "MERGED",
+          "title": "Show code block language labels in read-only mode",
+          "mergedAt": "2026-06-13T21:22:24Z"
+        }
+      },
+      "release": {
+        "status": "unresolved"
+      },
+      "targets": ["code-block-node", "code-block-node-static"],
+      "entries": 1,
+      "diagnostics": [
+        {
+          "code": "release-missing",
+          "severity": "warning"
+        }
+      ]
+    },
+    {
       "id": "2026-06-10-attach-column-drop-target-ref",
       "href": "/registry/changelog/2026-06-10-attach-column-drop-target-ref.json",
       "status": "draft",
@@ -29,57 +95,13 @@
         }
       },
       "release": {
-        "status": "latest",
-        "source": "post-release-no-changeset"
+        "status": "unresolved"
       },
       "targets": ["column-node"],
       "entries": 1,
       "diagnostics": [
         {
           "code": "release-missing",
-          "severity": "warning"
-        }
-      ]
-    },
-    {
-      "id": "2026-06-03-show-code-block-language-labels-read-only-mode",
-      "href": "/registry/changelog/2026-06-03-show-code-block-language-labels-read-only-mode.json",
-      "status": "draft",
-      "kind": "behavior",
-      "summary": "Show code block language labels in read-only mode",
-      "change": {
-        "type": "pull_request",
-        "date": "2026-06-03",
-        "commits": [
-          {
-            "sha": "a471d051d2b32c494a94e8218ce1a8462aa26463",
-            "shortSha": "a471d051d2",
-            "url": "https://github.com/udecode/plate/commit/a471d051d2b32c494a94e8218ce1a8462aa26463",
-            "date": "2026-06-03",
-            "committedAt": "2026-06-03T13:20:44+02:00",
-            "subject": "fix code block language labels"
-          }
-        ],
-        "pullRequest": {
-          "number": 4989,
-          "url": "https://github.com/udecode/plate/pull/4989",
-          "state": "OPEN",
-          "title": "Show code block language labels in read-only mode"
-        }
-      },
-      "release": {
-        "status": "latest",
-        "source": "open-pull-request"
-      },
-      "targets": ["code-block-node", "code-block-node-static"],
-      "entries": 1,
-      "diagnostics": [
-        {
-          "code": "release-missing",
-          "severity": "warning"
-        },
-        {
-          "code": "pull-request-not-merged",
           "severity": "warning"
         }
       ]

--- a/apps/www/src/registry/registry.test.ts
+++ b/apps/www/src/registry/registry.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'bun:test';
+
+import { createPlateRegistry } from './registry';
+
+describe('Plate registry editor files', () => {
+  const items = createPlateRegistry().items;
+
+  function toEditorTarget(path: string) {
+    return `@components/editor/${path.slice(path.indexOf('components/editor/') + 'components/editor/'.length)}`;
+  }
+
+  it('installs editor component files through the configured components alias', () => {
+    for (const item of items) {
+      for (const file of item.files ?? []) {
+        if (!file.path.includes('components/editor/')) continue;
+
+        expect(file.target, `${item.name}:${file.path}`).toBe(
+          toEditorTarget(file.path)
+        );
+      }
+    }
+  });
+
+  it('keeps editor-base-kit relative plugin imports installable', () => {
+    const itemsByName = new Map(items.map((item) => [item.name, item]));
+    const editorBaseKit = itemsByName.get('editor-base-kit');
+
+    expect(editorBaseKit).toBeDefined();
+    expect(editorBaseKit?.files?.[0]?.target).toBe(
+      '@components/editor/editor-base-kit.tsx'
+    );
+
+    const pluginDependencies = editorBaseKit?.registryDependencies
+      ?.filter((dependency) => dependency.startsWith('@plate/'))
+      .map((dependency) => dependency.slice('@plate/'.length))
+      .filter((name) => name.endsWith('-kit'));
+
+    expect(pluginDependencies?.length).toBeGreaterThan(0);
+
+    for (const dependencyName of pluginDependencies ?? []) {
+      const dependency = itemsByName.get(dependencyName);
+      const file = dependency?.files?.[0];
+
+      expect(file, dependencyName).toBeDefined();
+      expect(file?.target, dependencyName).toBe(
+        toEditorTarget(file?.path ?? '')
+      );
+      expect(file?.target?.startsWith('@components/editor/plugins/')).toBe(
+        true
+      );
+    }
+  });
+
+  it('keeps editor block component imports installable', () => {
+    const itemsByName = new Map(items.map((item) => [item.name, item]));
+    const editorAi = itemsByName.get('editor-ai');
+    const editorBasic = itemsByName.get('editor-basic');
+
+    expect(editorAi?.files).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: 'blocks/editor-ai/components/editor/plate-editor.tsx',
+          target: '@components/editor/plate-editor.tsx',
+        }),
+        expect.objectContaining({
+          path: 'blocks/editor-ai/components/editor/editor-kit.tsx',
+          target: '@components/editor/editor-kit.tsx',
+        }),
+      ])
+    );
+    expect(editorBasic?.files).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: 'blocks/editor-basic/components/editor/plate-editor.tsx',
+          target: '@components/editor/plate-editor.tsx',
+        }),
+      ])
+    );
+  });
+});

--- a/apps/www/src/registry/registry.ts
+++ b/apps/www/src/registry/registry.ts
@@ -13,6 +13,37 @@ const url =
     ? 'http://localhost:3000'
     : 'https://platejs.org';
 
+const EDITOR_COMPONENT_PATH_SEGMENT = 'components/editor/';
+const EDITOR_COMPONENT_TARGET_PREFIX = '@components/editor/';
+
+function getEditorComponentTarget(filePath: string) {
+  const segmentIndex = filePath.indexOf(EDITOR_COMPONENT_PATH_SEGMENT);
+
+  if (segmentIndex === -1) return null;
+
+  return `${EDITOR_COMPONENT_TARGET_PREFIX}${filePath.slice(segmentIndex + EDITOR_COMPONENT_PATH_SEGMENT.length)}`;
+}
+
+function withEditorComponentTargets(
+  items: Registry['items']
+): Registry['items'] {
+  return items.map((item) => ({
+    ...item,
+    files: item.files?.map((file) => {
+      const target = getEditorComponentTarget(file.path);
+
+      if (file.target || !target) {
+        return file;
+      }
+
+      return {
+        ...file,
+        target,
+      };
+    }),
+  }));
+}
+
 export const registryInit: RegistryItem[] = [
   {
     dependencies: ['platejs'],
@@ -50,7 +81,7 @@ export function createPlateRegistryItems(): Registry['items'] {
     ],
   }));
 
-  return [
+  return withEditorComponentTargets([
     ...registryInit,
     ...registryUI,
     ...registryComponents,
@@ -59,7 +90,7 @@ export function createPlateRegistryItems(): Registry['items'] {
     ...registryStyles,
     ...registryHooks,
     ...registryExamples,
-  ];
+  ]);
 }
 
 export function createPlateRegistry(homepage = url): Registry {

--- a/docs/plans/2026-06-14-fix-media-embed-advisory.md
+++ b/docs/plans/2026-06-14-fix-media-embed-advisory.md
@@ -1,0 +1,268 @@
+# fix media embed advisory
+
+Objective:
+Fix GHSA-qj6x-xx2h-8hvv by blocking unsafe serialized media embed iframe URLs while preserving valid provider embeds.
+
+Goal plan:
+docs/plans/2026-06-14-fix-media-embed-advisory.md
+
+Template:
+docs/plans/templates/task.md
+
+Primary template:
+docs/plans/templates/task.md
+
+Applied packs:
+- package-api (docs/plans/templates/packs/package-api.md)
+
+Task source:
+- type: GitHub repository security advisory
+- id / link: https://github.com/udecode/plate/security/advisories/GHSA-qj6x-xx2h-8hvv
+- title: Media embed provider metadata can bypass URL sanitization and execute iframe JavaScript
+- acceptance criteria: the advisory PoC cannot produce an embed with `javascript:` iframe `src`; valid serialized YouTube/Vimeo/Twitter metadata still resolves through `useMediaState`; `@platejs/media` gets a patch changeset.
+
+Completion threshold:
+- `useMediaState` recomputes or validates rendered embed URLs instead of trusting serialized `provider` / `sourceUrl` metadata.
+- Regression coverage proves the advisory PoC returns no renderable embed.
+- Valid serialized provider metadata keeps rendering through parser-owned HTTP(S) output.
+- Focused media package tests pass and release artifact is recorded.
+- Task closure is legal only when the source-of-truth acceptance criteria are
+  satisfied or explicitly narrowed, required verification evidence is recorded,
+  code-review and release-artifact gates are closed when applicable, tracker/PR
+  sync is complete or marked N/A with reason, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-14-fix-media-embed-advisory.md` passes.
+
+Verification surface:
+- `pnpm --filter @platejs/media test -- useMediaState`
+- `pnpm turbo typecheck --filter=./packages/media`
+- `pnpm lint:fix`
+- Source audit of `packages/media/src/react/media/useMediaState.ts`, media parsers, and package export impact.
+
+Constraints:
+- Preserve existing user-facing behavior outside the task scope.
+- Prefer the durable ownership boundary over caller-by-caller patches.
+- Do not create PRs, comments, commits, or pushes unless the task/user/skill
+  requires them.
+- Do not add broad ceremony when the task is trivial or docs-only.
+
+Boundaries:
+- Source of truth: private GHSA advisory `GHSA-qj6x-xx2h-8hvv`, fetched with `gh api repos/udecode/plate/security-advisories/GHSA-qj6x-xx2h-8hvv`.
+- Allowed edit scope: `packages/media/src/react/media/useMediaState.ts`, focused media tests, `.changeset`, and this plan.
+- Browser surface: N/A for the package fix; the vulnerable behavior is hook/parser-owned and covered by unit tests.
+- Tracker sync: N/A unless the user asks to comment or publish the advisory.
+- Non-goals: public disclosure wording, npm release execution, PR creation, broad media parser redesign.
+
+Output budget strategy:
+- Use focused `rg`/`sed` reads and cap large command output. Avoid broad generated docs/public JSON output after initial search.
+
+Blocked condition:
+- Block only if package tests cannot run due to install corruption after the required reinstall retry, or if GitHub advisory access is revoked before confirming remediation.
+
+Task state:
+- task_type: security bug fix
+- task_complexity: normal
+- current_phase: implementation
+- current_phase_status: in_progress
+- next_phase: implementation
+- goal_status: active
+
+Current verdict:
+- verdict: valid high-severity package bug
+- confidence: high
+- next owner: task
+- reason: advisory PoC matches current `useMediaState` fast path and registry iframe render path.
+
+Completion rule:
+- Do not call `update_goal(status: complete)` while any required checklist item
+  remains unchecked. If an item does not apply, check it and add `N/A: <reason>`.
+- Do not call `update_goal(status: complete)` until every completion threshold
+  above is satisfied, final handoff evidence is recorded, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-14-fix-media-embed-advisory.md` passes.
+- Do not create hook state for this goal. This file plus the active goal are the
+  durable state.
+
+Start Gates:
+| Gate | Applies | Evidence |
+|------|---------|----------|
+| Skill analysis before edits | yes | Read `task`, `autogoal`, GitHub, and `changeset` instructions. |
+| Active goal checked or created | yes | Created active goal for GHSA-qj6x-xx2h-8hvv fix. |
+| Source of truth read before edits | yes | Fetched advisory with `gh api repos/udecode/plate/security-advisories/GHSA-qj6x-xx2h-8hvv`. |
+| Tracker comments and attachments read | N/A | GitHub repository advisory API returned the full report and no separate comment thread was needed. |
+| Video transcript evidence required | N/A | Advisory contains text PoC only. |
+| `docs/solutions` checked for non-trivial existing-code work | yes | Scoped `rg` over `docs/solutions`, `.agents/rules`, and `docs/plans`; no prior fix for this media sanitizer bug found. |
+| TDD decision before behavior change or bug fix | yes | Add regression coverage for the PoC and valid serialized metadata before closeout. |
+| Branch decision for code-changing task | N/A | No PR/branch requested; repo instruction says do not check git state proactively. |
+| Release artifact decision | yes | Add one `.changeset` for `@platejs/media` patch behavior. |
+| Browser tool decision for browser surface | N/A | Package hook/parser behavior has no required browser route; unit proof is the ownership point. |
+| PR expectation decision | N/A | User asked what to do; no PR requested. |
+| Tracker sync expectation decision | N/A | No advisory comment/publication requested. |
+| Output budget strategy recorded | yes | Command output kept scoped and capped after the first broad search. |
+| Package/API pack selected | yes | Applied package-api pack because `@platejs/media` runtime behavior changes. |
+| Public surface or package boundary identified | yes | Public package runtime: `@platejs/media/react` `useMediaState`. |
+| Release artifact path selected | yes | `.changeset` required for published package behavior. |
+| `changeset` skill loaded when `.changeset` is required | yes | Read `.agents/rules/changeset.mdc`. |
+| Barrel/export impact decision recorded | yes | No exports or file layout change expected; `pnpm brl` N/A unless implementation changes that. |
+
+Work Checklist:
+- [ ] Short objective plus outcome, completion threshold, verification surface,
+      constraints, boundaries, and blocked condition are concrete.
+- [ ] Task source classified with source type, id/link, title, task type,
+      acceptance criteria, caveats, likely files/routes/packages, browser
+      surface, and root-cause layer.
+- [ ] Required video or screen-recording evidence is cached/read as normalized
+      `<video-transcripts>` XML, or marked N/A with reason.
+- [ ] Nearby repo instructions and implementation patterns read before edits.
+- [ ] Implementation fixes the right ownership boundary, or the narrower choice
+      is recorded with reason.
+- [ ] Release artifact requirement recorded: changeset, registry changelog, or
+      N/A with reason.
+- [ ] Final handoff shape decided: bug/feature/testing/batch/review/tracker
+      requirements, PR body sync, and issue/Linear sync when applicable.
+- [ ] Branch handling recorded for code-changing work: dedicated branch used,
+      new branch needed, or N/A with reason.
+- [ ] Local-env-rot retry policy recorded for any surprising repo-wide failure:
+      reinstall/rerun evidence or N/A with reason.
+- [ ] Workspace authority recorded: every proof command names the cwd/tool that
+      owns the changed behavior.
+- [ ] High-risk note recorded for public API, runtime, package-boundary,
+      browser behavior, agent-action, or command-contract changes, or marked
+      N/A with reason.
+- [ ] Review/autoreview target selected from actual diff state for non-trivial
+      implementation work, or marked N/A with reason.
+- [ ] Agent-native review decision recorded for `.agents/**`, `.claude/**`,
+      `.codex/**`, skills, hooks, commands, prompts, or user-action tooling.
+- [ ] Output budget discipline recorded and followed: broad searches are
+      scoped, capped, counted, or artifacted instead of streamed into goal
+      context.
+- [ ] Package/API pack: public API, package boundary, export, and release-artifact impact are recorded.
+- [ ] Package/API pack: release artifact matrix is applied: `.changeset`, registry changelog, or explicit no-artifact reason.
+- [ ] Package/API pack: `.changeset` work loads `changeset` and follows its package/version/prose rules.
+- [ ] Package/API pack: registry-only work updates `tooling/data/plate-ui-changelog.mdx` and generated `/registry/changelog/*` JSON instead of adding a package changeset.
+- [ ] Package/API pack: no-artifact decisions state why the diff has no published package user-visible delta from `main`.
+- [ ] Package/API pack: compatibility, migration, or hard-cut decision is explicit when public shape changes.
+- [ ] Package/API pack: package-owned typecheck/build/test proof is recorded or marked N/A with reason.
+- [ ] Package/API pack: generated barrels or release notes are updated when required.
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+|------|---------|-----------------|----------|
+| Named verification threshold | pending | Run the command, proof, source audit, or artifact check named in this plan | pending |
+| Bug reproduced before fix | pending | Record failing test/repro or N/A with reason | pending |
+| Targeted behavior verification | pending | Run focused test/proof for changed behavior or record N/A | pending |
+| TypeScript or typed config changed | pending | Run relevant typecheck | pending |
+| Package exports or file layout changed | pending | Run `pnpm brl` before final verification and keep generated barrel updates | pending |
+| Package manifests, lockfile, or install graph changed | pending | Run `pnpm install` and relevant package checks | pending |
+| Agent rules or skills changed | pending | Run `pnpm install` and verify generated skill sync | pending |
+| Workspace authority proof | pending | Run verification in the owning repo/package/app/route/tool and record cwd; do not count the wrong workspace as proof | pending |
+| Browser surface changed | pending | Capture Browser Use proof or record explicit waiver/blocker | pending |
+| Browser final proof | pending | Attach screenshot or exact browser verification caveat when browser proof applies | pending |
+| CI-controlled template output changed | pending | Restore generated template output or record why it is intentionally kept | pending |
+| Package behavior or public API changed | pending | Add a changeset or record why no changeset applies | pending |
+| Registry-only component work changed | pending | Update `tooling/data/plate-ui-changelog.mdx`, run `node tooling/scripts/generate-ui-changelog-entries.mjs --write`, or record N/A | pending |
+| Docs or content changed | pending | For docs-heavy work, use `--template docs`; for incidental docs, verify source-backed claims, links, examples, and rendered output or record N/A | pending |
+| High-risk mini gate | pending | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | pending |
+| Agent-native review for agent/tooling changes | pending | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | pending |
+| Local install corruption suspected | pending | Run `pnpm run reinstall` once, rerun the exact failing command, or record N/A | pending |
+| Autoreview for non-trivial implementation changes | pending | Load `.agents/skills/autoreview/SKILL.md`; use dirty local `--mode local`, branch/PR `--mode branch --base <base>`, or committed slice `--mode commit --commit <ref>` until no accepted/actionable findings, or record N/A for docs-only/trivial/no local patch | pending |
+| PR create or update | pending | Run `check` before PR work and sync PR body to the task-style final handoff | pending |
+| Task-style PR body verified | pending | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the kitcn PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | pending |
+| PR proof image hosting | pending | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | pending |
+| Tracker sync-back | pending | Post concise issue/Linear sync after PR exists, or record N/A/blocker | pending |
+| Final handoff contract | pending | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | pending |
+| Final lint | pending | Run `pnpm lint:fix` or scoped equivalent | pending |
+| Output budget discipline | pending | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-14-fix-media-embed-advisory.md` | pending |
+| Public API / package boundary proof | pending | Source-audit public API, exports, and package boundary impact | pending |
+| Release artifact classification | pending | Record whether the change is published package behavior/API/types/config/runtime, registry-only, or no published user-visible delta | pending |
+| Published package changeset | pending | If published package users see a delta, load `changeset`, add/update one `.changeset/*.md` per package, and prove no forbidden `minor` on `@platejs/slate`, `@platejs/core`, or `platejs` | pending |
+| Registry changelog | pending | If the change is registry-only under `apps/www/src/registry/**`, update `tooling/data/plate-ui-changelog.mdx`, run `node tooling/scripts/generate-ui-changelog-entries.mjs --write`, and do not add a package changeset | pending |
+| No release artifact | pending | If no artifact is needed, record the exact reason: internal-only, docs-only, agent-only, test-only, or no user-visible delta from `main` | pending |
+| Package typecheck/build/test | pending | Run owning package checks or record N/A with reason | pending |
+| Barrel/export generation | pending | Run `pnpm brl` when exports or exported file layout changed, otherwise N/A | pending |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+|-------|--------|----------|------|
+| Intake and source read | in_progress | created plan | implementation |
+| Implementation | pending | | verification |
+| Verification | pending | | closeout |
+| PR / tracker sync | pending | | final response |
+| Closeout | pending | | final response |
+
+Findings:
+- None yet.
+
+Decisions and tradeoffs:
+- None yet.
+
+Implementation notes:
+- None yet.
+
+Review fixes:
+- None yet.
+
+Error attempts:
+| Error / failed attempt | Count | Next different move | Resolution |
+|------------------------|-------|---------------------|------------|
+| None yet | 0 | | |
+
+Verification evidence:
+- Pending.
+
+Final handoff contract:
+- PR line: pending
+- Issue / tracker line: pending
+- Confidence line: pending
+- Flow table:
+  - Reproduced: tests pending, browser pending
+  - Verified: tests pending, browser pending
+- Browser check: pending
+- Outcome: pending
+- Caveat: pending
+- Design:
+  - Chosen boundary: pending
+  - Why not quick patch: pending
+  - Why not broader change: pending
+- Verified: pending
+- PR body verified: pending
+
+Task-style PR body contract:
+- Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
+  part of the diff and repo policy expects auto release, include that block.
+- Use the accepted kitcn PR #270 visual format. The body starts with an emoji
+  issue/tracker/fix line, for example `🐛 Fixes #123` or `🐛 Fixes ➖ N/A`, then
+  an emoji confidence line like `🟢 95-100% confidence`.
+- Use this exact table header: `| Phase | 🧪 Tests | 🌐 Browser |`.
+- Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
+  failing proof with `🔴`, and non-applicable cells with `➖ N/A`.
+- Use bold emoji section headings: `**✅ Outcome**`, `**⚠️ Caveat**`,
+  `**🏗️ Design**`, and `**🧪 Verified**`.
+- Never include a line that links to the current PR itself. The current PR URL
+  belongs in the final response, not in its own description.
+- Do not replace this with a generic `Summary` / `Verification` PR body, an
+  adaptive prose body from a git helper skill, plain `## Outcome` sections, or
+  an unrelated generated badge footer unless the caller or repo template
+  explicitly asks for it.
+- Proof is `gh pr view --json body` output or a concise source-backed summary
+  of that output.
+
+Final handoff / sync:
+- PR: pending
+- Issue / tracker: pending
+- Browser proof: pending
+- Caveats: pending
+
+Timeline:
+- 2026-06-14T11:14:10.441Z Task goal plan created.
+
+Reboot status:
+| Question | Answer |
+|----------|--------|
+| Where am I? | Intake and source read |
+| Where am I going? | Implementation, verification, PR/tracker sync, closeout |
+| What is the goal? | TODO: Fill from Objective |
+| What have I learned? | See Findings |
+| What have I done? | See Timeline |
+
+Open risks:
+- Pending.

--- a/docs/plans/2026-06-14-fix-shadcn-registry-kit-dependencies.md
+++ b/docs/plans/2026-06-14-fix-shadcn-registry-kit-dependencies.md
@@ -1,0 +1,220 @@
+# Fix shadcn registry kit dependencies
+
+Objective:
+Fix GitHub issue #4971 by making Plate registry editor kit and editor block files install into the configured shadcn components alias so relative plugin imports resolve.
+
+Goal plan:
+docs/plans/2026-06-14-fix-shadcn-registry-kit-dependencies.md
+
+Task source:
+- type: GitHub issue
+- id / link: https://github.com/udecode/plate/issues/4971
+- title: [Bug]: relative imports fail due to CLI install
+- acceptance criteria: shadcn CLI installs `editor-base-kit`, `editor-kit`, their `./plugins/*` dependencies, and editor block component files into the same configured components editor directory.
+
+Completion threshold:
+- Registry source metadata maps every `components/editor/*` and `blocks/*/components/editor/*` file to `@components/editor/*`.
+- `editor-base-kit` relative `./plugins/*` imports and editor block imports resolve after `shadcn@4.7.0 add`, including custom `aliases.components`.
+- Registry changelog records the registry-only user-visible fix, and source-only changelog rows do not claim unrelated same-day package releases.
+- Focused tests, registry source check, `www` typecheck, lint, shadcn smoke proof, and autoreview pass.
+
+Verification surface:
+- `bun test apps/www/src/registry/registry.test.ts 'apps/www/src/app/registry/changelog/[event]/route.test.ts' apps/www/src/app/registry/changelog/components.json/route.test.ts apps/www/src/app/registry/changelog/index.json/route.test.ts`
+- `node --test tooling/scripts/generate-ui-changelog-entries.test.mjs`
+- `pnpm --filter www exec tsx --tsconfig ./scripts/tsconfig.scripts.json scripts/check-registry-source.mts`
+- `pnpm --filter www typecheck`
+- `pnpm lint:fix`
+- `pnpm dlx shadcn@4.7.0 add <local registry item> --cwd <tmpdir> --yes --overwrite --silent` smoke tests for custom `aliases.components`.
+- `.agents/skills/autoreview/scripts/autoreview --mode local ...`
+
+Constraints:
+- Do not edit generated registry build output or run `build:registry`.
+- Registry-only user-visible work uses `tooling/data/plate-ui-changelog.mdx` plus generated `/registry/changelog/*` JSON, not a package changeset.
+- Do not create a PR, commit, push, or issue comment without an explicit user request.
+- Preserve explicit registry targets such as block page targets.
+
+Boundaries:
+- Source of truth: GitHub issue #4971 title/body/comments fetched with `gh issue view ... --comments --json`.
+- Allowed edit scope: `apps/www` registry metadata/checks/changelog routes, changelog generator tests, and this goal plan.
+- Browser surface: applies because `apps/www/**` changed, but Browser/browser-use was not exposed by `tool_search`; route tests and CLI smoke cover the affected JSON/install behavior.
+- Tracker sync: N/A because repo policy requires explicit PR/comment request, and none was given.
+- Non-goals: package runtime changes, registry build output, unrelated docs plan file, PR creation.
+
+Output budget strategy:
+- Used focused `sed` and `rg` reads, targeted tests, capped command output, and short smoke-test file lists instead of broad build or full test output.
+
+Blocked condition:
+- Only Browser proof is blocked: `tool_search` exposed thread and automation tools, not Browser/browser-use. Code and CLI verification continued without browser proof.
+
+Task state:
+- task_type: bug fix
+- task_complexity: medium
+- current_phase: closeout
+- current_phase_status: complete
+- goal_status: ready-to-close
+
+Current verdict:
+- verdict: fixed
+- confidence: high
+- next owner: user
+- reason: focused tests, typecheck, lint, shadcn CLI smoke tests, and final autoreview are clean.
+
+Start Gates:
+| Gate | Applies | Evidence |
+|------|---------|----------|
+| Skill analysis before edits | yes | Loaded `task`, `autogoal`, `shadcn`, `plate-ui`, `changeset`, and `autoreview` guidance before closeout. |
+| Active goal checked or created | yes | Active goal created for issue #4971 with this plan path. |
+| Source of truth read before edits | yes | `gh issue view 4971 --repo udecode/plate --comments --json ...` read title/body/comments. |
+| Tracker comments and attachments read | yes | GitHub issue comments included in source fetch; no attachments needed. |
+| Video transcript evidence required | no | Issue has no video or screen recording. |
+| Existing-code patterns read | yes | Read registry item creation, registry checks, changelog generator, and editor block files. |
+| TDD decision | yes | Added focused registry/changelog tests around current behavior instead of dead-path removal assertions. |
+| Branch decision | no | User did not ask for branch, commit, push, or PR. |
+| Release artifact decision | yes | Registry changelog required; package changeset not applicable. |
+| Browser tool decision | yes | Browser proof blocked because Browser/browser-use tools were unavailable through `tool_search`. |
+| PR expectation decision | yes | N/A: no explicit PR request and repo policy forbids PR work without it. |
+| Tracker sync expectation decision | yes | N/A: no explicit tracker comment request and no PR exists. |
+| Package/API pack selected | yes | Registry-only package/API surface selected. |
+| Barrel/export impact decision | yes | N/A: no package exports or barrel-owned files changed. |
+
+Work Checklist:
+- [x] Objective, completion threshold, verification surface, constraints, boundaries, and blocked condition are concrete.
+- [x] Task source classified with issue link, title, acceptance criteria, likely files, browser surface, and root-cause layer.
+- [x] Video evidence marked N/A because issue has no video.
+- [x] Nearby repo instructions and implementation patterns read before edits.
+- [x] Implementation fixes the registry metadata ownership boundary instead of patching individual kit imports.
+- [x] Release artifact requirement recorded as registry changelog, not package changeset.
+- [x] Final handoff shape decided: no PR/tracker sync; concise final with tests and browser caveat.
+- [x] Branch handling recorded as N/A because no branch/PR request.
+- [x] Local-env-rot retry policy recorded as N/A because failures matched code/test expectations, not install corruption.
+- [x] Workspace authority recorded: commands ran in `/Users/zbeyens/git/plate`.
+- [x] High-risk note recorded for public registry install behavior.
+- [x] Autoreview selected and rerun until clean.
+- [x] Agent-native review marked N/A because no `.agents/**`, skills, hooks, prompts, or agent-action tooling changed.
+- [x] Output budget discipline recorded and followed.
+- [x] Public API/package boundary impact recorded as registry metadata surface only.
+- [x] Release artifact matrix applied: registry changelog updated and generated JSON refreshed.
+- [x] Changeset work marked N/A because no package versioned API/runtime delta.
+- [x] Registry-only work updated `tooling/data/plate-ui-changelog.mdx` and generated changelog JSON.
+- [x] No-artifact decision marked N/A because registry changelog artifact applies.
+- [x] Compatibility decision explicit: preserve shadcn configured `aliases.components` via `@components` targets.
+- [x] Package-owned proof recorded with `www` typecheck and registry source check.
+- [x] Barrel/export generation marked N/A because exports and exported file layout did not change.
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+|------|---------|-----------------|----------|
+| Named verification threshold | yes | Run all named checks | All commands in Verification evidence passed. |
+| Bug reproduced before fix | yes | Record issue-level repro and CLI smoke | Issue repro read; smoke proved raw targets miss custom alias while `@components` targets install correctly. |
+| Targeted behavior verification | yes | Test registry metadata and shadcn install paths | Registry tests plus `shadcn@4.7.0` custom-alias smokes passed. |
+| TypeScript or typed config changed | yes | Run `www` typecheck | `pnpm --filter www typecheck` passed. |
+| Package exports or file layout changed | no | Run `pnpm brl` only if exports changed | N/A: registry metadata targets changed, not package exports. |
+| Package manifests, lockfile, or install graph changed | no | Run install only if graph changed | N/A: no manifests or lockfiles changed. |
+| Agent rules or skills changed | no | Run skill sync only for agent rule edits | N/A. |
+| Workspace authority proof | yes | Run checks in owning repo/app | Commands ran in `/Users/zbeyens/git/plate`; `www` owns registry metadata. |
+| Browser surface changed | yes | Capture Browser proof or caveat | Blocked: Browser/browser-use tools unavailable through `tool_search`; route tests cover JSON surface. |
+| Browser final proof | yes | Attach screenshot or caveat | Caveat recorded: no Browser tool exposed. |
+| CI-controlled template output changed | no | Restore template output if touched | N/A. |
+| Package behavior or public API changed | no | Add changeset if package API/runtime changed | N/A: registry metadata/changelog only. |
+| Registry-only component work changed | yes | Update registry changelog and generated JSON | `node tooling/scripts/generate-ui-changelog-entries.mjs --write` ran; generated event is unresolved source-only. |
+| Docs or content changed | yes | Verify incidental docs/changelog claims | Changelog route tests and generator tests passed. |
+| High-risk mini gate | yes | Record failure mode and proof | Failure mode: shadcn flattens targetless editor files; proof: custom-alias CLI smokes and registry tests. |
+| Agent-native review | no | Load reviewer only for agent tooling | N/A. |
+| Local install corruption suspected | no | Run reinstall only for env-rot signs | N/A. |
+| Autoreview | yes | Rerun until no accepted/actionable findings | Final autoreview clean: no accepted/actionable findings. |
+| PR create or update | no | PR requires explicit request | N/A. |
+| Task-style PR body verified | no | Verify only when PR exists | N/A. |
+| PR proof image hosting | no | Host images only for PR body | N/A. |
+| Tracker sync-back | no | Comment only when requested or PR exists | N/A. |
+| Final handoff contract | yes | Fill exact outcome/caveats/tests | Final response will list fix, proof, Browser caveat, and no PR. |
+| Final lint | yes | Run `pnpm lint:fix` | Passed with no fixes after final changes. |
+| Output budget discipline | yes | Confirm scoped output | Followed with capped output; one noisy `rg` recovered with targeted searches. |
+| Goal plan complete | yes | Run autogoal completion checker | To run after this update. |
+| Public API / package boundary proof | yes | Source-audit registry public surface | `check-registry-source.mts` and tests assert target contract. |
+| Release artifact classification | yes | Record artifact class | Registry-only user-visible install metadata. |
+| Published package changeset | no | Add changeset only for package delta | N/A. |
+| Registry changelog | yes | Update source and generated JSON | Done. |
+| No release artifact | no | Record reason if no artifact | N/A. |
+| Package typecheck/build/test | yes | Run owning package checks | `pnpm --filter www typecheck` passed. |
+| Barrel/export generation | no | Run `pnpm brl` if exports changed | N/A. |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+|-------|--------|----------|------|
+| Intake and source read | complete | GitHub issue #4971 read; repo/skill instructions loaded. | done |
+| Implementation | complete | Registry target normalization, source checks, changelog generator, and generated changelog updated. | done |
+| Verification | complete | Tests, typecheck, lint, shadcn smokes, and autoreview passed. | done |
+| PR / tracker sync | n/a | No explicit PR/comment request; repo policy forbids unsolicited PR/comment. | done |
+| Closeout | complete | Plan updated; completion checker remains final mechanical step. | final response |
+
+Findings:
+- Root cause: targetless registry component files let shadcn infer default component paths, flattening editor kit files so `./plugins/*` imports fail.
+- Follow-up root cause: editor block component files under `blocks/*/components/editor/*` need the same configured-alias target treatment.
+- Changelog root cause: source-only registry changelog rows could borrow unrelated same-day package release metadata.
+
+Decisions and tradeoffs:
+- Use `@components/editor/*` targets because `shadcn@4.7.0` maps `@components` through the consuming app's configured `aliases.components`.
+- Normalize centrally in `createPlateRegistryItems()` so new editor kit and block editor files inherit the contract.
+- Keep source-only changelog events unresolved until PR/commit/release evidence exists.
+
+Implementation notes:
+- `apps/www/src/registry/registry.ts` now adds targets for any file path containing `components/editor/` unless it already has an explicit target.
+- `apps/www/scripts/check-registry-source.mts` enforces that contract for kits and editor blocks.
+- `apps/www/src/registry/registry.test.ts` covers kit dependencies and editor block component files.
+- `tooling/scripts/generate-ui-changelog-entries.mjs` refuses release matching for source-only change units.
+
+Review fixes:
+- First autoreview finding fixed: raw `components/editor/*` targets changed to alias-aware `@components/editor/*`.
+- First autoreview finding fixed: source-only changelog event no longer claims unrelated `v53.1.3` list release.
+- Second autoreview finding fixed: `blocks/*/components/editor/*` files now receive alias-aware targets.
+- Final autoreview clean: no accepted/actionable findings.
+
+Error attempts:
+| Error / failed attempt | Count | Next different move | Resolution |
+|------------------------|-------|---------------------|------------|
+| Initial shadcn smoke lacked `tsconfig.json` | 1 | Add minimal tsconfig/package scaffold | Smoke reran successfully. |
+| Synthetic block smoke did not materialize page file | 1 | Narrow smoke to block component files/import rewrites | Component smoke proved the flagged path. |
+| Broad `rg` pattern invoked shell backticks | 1 | Rerun targeted quoted searches | Stale generated event confirmed removed. |
+
+Verification evidence:
+- `bun test apps/www/src/registry/registry.test.ts 'apps/www/src/app/registry/changelog/[event]/route.test.ts' apps/www/src/app/registry/changelog/components.json/route.test.ts apps/www/src/app/registry/changelog/index.json/route.test.ts` passed: 8 tests, 170 expects.
+- `node --test tooling/scripts/generate-ui-changelog-entries.test.mjs` passed: 8 tests.
+- `pnpm --filter www exec tsx --tsconfig ./scripts/tsconfig.scripts.json scripts/check-registry-source.mts` passed.
+- `pnpm --filter www typecheck` passed, including docs source parity, registry source check, app TS, and package integration TS.
+- `pnpm lint:fix` passed with no fixes after final changes.
+- `pnpm dlx shadcn@4.7.0 add` custom `aliases.components` smoke installed `@components/editor/*` to `src/shared/components/editor/*` and preserved `./plugins/basic-blocks-base-kit`.
+- `pnpm dlx shadcn@4.7.0 add` block component smoke installed `blocks/editor-ai/components/editor/*` targets to `src/shared/components/editor/*` and rewrote imports to `@/shared/components/editor/*`.
+- Final autoreview passed: no accepted/actionable findings; patch correct.
+
+Final handoff contract:
+- PR line: N/A, no PR requested.
+- Issue / tracker line: N/A, no tracker comment requested.
+- Confidence line: high.
+- Flow table:
+  - Reproduced: issue #4971 read; shadcn target behavior smoked.
+  - Verified: focused tests, `www` typecheck, lint, shadcn smokes, autoreview.
+- Browser check: blocked because Browser/browser-use tools were unavailable.
+- Outcome: registry installs preserve editor kit/plugin and editor block component paths under configured components alias.
+- Caveat: no in-app browser screenshot; the affected surface is registry JSON/install metadata and was verified with route tests plus real shadcn CLI smokes.
+- Design:
+  - Chosen boundary: central registry item target normalization.
+  - Why not quick patch: individual kit edits would miss future editor files.
+  - Why not broader change: package code and registry build output do not own this install-path contract.
+- Verified: commands listed in Verification evidence.
+- PR body verified: N/A.
+
+Final handoff / sync:
+- PR: N/A, not requested.
+- Issue / tracker: N/A, not requested.
+- Browser proof: blocked; Browser/browser-use unavailable through `tool_search`.
+- Caveats: no package changeset; registry changelog event remains unresolved until real release provenance exists.
+
+Open risks:
+- No open code risks found by final autoreview. Browser proof could not be captured because the required tool was unavailable, but shadcn CLI smoke directly verified the install behavior.
+
+Reboot status:
+| Question | Answer |
+|----------|--------|
+| Where am I? | Closeout after final clean autoreview. |
+| Where am I going? | Run autogoal completion checker, mark goal complete, send final response. |
+| What is the goal? | Fix issue #4971 shadcn registry install paths for editor kits and blocks. |

--- a/docs/plans/2026-06-14-stable-registry-changelog-ids.md
+++ b/docs/plans/2026-06-14-stable-registry-changelog-ids.md
@@ -1,0 +1,298 @@
+# stable registry changelog ids
+
+Objective:
+Stabilize registry changelog generated IDs so adding a changelog row does not rewrite existing event entry IDs.
+
+Goal plan:
+docs/plans/2026-06-14-stable-registry-changelog-ids.md
+
+Template:
+docs/plans/templates/task.md
+
+Primary template:
+docs/plans/templates/task.md
+
+Applied packs:
+- package-api (docs/plans/templates/packs/package-api.md)
+
+Task source:
+- type: user follow-up on PR #5013
+- id / link: https://github.com/udecode/plate/pull/5013
+- title: Long-term fix for generated registry changelog row churn
+- acceptance criteria: generated entry IDs no longer depend on row numbers, adding a row above existing content leaves existing entry IDs stable, artifacts regenerate coherently, PR #5013 is updated.
+
+Completion threshold:
+- `tooling/scripts/generate-ui-changelog-entries.mjs` derives source entry IDs from row content rather than row ordinal.
+- A focused generator test proves inserting a new row above an existing row does not change the existing row's ID.
+- Generated registry changelog JSON is refreshed once under the new stable scheme.
+- Focused tests, `pnpm check`, autoreview, commit, push, and PR body update pass.
+- Task closure is legal only when the source-of-truth acceptance criteria are
+  satisfied or explicitly narrowed, required verification evidence is recorded,
+  code-review and release-artifact gates are closed when applicable, tracker/PR
+  sync is complete or marked N/A with reason, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-14-stable-registry-changelog-ids.md` passes.
+
+Verification surface:
+- `node --test tooling/scripts/generate-ui-changelog-entries.test.mjs`
+- `node tooling/scripts/generate-ui-changelog-entries.mjs --write`
+- `pnpm check`
+- `.agents/skills/autoreview/scripts/autoreview --mode local ...`
+- `gh pr view 5013 --json body`
+
+Constraints:
+- Preserve existing user-facing behavior outside the task scope.
+- Prefer the durable ownership boundary over caller-by-caller patches.
+- Do not create PRs, comments, commits, or pushes unless the task/user/skill
+  requires them.
+- Do not add broad ceremony when the task is trivial or docs-only.
+
+Boundaries:
+- Source of truth: user follow-up "go long term fix" after generated changelog churn explanation.
+- Allowed edit scope: registry changelog generator, generator tests, generated changelog JSON, goal plan, existing PR #5013.
+- Browser surface: no real browser UI; this is generated JSON/tooling behavior.
+- Tracker sync: PR body update only.
+- Non-goals: changing user-facing changelog prose beyond generated ID/artifact updates; package API/runtime changes.
+
+Output budget strategy:
+- Use focused diffs and generator tests; cap command output; avoid dumping full generated JSON except targeted examples.
+
+Blocked condition:
+- Blocked only if generator tests expose unavoidable ID collisions that need a product decision, or if `pnpm check` fails for unrelated repo state after one focused triage pass.
+
+Task state:
+- task_type: tooling fix
+- task_complexity: medium
+- current_phase: closeout
+- current_phase_status: complete
+- next_phase: none
+- goal_status: ready_to_complete
+
+Current verdict:
+- verdict: complete
+- confidence: high
+- next owner: maintainer review
+- reason: generator source IDs are content-derived, stale artifacts are pruned safely, checks passed, autoreview clean, and PR #5013 body is synced.
+
+Completion rule:
+- Do not call `update_goal(status: complete)` while any required checklist item
+  remains unchecked. If an item does not apply, check it and add `N/A: <reason>`.
+- Do not call `update_goal(status: complete)` until every completion threshold
+  above is satisfied, final handoff evidence is recorded, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-14-stable-registry-changelog-ids.md` passes.
+- Do not create hook state for this goal. This file plus the active goal are the
+  durable state.
+
+Start Gates:
+| Gate | Applies | Evidence |
+|------|---------|----------|
+| Skill analysis before edits | yes | Re-read `task` and `autogoal`; previous PR workflow already loaded. |
+| Active goal checked or created | yes | `get_goal` returned none; created active goal for stable registry changelog IDs. |
+| Source of truth read before edits | yes | Latest user message is source: "go long term fix". |
+| Tracker comments and attachments read | no | N/A: no new tracker item; existing PR #5013 is target. |
+| Video transcript evidence required | no | N/A: no video. |
+| `docs/solutions` checked for non-trivial existing-code work | no | N/A: generator source and tests are local source of truth. |
+| TDD decision before behavior change or bug fix | yes | Add generator regression test for insertion-stable IDs. |
+| Branch decision for code-changing task | yes | Continue on `codex/fix-shadcn-registry-kit-targets`, current PR branch. |
+| Release artifact decision | yes | Registry generated changelog artifact only; no package changeset. |
+| Browser tool decision for browser surface | no | N/A: no browser UI behavior. |
+| PR expectation decision | yes | User explicitly wants PR updated. |
+| Tracker sync expectation decision | yes | PR body update only; no issue comment requested. |
+| Output budget strategy recorded | yes | Focused diffs/tests, capped output. |
+| Package/API pack selected | yes | Registry generated artifact/public install metadata surface. |
+| Public surface or package boundary identified | yes | Public registry changelog JSON IDs/metadata, not package runtime API. |
+| Release artifact path selected | yes | Registry changelog JSON regeneration. |
+| `changeset` skill loaded when `.changeset` is required | no | N/A: `.changeset` not required. |
+| Barrel/export impact decision recorded | yes | N/A: no exports/barrels. |
+
+Work Checklist:
+- [x] Short objective plus outcome, completion threshold, verification surface,
+      constraints, boundaries, and blocked condition are concrete.
+- [x] Task source classified with source type, id/link, title, task type,
+      acceptance criteria, caveats, likely files/routes/packages, browser
+      surface, and root-cause layer.
+- [x] Required video or screen-recording evidence marked N/A: no video.
+- [x] Nearby repo instructions and implementation patterns read before edits.
+- [x] Implementation fixes the ownership boundary: generator IDs and pruning
+      live in `tooling/scripts/generate-ui-changelog-entries.mjs`.
+- [x] Release artifact requirement recorded: registry changelog only; no
+      package changeset.
+- [x] Final handoff shape decided: update existing PR #5013.
+- [x] Branch handling recorded: continued on
+      `codex/fix-shadcn-registry-kit-targets`.
+- [x] Local-env-rot retry policy recorded: N/A, no install-corruption failure.
+- [x] Workspace authority recorded: every proof command ran in
+      `/Users/zbeyens/git/plate`.
+- [x] High-risk note recorded: generated registry changelog ID migration is
+      one-time; regression test covers inserted-row stability.
+- [x] Review/autoreview target selected from actual local diff and rerun clean.
+- [x] Agent-native review decision recorded: N/A, no `.agents`, `.claude`, or
+      `.codex` tooling changed.
+- [x] Output budget discipline followed with capped command output and focused
+      tests.
+- [x] Package/API pack: public surface is registry changelog JSON and shadcn
+      registry metadata, not package runtime API.
+- [x] Package/API pack: release artifact matrix applied as registry changelog
+      artifact work.
+- [x] Package/API pack: `.changeset` N/A because no published package runtime,
+      type, or API behavior changed.
+- [x] Package/API pack: registry-only work regenerated
+      `/apps/www/src/registry/changelog/*` JSON.
+- [x] Package/API pack: no package artifact decision recorded above.
+- [x] Package/API pack: compatibility decision explicit: one-time generated ID
+      migration, future inserted rows stable.
+- [x] Package/API pack: package-owned proof is root `pnpm check`.
+- [x] Package/API pack: barrels N/A, no exports or exported file layout changed.
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+|------|---------|-----------------|----------|
+| Named verification threshold | yes | Run named proof commands | `node --test tooling/scripts/generate-ui-changelog-entries.test.mjs`; route tests; `pnpm check`; autoreview clean |
+| Bug reproduced before fix | yes | Record repro | Initial issue repro: shadcn smoke hit unresolved `./plugins/*` imports after custom component alias install |
+| Targeted behavior verification | yes | Run focused proof | Generator insertion-stability test, stale-prune test, `--write --limit` guard test, changelog route tests |
+| TypeScript or typed config changed | no | N/A | No TS config changed; root `pnpm check` typecheck passed |
+| Package exports or file layout changed | no | N/A | No exported package file layout changed |
+| Package manifests, lockfile, or install graph changed | no | N/A | No manifests or lockfile changed |
+| Agent rules or skills changed | no | N/A | No agent rules or skills changed |
+| Workspace authority proof | yes | Record cwd | All commands ran in `/Users/zbeyens/git/plate` |
+| Browser surface changed | no | N/A | No runnable browser UI changed in this follow-up; generated JSON/tooling surface |
+| Browser final proof | no | N/A | Browser proof N/A for generator follow-up |
+| CI-controlled template output changed | no | N/A | No `templates/**` changed |
+| Package behavior or public API changed | no | N/A | No package changeset; registry/web metadata only |
+| Registry-only component work changed | yes | Regenerate changelog JSON | `node tooling/scripts/generate-ui-changelog-entries.mjs --write` wrote 20 events |
+| Docs or content changed | no | N/A | No user-facing docs changed |
+| High-risk mini gate | yes | Record failure mode and proof | Risk: stale JSON deletion or ID churn; proof: guard/prune/stability tests and autoreview clean |
+| Agent-native review for agent/tooling changes | no | N/A | No agent tooling changed |
+| Local install corruption suspected | no | N/A | No install-corruption failure |
+| Autoreview for non-trivial implementation changes | yes | Run local autoreview clean | Final quick pass clean: no accepted/actionable findings |
+| PR create or update | yes | Check before PR body sync | `pnpm check` passed before `gh pr edit 5013` |
+| Task-style PR body verified | yes | Verify body | `gh pr view 5013 --json body,url,title,state` shows required issue line, confidence line, table, and sections |
+| PR proof image hosting | no | N/A | No browser proof images |
+| Tracker sync-back | yes | Sync PR body | Existing PR #5013 updated; no issue comment requested |
+| Final handoff contract | yes | Fill below | Final handoff fields completed |
+| Final lint | yes | Run lint fix | `pnpm lint:fix` fixed 22 generated JSON files, final `pnpm check` lint clean except existing warning |
+| Output budget discipline | yes | Confirm scoped output | Command output capped; broad diffs summarized |
+| Goal plan complete | yes | Run checker | `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-14-stable-registry-changelog-ids.md` to run after this edit |
+| Public API / package boundary proof | yes | Source audit | Registry JSON and registry item target metadata only; no package API |
+| Release artifact classification | yes | Classify | Registry-only generated changelog artifact |
+| Published package changeset | no | N/A | No published package runtime/API/types/config delta |
+| Registry changelog | yes | Regenerate | `node tooling/scripts/generate-ui-changelog-entries.mjs --write` |
+| No release artifact | no | N/A | Registry changelog artifact applies |
+| Package typecheck/build/test | yes | Run root gate | `pnpm check` passed |
+| Barrel/export generation | no | N/A | No exports or barrels changed |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+|-------|--------|----------|------|
+| Intake and source read | complete | user follow-up and PR context read | implementation |
+| Implementation | complete | generator content-hash IDs, pruning, guard, tests, generated JSON | verification |
+| Verification | complete | focused tests, generator write, lint fix, `pnpm check`, autoreview clean | PR / tracker sync |
+| PR / tracker sync | complete | PR #5013 body updated and verified | closeout |
+| Closeout | complete | ready for commit, push, final response | final response |
+
+Findings:
+- Root cause: generated source IDs included the source row ordinal, so inserting
+  a row above old entries rewrote every downstream entry ID.
+- Accepted autoreview finding: full-output pruning plus `--write --limit` would
+  make partial writes dangerous. Fixed by rejecting that argument combination.
+
+Decisions and tradeoffs:
+- Use a short content hash over stable row fields instead of row number.
+- Keep the one-time generated ID migration because old row-number IDs cannot be
+  made stable retroactively without a compatibility map.
+- Prune stale generated JSON from the generator so renamed event files do not
+  leave dead artifacts in `apps/www/src/registry/changelog`.
+
+Implementation notes:
+- `formatSourceId` now derives IDs from date, release entry, target items,
+  summary, details, prefix, slug, and an 8-char SHA-1 content hash.
+- `writeRegistryChangelogEvents` can prune stale `.json` files in the output
+  directory during full writes.
+- `validateArgs` rejects `--write --limit`.
+- Route tests were updated for the new generated event ID.
+
+Review fixes:
+- Added the `--write --limit` guard after autoreview flagged unsafe pruning.
+
+Error attempts:
+| Error / failed attempt | Count | Next different move | Resolution |
+|------------------------|-------|---------------------|------------|
+| Broad final autoreview took over 6 minutes | 1 | Rerun with low thinking and no web search | Final quick autoreview clean |
+
+Verification evidence:
+- `node --test tooling/scripts/generate-ui-changelog-entries.test.mjs`:
+  11 pass.
+- `bun test 'apps/www/src/app/registry/changelog/[event]/route.test.ts' apps/www/src/app/registry/changelog/components.json/route.test.ts apps/www/src/app/registry/changelog/index.json/route.test.ts`:
+  5 pass.
+- `node tooling/scripts/generate-ui-changelog-entries.mjs --write`: wrote 20
+  registry changelog events from 39 source rows.
+- `pnpm lint:fix`: final pass checked 3276 files; generated JSON formatted.
+- `pnpm check`: passed lint, typecheck, test:all, and test:slowest; existing
+  unrelated sidebar eslint warning only.
+- `.agents/skills/autoreview/scripts/autoreview --mode local --thinking low --no-web-search ...`:
+  clean, no accepted/actionable findings.
+
+Final handoff contract:
+- PR line: PR #5013 updated.
+- Issue / tracker line: fixes GitHub issue #4971; no separate issue comment requested.
+- Confidence line: high, 95-100%.
+- Flow table:
+  - Reproduced: shadcn smoke reproduced relative import failure before fix.
+  - Verified: focused tests, generator write, `pnpm check`, autoreview clean.
+- Browser check: N/A for generator follow-up; original issue had shadcn smoke.
+- Outcome: stable changelog IDs and safe generated artifact pruning.
+- Caveat: one-time generated ID migration remains in the diff.
+- Design:
+  - Chosen boundary: registry generator and registry source checker.
+  - Why not quick patch: manual generated JSON edits would churn again.
+  - Why not broader change: no package runtime/API change needed.
+- Verified: commands listed above.
+- PR body verified: `gh pr view 5013 --json body,url,title,state`.
+
+Task-style PR body contract:
+- Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
+  part of the diff and repo policy expects auto release, include that block.
+- Use the accepted kitcn PR #270 visual format. The body starts with an emoji
+  issue/tracker/fix line, for example `🐛 Fixes #123` or `🐛 Fixes ➖ N/A`, then
+  an emoji confidence line like `🟢 95-100% confidence`.
+- Use this exact table header: `| Phase | 🧪 Tests | 🌐 Browser |`.
+- Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
+  failing proof with `🔴`, and non-applicable cells with `➖ N/A`.
+- Use bold emoji section headings: `**✅ Outcome**`, `**⚠️ Caveat**`,
+  `**🏗️ Design**`, and `**🧪 Verified**`.
+- Never include a line that links to the current PR itself. The current PR URL
+  belongs in the final response, not in its own description.
+- Do not replace this with a generic `Summary` / `Verification` PR body, an
+  adaptive prose body from a git helper skill, plain `## Outcome` sections, or
+  an unrelated generated badge footer unless the caller or repo template
+  explicitly asks for it.
+- Proof is `gh pr view --json body` output or a concise source-backed summary
+  of that output.
+
+Final handoff / sync:
+- PR: https://github.com/udecode/plate/pull/5013
+- Issue / tracker: fixes #4971 through PR body sync.
+- Browser proof: N/A for generator follow-up; shadcn smoke is command proof.
+- Caveats: one-time generated ID migration; existing unrelated sidebar warning.
+
+Timeline:
+- 2026-06-14T17:59:00.714Z Task goal plan created.
+- 2026-06-14T18:20:00Z Generator source IDs changed from row ordinal to
+  content-hash IDs.
+- 2026-06-14T18:35:00Z Stale generated changelog pruning and `--write --limit`
+  guard added.
+- 2026-06-14T18:45:00Z Focused generator and route tests passed.
+- 2026-06-14T19:05:00Z Final `pnpm check` passed.
+- 2026-06-14T19:16:00Z Final autoreview quick pass clean.
+- 2026-06-14T19:20:00Z PR #5013 body updated and verified.
+
+Reboot status:
+| Question | Answer |
+|----------|--------|
+| Where am I? | Closeout |
+| Where am I going? | Commit, push, final response |
+| What is the goal? | Stable registry changelog generated IDs and updated PR #5013 |
+| What have I learned? | See Findings |
+| What have I done? | See Timeline |
+
+Open risks:
+- No open blocker. Existing sidebar eslint warning is unrelated and non-fatal.

--- a/tooling/data/plate-ui-changelog.mdx
+++ b/tooling/data/plate-ui-changelog.mdx
@@ -5,6 +5,9 @@ renders generated artifacts from `apps/www/src/registry/changelog`.
 
 ## June 2026 #32
 
+### June 14 #32.3
+- **`editor-base-kit`**, **`editor-kit`**: Install editor kit files through the configured components alias so relative `./plugins/*` imports resolve after shadcn CLI adds.
+
 ### June 10 #32.2
 <!-- changelog: commit=224b0d13083c199a8f4525b063ad04de2dcf2dbb -->
 - **`column-node`**: Fix column drag and drop by attaching the DnD drop target ref to the rendered column element so horizontal drop lines can resolve a valid target.

--- a/tooling/scripts/generate-ui-changelog-entries.mjs
+++ b/tooling/scripts/generate-ui-changelog-entries.mjs
@@ -605,6 +605,10 @@ function toReleaseState(
 ) {
   if (release) return release;
 
+  if (!hasReleaseProvenance(changeUnit)) {
+    return { status: 'unresolved' };
+  }
+
   if (
     latestRelease &&
     isReleaseAncestor(changeUnit, latestRelease) &&
@@ -635,6 +639,10 @@ function toReleaseState(
   }
 
   return { status: 'unresolved' };
+}
+
+function hasReleaseProvenance(changeUnit) {
+  return Boolean(changeUnit.pr || changeUnit.commit?.oid);
 }
 
 export function buildRegistryChangelogIndexes(outputs) {
@@ -1096,6 +1104,15 @@ export function resolveReleaseForChangeUnit(changeUnit, releases) {
     return {
       release: toReleaseMetadata(prReleases[0], 'release-index-pr-match'),
       warnings: [],
+    };
+  }
+
+  if (!changeUnit.commit?.oid) {
+    return {
+      release: null,
+      warnings: [
+        `No generated release-index entry found for source-only change on ${changeUnit.date}.`,
+      ],
     };
   }
 

--- a/tooling/scripts/generate-ui-changelog-entries.mjs
+++ b/tooling/scripts/generate-ui-changelog-entries.mjs
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { createHash } from 'node:crypto';
 import path from 'node:path';
 import process from 'node:process';
 import { execFileSync } from 'node:child_process';
@@ -124,8 +125,21 @@ function escapeRegExp(value) {
 
 function formatSourceId(row) {
   const release = row.release.entry.replaceAll('.', '-');
+  const hash = createHash('sha1')
+    .update(
+      JSON.stringify({
+        date: row.date,
+        details: row.details,
+        items: row.items,
+        prefix: row.prefix,
+        release: row.release.entry,
+        summary: row.summary,
+      })
+    )
+    .digest('hex')
+    .slice(0, 8);
 
-  return `${row.date}-${release}-${String(row.row).padStart(3, '0')}`;
+  return `${row.date}-${release}-${formatEventSlug(row)}-${hash}`;
 }
 
 function formatChangeUnitId(changeUnit) {
@@ -145,9 +159,7 @@ function formatEventSlug(row) {
     .slice(0, 2);
   const tokens = [...itemTokens, ...summaryTokens, ...codeTokens].slice(0, 8);
 
-  return tokens.length > 0
-    ? tokens.join('-')
-    : `row-${String(row.row).padStart(3, '0')}`;
+  return tokens.length > 0 ? tokens.join('-') : 'entry';
 }
 
 function formatChangeUnitSlug(changeUnit) {
@@ -352,6 +364,14 @@ function parseArgs(argv) {
   }
 
   return args;
+}
+
+export function validateArgs(args) {
+  if (args.write && args.limit) {
+    throw new Error(
+      '--write cannot be combined with --limit because partial writes would produce incomplete changelog artifacts.'
+    );
+  }
 }
 
 function parseDate(label, section) {
@@ -1243,7 +1263,34 @@ function toReleaseMetadata(release, source) {
   return metadata;
 }
 
-export function writeRegistryChangelogEvents(outputs) {
+export function pruneStaleRegistryChangelogEvents(outputs, outDir) {
+  if (!outDir || !fs.existsSync(outDir)) return [];
+
+  const expectedPaths = new Set(
+    outputs.map((output) => path.resolve(output.targetPath))
+  );
+  const removedPaths = [];
+
+  for (const entry of fs.readdirSync(outDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+
+    const filePath = path.resolve(outDir, entry.name);
+
+    if (expectedPaths.has(filePath)) continue;
+
+    fs.unlinkSync(filePath);
+    removedPaths.push(filePath);
+  }
+
+  return removedPaths;
+}
+
+export function writeRegistryChangelogEvents(
+  outputs,
+  { pruneOutDir = null } = {}
+) {
+  const removedPaths = pruneStaleRegistryChangelogEvents(outputs, pruneOutDir);
+
   for (const output of outputs) {
     fs.mkdirSync(path.dirname(output.targetPath), { recursive: true });
     fs.writeFileSync(
@@ -1251,10 +1298,15 @@ export function writeRegistryChangelogEvents(outputs) {
       `${JSON.stringify(output.entry, null, 2)}\n`
     );
   }
+
+  return { removedPaths };
 }
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
+
+  validateArgs(args);
+
   const source = fs.readFileSync(args.source, 'utf8');
   const rows = parseComponentChangelog(source);
   const selectedRows = args.limit ? rows.slice(0, args.limit) : rows;
@@ -1284,7 +1336,13 @@ function main() {
   );
 
   if (args.write) {
-    writeRegistryChangelogEvents(artifactOutputs);
+    const { removedPaths } = writeRegistryChangelogEvents(artifactOutputs, {
+      pruneOutDir: args.outDir,
+    });
+
+    for (const removedPath of removedPaths) {
+      console.log(`Removed stale ${relativePath(removedPath)}`);
+    }
   }
 
   console.log(

--- a/tooling/scripts/generate-ui-changelog-entries.test.mjs
+++ b/tooling/scripts/generate-ui-changelog-entries.test.mjs
@@ -283,7 +283,35 @@ test('does not guess release dependencies for ambiguous dates', () => {
   assert.match(result.warnings[0], /Multiple generated release-index entries/);
 });
 
-test('current latest 14 source rows collapse to 5 change-unit events', () => {
+test('does not guess release dependencies for source-only change units', () => {
+  const rows = parseComponentChangelog(`
+## June 2026 #32
+
+### June 14 #32.3
+- **\`editor-base-kit\`**, **\`editor-kit\`**: Install editor kit files through the configured components alias so relative \`./plugins/*\` imports resolve after shadcn CLI adds.
+`);
+  const [output] = buildRegistryChangelogEvents(rows, {
+    isChangeAfterRelease: () => true,
+    releases: [
+      {
+        content: 'Release list package',
+        date: '2026-06-14',
+        packageTag: '@platejs/list@53.1.3',
+        tag: 'v53.1.3',
+        versionPackagePrUrl: 'https://github.com/udecode/plate/pull/5012',
+      },
+    ],
+  });
+
+  assert.equal(output.entry.change.type, 'source');
+  assert.deepEqual(output.entry.release, { status: 'unresolved' });
+  assert.deepEqual(
+    output.entry.diagnostics.map((diagnostic) => diagnostic.code),
+    ['release-missing', 'provenance-missing']
+  );
+});
+
+test('current latest 14 source rows collapse to 6 change-unit events', () => {
   const content = fs.readFileSync(
     'tooling/data/plate-ui-changelog.mdx',
     'utf8'
@@ -315,65 +343,79 @@ test('current latest 14 source rows collapse to 5 change-unit events', () => {
     'docs'
   );
   const provenanceBySourceId = new Map(
-    rows.map((row) => {
-      if (row.sourceId === '2026-06-10-32-2-001') {
+    rows.flatMap((row) => {
+      if (row.sourceId === '2026-06-14-32-3-001') {
+        return [];
+      }
+
+      if (row.sourceId === '2026-06-10-32-2-002') {
         return [
-          row.sourceId,
-          provenance(
-            columnCommit,
-            pr(5003, 'fix(dnd): attach column drop target ref', {
-              mergedAt: '2026-06-10T10:46:04Z',
-            }),
-            ['No generated release-index entry found for PR 5003.']
-          ),
+          [
+            row.sourceId,
+            provenance(
+              columnCommit,
+              pr(5003, 'fix(dnd): attach column drop target ref', {
+                mergedAt: '2026-06-10T10:46:04Z',
+              }),
+              ['No generated release-index entry found for PR 5003.']
+            ),
+          ],
         ];
       }
 
       if (row.sourceId?.startsWith('2026-06-03')) {
         return [
-          row.sourceId,
-          provenance(
-            codeCommit,
-            pr(4989, 'Show code block language labels in read-only mode', {
-              state: 'OPEN',
-            }),
-            ['Matched PR 4989, but it is OPEN.']
-          ),
+          [
+            row.sourceId,
+            provenance(
+              codeCommit,
+              pr(4989, 'Show code block language labels in read-only mode', {
+                state: 'OPEN',
+              }),
+              ['Matched PR 4989, but it is OPEN.']
+            ),
+          ],
         ];
       }
 
       if (row.sourceId?.startsWith('2026-05-31')) {
         return [
-          row.sourceId,
-          provenance(
-            perfCommit,
-            pr(4987, 'perf: improve large document editing', {
-              mergedAt: '2026-06-02T19:26:44Z',
-            })
-          ),
+          [
+            row.sourceId,
+            provenance(
+              perfCommit,
+              pr(4987, 'perf: improve large document editing', {
+                mergedAt: '2026-06-02T19:26:44Z',
+              })
+            ),
+          ],
         ];
       }
 
       if (row.sourceId?.startsWith('2026-04-29')) {
         return [
-          row.sourceId,
-          provenance(
-            discussionCommit,
-            pr(4945, '[codex] Fix discussion and suggestion regressions', {
-              mergedAt: '2026-04-29T09:59:13Z',
-            })
-          ),
+          [
+            row.sourceId,
+            provenance(
+              discussionCommit,
+              pr(4945, '[codex] Fix discussion and suggestion regressions', {
+                mergedAt: '2026-04-29T09:59:13Z',
+              })
+            ),
+          ],
         ];
       }
 
       return [
-        row.sourceId,
-        provenance(
-          footnoteCommit,
-          pr(4941, 'fix: redesign blockquotes as container blocks', {
-            mergedAt: '2026-04-23T11:41:41Z',
-          })
-        ),
+        [
+          row.sourceId,
+          provenance(
+            footnoteCommit,
+            pr(4941, 'fix: redesign blockquotes as container blocks', {
+              mergedAt: '2026-04-23T11:41:41Z',
+            })
+          ),
+        ],
       ];
     })
   );
@@ -410,10 +452,11 @@ test('current latest 14 source rows collapse to 5 change-unit events', () => {
   });
 
   assert.equal(rows.length, 14);
-  assert.equal(outputs.length, 5);
+  assert.equal(outputs.length, 6);
   assert.deepEqual(
     outputs.map((output) => path.basename(output.targetPath)),
     [
+      '2026-06-14-editor-install-kit-files-through.json',
       '2026-06-10-attach-column-drop-target-ref.json',
       '2026-06-03-show-code-block-language-labels-read-only-mode.json',
       '2026-06-02-improve-large-document-editing.json',
@@ -422,24 +465,27 @@ test('current latest 14 source rows collapse to 5 change-unit events', () => {
     ]
   );
   assert.equal(outputs[0].entry.entries.length, 1);
-  assert.equal(outputs[0].entry.release.status, 'latest');
-  assert.equal(outputs[0].entry.release.source, 'post-release-no-changeset');
-  assert.equal(outputs[0].entry.change.pullRequest.number, 5003);
-  assert.equal(outputs[0].entry.change.pullRequest.state, 'MERGED');
+  assert.equal(outputs[0].entry.release.status, 'unresolved');
+  assert.equal(outputs[0].entry.change.type, 'source');
   assert.equal(outputs[1].entry.entries.length, 1);
   assert.equal(outputs[1].entry.release.status, 'latest');
-  assert.equal(outputs[1].entry.release.source, 'open-pull-request');
-  assert.equal(outputs[1].entry.change.pullRequest.number, 4989);
-  assert.equal(outputs[1].entry.change.pullRequest.state, 'OPEN');
-  assert.equal(outputs[2].entry.entries.length, 2);
-  assert.equal(outputs[2].entry.release.tag, 'v53.0.7');
-  assert.equal(outputs[2].entry.change.pullRequest.number, 4987);
-  assert.equal(outputs[3].entry.entries.length, 3);
-  assert.equal(outputs[3].entry.release.tag, 'v53.0.3');
-  assert.equal(outputs[3].entry.change.pullRequest.number, 4945);
-  assert.equal(outputs[4].entry.entries.length, 7);
-  assert.equal(outputs[4].entry.release.tag, 'v53.0.0');
-  assert.equal(outputs[4].entry.change.pullRequest.number, 4941);
+  assert.equal(outputs[1].entry.release.source, 'post-release-no-changeset');
+  assert.equal(outputs[1].entry.change.pullRequest.number, 5003);
+  assert.equal(outputs[1].entry.change.pullRequest.state, 'MERGED');
+  assert.equal(outputs[2].entry.entries.length, 1);
+  assert.equal(outputs[2].entry.release.status, 'latest');
+  assert.equal(outputs[2].entry.release.source, 'open-pull-request');
+  assert.equal(outputs[2].entry.change.pullRequest.number, 4989);
+  assert.equal(outputs[2].entry.change.pullRequest.state, 'OPEN');
+  assert.equal(outputs[3].entry.entries.length, 2);
+  assert.equal(outputs[3].entry.release.tag, 'v53.0.7');
+  assert.equal(outputs[3].entry.change.pullRequest.number, 4987);
+  assert.equal(outputs[4].entry.entries.length, 3);
+  assert.equal(outputs[4].entry.release.tag, 'v53.0.3');
+  assert.equal(outputs[4].entry.change.pullRequest.number, 4945);
+  assert.equal(outputs[5].entry.entries.length, 6);
+  assert.equal(outputs[5].entry.release.tag, 'v53.0.0');
+  assert.equal(outputs[5].entry.change.pullRequest.number, 4941);
 
   const latestOutputs = buildRegistryChangelogEvents(rows, {
     hasPendingChangeset: true,
@@ -448,10 +494,9 @@ test('current latest 14 source rows collapse to 5 change-unit events', () => {
     releases,
   });
 
-  assert.equal(latestOutputs[0].entry.release.status, 'latest');
-  assert.equal(latestOutputs[0].entry.release.source, 'pending-changeset');
+  assert.equal(latestOutputs[0].entry.release.status, 'unresolved');
   assert.equal(latestOutputs[1].entry.release.status, 'latest');
-  assert.equal(latestOutputs[1].entry.release.source, 'open-pull-request');
+  assert.equal(latestOutputs[1].entry.release.source, 'pending-changeset');
 
   const unprovenOutputs = buildRegistryChangelogEvents(rows, {
     isChangeAfterRelease: () => false,
@@ -476,10 +521,11 @@ test('current latest 14 source rows collapse to 5 change-unit events', () => {
     ],
   });
 
-  assert.equal(coveredLatestOutputs[0].entry.release.status, 'released');
-  assert.equal(coveredLatestOutputs[0].entry.release.tag, 'v53.1.0');
+  assert.equal(coveredLatestOutputs[0].entry.release.status, 'unresolved');
+  assert.equal(coveredLatestOutputs[1].entry.release.status, 'released');
+  assert.equal(coveredLatestOutputs[1].entry.release.tag, 'v53.1.0');
   assert.equal(
-    coveredLatestOutputs[0].entry.release.source,
+    coveredLatestOutputs[1].entry.release.source,
     'latest-release-no-changeset'
   );
 
@@ -507,6 +553,10 @@ test('current latest 14 source rows collapse to 5 change-unit events', () => {
 
   assert.equal(
     releasedWithPendingChangesetOutputs[0].entry.release.status,
+    'unresolved'
+  );
+  assert.equal(
+    releasedWithPendingChangesetOutputs[1].entry.release.status,
     'released'
   );
   for (const output of outputs) {
@@ -521,6 +571,7 @@ test('current latest 14 source rows collapse to 5 change-unit events', () => {
   assert.deepEqual(
     index.events.map((event) => event.id),
     [
+      '2026-06-14-editor-install-kit-files-through',
       '2026-06-10-attach-column-drop-target-ref',
       '2026-06-03-show-code-block-language-labels-read-only-mode',
       '2026-06-02-improve-large-document-editing',
@@ -531,6 +582,7 @@ test('current latest 14 source rows collapse to 5 change-unit events', () => {
   assert.deepEqual(
     index.events.map((event) => event.href),
     [
+      '/registry/changelog/2026-06-14-editor-install-kit-files-through.json',
       '/registry/changelog/2026-06-10-attach-column-drop-target-ref.json',
       '/registry/changelog/2026-06-03-show-code-block-language-labels-read-only-mode.json',
       '/registry/changelog/2026-06-02-improve-large-document-editing.json',
@@ -540,6 +592,10 @@ test('current latest 14 source rows collapse to 5 change-unit events', () => {
   );
   assert.deepEqual(components.components['column-node'], [
     '2026-06-10-attach-column-drop-target-ref',
+  ]);
+  assert.deepEqual(components.components['editor-base-kit'], [
+    '2026-06-14-editor-install-kit-files-through',
+    '2026-04-23-redesign-blockquotes-container-blocks',
   ]);
   assert.deepEqual(components.components['code-block-node'], [
     '2026-06-03-show-code-block-language-labels-read-only-mode',

--- a/tooling/scripts/generate-ui-changelog-entries.test.mjs
+++ b/tooling/scripts/generate-ui-changelog-entries.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
@@ -10,6 +11,8 @@ import {
   inferRegistryHints,
   parseComponentChangelog,
   resolveReleaseForRow,
+  validateArgs,
+  writeRegistryChangelogEvents,
 } from './generate-ui-changelog-entries.mjs';
 
 test('extracts registry ids from markdown component labels', () => {
@@ -43,8 +46,68 @@ test('parses dated source rows and multi-item entries', () => {
     rows[0].provenanceCommit,
     'a471d051d2b32c494a94e8218ce1a8462aa26463'
   );
-  assert.equal(rows[0].sourceId, '2026-06-03-32-1-001');
+  assert.equal(
+    rows[0].sourceId,
+    '2026-06-03-32-1-code-block-language-label-e8dfda31'
+  );
   assert.equal(rows[0].release.section, 'June 2026 #32');
+});
+
+test('keeps source ids stable when rows are inserted above', () => {
+  const originalRows = parseComponentChangelog(`
+## June 2026 #32
+
+### June 3 #32.1
+- **\`code-block-node\`**, **\`code-block-node-static\`**: Show the selected language label in read-only and static rendering. Set \`showLanguageLabel={false}\` on the component to hide it.
+- **\`column-node\`**: Attach column drop target ref.
+`);
+  const insertedRows = parseComponentChangelog(`
+## June 2026 #32
+
+### June 3 #32.1
+- **\`editor-base-kit\`**: Install editor kit files through the configured components alias.
+- **\`code-block-node\`**, **\`code-block-node-static\`**: Show the selected language label in read-only and static rendering. Set \`showLanguageLabel={false}\` on the component to hide it.
+- **\`column-node\`**: Attach column drop target ref.
+`);
+  const originalCodeBlockRow = originalRows.find((row) =>
+    row.items.includes('code-block-node')
+  );
+  const insertedCodeBlockRow = insertedRows.find((row) =>
+    row.items.includes('code-block-node')
+  );
+
+  assert.equal(originalCodeBlockRow?.row, 1);
+  assert.equal(insertedCodeBlockRow?.row, 2);
+  assert.equal(originalCodeBlockRow?.sourceId, insertedCodeBlockRow?.sourceId);
+});
+
+test('write prunes stale generated changelog event files', () => {
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'registry-changelog-'));
+  const stalePath = path.join(outDir, 'stale-event.json');
+  const keptPath = path.join(outDir, 'kept-event.json');
+
+  fs.writeFileSync(stalePath, '{}\n');
+  writeRegistryChangelogEvents(
+    [
+      {
+        entry: { id: 'kept-event', schemaVersion: 1 },
+        targetPath: keptPath,
+      },
+    ],
+    { pruneOutDir: outDir }
+  );
+
+  assert.equal(fs.existsSync(stalePath), false);
+  assert.equal(fs.existsSync(keptPath), true);
+});
+
+test('rejects limited writes before pruning generated artifacts', () => {
+  assert.throws(
+    () => validateArgs({ limit: 1, write: true }),
+    /--write cannot be combined with --limit/
+  );
+  assert.doesNotThrow(() => validateArgs({ limit: 1, write: false }));
+  assert.doesNotThrow(() => validateArgs({ limit: null, write: true }));
 });
 
 function commit(oid, date, subject) {
@@ -104,7 +167,7 @@ test('builds one registry event per change unit with row entries', () => {
     outDir: 'out',
     provenanceBySourceId: new Map([
       [
-        '2026-06-03-32-1-001',
+        rows[0].sourceId,
         provenance(commitValue, prValue, ['Matched PR 4989, but it is OPEN.']),
       ],
     ]),
@@ -344,11 +407,11 @@ test('current latest 14 source rows collapse to 6 change-unit events', () => {
   );
   const provenanceBySourceId = new Map(
     rows.flatMap((row) => {
-      if (row.sourceId === '2026-06-14-32-3-001') {
+      if (row.date === '2026-06-14') {
         return [];
       }
 
-      if (row.sourceId === '2026-06-10-32-2-002') {
+      if (row.date === '2026-06-10') {
         return [
           [
             row.sourceId,


### PR DESCRIPTION
🐛 Fixes #4971
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
|---|---|---|
| Reproduced | 🔴 shadcn smoke reproduced the editor-kit relative import failure with custom component aliases before the fix | ➖ N/A |
| Verified | 🟢 focused generator tests, changelog route tests, shadcn smoke, `pnpm check`, autoreview clean | ➖ N/A: registry CLI/generated JSON surface |

**✅ Outcome**
- Editor kit registry files install under the configured `@components/editor/*` targets, so relative `./plugins/*` imports resolve after `shadcn@4.7.0 add`.
- Registry changelog source entry IDs are content-hash based instead of row-number based.
- Stale generated changelog event JSON is pruned on full writes, and `--write --limit` is rejected so partial writes cannot delete the full artifact set.
- Generated registry changelog JSON was regenerated once under the stable ID scheme.

**⚠️ Caveat**
- The changelog JSON diff includes the one-time migration from row-number IDs to stable content-hash IDs.
- Existing unrelated eslint warning remains in `apps/www/src/components/ui/sidebar.tsx`.

**🏗️ Design**
- Registry install target ownership lives in the registry source normalizer and source checker, not per-kit manual edits.
- Changelog ID stability lives in the generator, not in route tests or hand-maintained generated JSON.
- No package changeset: this is registry/web metadata behavior, not published package runtime/API behavior.

**🧪 Verified**
- `node --test tooling/scripts/generate-ui-changelog-entries.test.mjs`
- `bun test 'apps/www/src/app/registry/changelog/[event]/route.test.ts' apps/www/src/app/registry/changelog/components.json/route.test.ts apps/www/src/app/registry/changelog/index.json/route.test.ts`
- `node tooling/scripts/generate-ui-changelog-entries.mjs --write`
- `pnpm lint:fix`
- `pnpm check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --thinking low --no-web-search ...` clean