### PR TITLE
Fix malformed markdown HTML fallback

### DIFF
--- a/.agents/rules/task.mdc
+++ b/.agents/rules/task.mdc
@@ -33,6 +33,13 @@ they earn their keep, and verify before calling the task done.
    - File path or spec path: read it first.
    - GitHub issue URL: fetch it with `gh issue view` first.
    - GitHub PR URL: fetch it with `gh pr view` first.
+   - GitHub repository security advisory URL
+     (`github.com/<owner>/<repo>/security/advisories/GHSA-*`): fetch it with
+     `gh api repos/<owner>/<repo>/security-advisories/<GHSA_ID>` first.
+   - Public GitHub Advisory Database URL (`github.com/advisories/GHSA-*`):
+     fetch it with `gh api advisories/<GHSA_ID>` first. Treat it as read-only
+     unless you can identify a repository security advisory owned by the
+     current repo/org.
    - Bare GitHub issue like `#555`: resolve it against the current `gh` repo
      first, then fetch it with `gh issue view`.
    - Linear issue link/id: fetch it with the Linear integration first.
@@ -73,6 +80,8 @@ they earn their keep, and verify before calling the task done.
      - browser/UI route or interaction touched: add `--with browser`
      - package exports, public API, release artifacts, or package boundary
        touched: add `--with package-api`
+     - GitHub security advisory, GHSA, CVE, npm advisory, or private
+       vulnerability disclosure touched: add `--with security-advisory`
      `node .agents/skills/autogoal/scripts/create-goal-scratchpad.mjs --template <task|docs> --with <pack> --title "<short task title>"`
    - follow local repo overrides for where planning files live
 10. If testing or coverage work, load `testing` before `tdd` and choose the
@@ -102,6 +111,57 @@ Apply only when the source is a tracker item.
 - Do not require PR creation, screenshots, or comments for analytical, blocked,
   or inconclusive work.
 
+## Security Advisory Hotfixes
+
+Apply this when the source or required closeout is a GitHub security advisory,
+GHSA, CVE request, npm advisory, private vulnerability report, or public
+package security hotfix.
+
+- Treat the advisory as the tracker source. Use the GitHub advisory API through
+  `gh api` when the source is a GitHub repository advisory or public GHSA; do
+  not rely on the web UI as the only proof. For npm-only advisories or private
+  reports without a GitHub advisory, record the external advisory/report source
+  and the external owner or blocker instead.
+- Public GitHub Advisory Database records from `github.com/advisories/GHSA-*`
+  are read-only for normal repo maintainers. If the fix belongs to this repo,
+  locate or create the repository security advisory before trying to update
+  vulnerable ranges, publish, or request a CVE. If no repo advisory is owned by
+  this repo/org, close with global GHSA readback plus external owner/blocker.
+- If the source is private, draft, embargoed, or not yet publicly disclosed,
+  do not create a public PR, public issue comment, release note, or tracker
+  sync that reveals exploit details before the fixed version is available and
+  disclosure is approved. Use the repository advisory/private fork workflow
+  when available. If a public PR is necessary before disclosure, keep the title,
+  body, branch, commits, tests, and comments sanitized unless the user
+  explicitly approves disclosure.
+- Use `--with security-advisory` in the goal plan. Also use
+  `--with package-api` when a published package, changeset, or npm release is
+  part of the fix.
+- Do not stop at a merged PR, merged Version Packages PR, or created GitHub
+  Release while the advisory is still draft, lacks a patched version, or points
+  at the wrong affected range.
+- Verify the patched package is actually published before publishing the
+  advisory. For npm packages, read back `npm view <package>@<version>` and the
+  GitHub release/tag when relevant.
+- When a repository advisory exists, update advisory vulnerabilities with the
+  exact package, vulnerable range, and fixed version. The affected range should
+  exclude the fixed version. Public/global GHSA records without a repo advisory
+  are read-only; record readback and owner/blocker instead of mutating them.
+- Publish repository advisories after the fixed version is available. For
+  external/npm/private advisories, record the external publication state or the
+  owner/blocker instead.
+- If a repository advisory has empty `cve_id` and is eligible, request a CVE
+  through the advisory API unless the user explicitly says not to; read back the
+  advisory afterward and record that assignment may remain pending. For
+  public/global GHSA records without a repo advisory and non-GitHub sources,
+  record existing CVE, external CNA/request owner, GitHub/global owner, or N/A
+  reason.
+- Final closeout must read back state, published timestamp, affected package,
+  vulnerable range, patched version, CVE status, and the expected GitHub
+  review/Dependabot propagation caveat.
+- Final handoff for private/draft work must state the disclosure-safe path used
+  or the exact user approval that allowed public details.
+
 ## Load Skills Only When Justified
 
 ## Skill Diet
@@ -122,9 +182,10 @@ lock.
 - `autogoal`: measurable or auditable non-trivial work. Use the dominant-risk
   primary template and touched-surface packs: docs-heavy work gets
   `--template docs`, normal work gets `--template task`, and supporting docs,
-  browser, agent-native, or package/API surfaces add matching `--with <pack>`
-  rows. Review expectations stay in the primary template. Do not use root
-  planning files, hooks, `.planning/**`, or `docs/goals/**`.
+  browser, agent-native, security-advisory, or package/API surfaces add
+  matching `--with <pack>` rows. Review expectations stay in the primary
+  template. Do not use root planning files, hooks, `.planning/**`, or
+  `docs/goals/**`.
 - `major-task`: heavyweight architecture, framework, migration, benchmark, or
   proposal work.
 - `testing`: tasks primarily about tests, coverage, regression gaps, or suite
@@ -261,6 +322,9 @@ Keep verification mandatory and proportional.
   signals unrelated to the diff, run `pnpm run reinstall` once and rerun the
   exact failing command before declaring the task blocked.
 - If work changes published packages, satisfy the changeset gate.
+- If work changes or resolves a security advisory, satisfy the
+  security-advisory gate through publish/readback or record the external
+  blocker.
 - If work is registry-only under `apps/www/src/registry/`, satisfy the registry
   changelog gate instead of a package changeset.
 - If verified work changed code, create or update the PR before tracker
@@ -322,6 +386,8 @@ with `gh pr view --json body` before final handoff.
 - Non-trivial docs work loaded `docs-creator` and used `--template docs`.
 - Supporting docs, browser, agent-native, package/API, or extra-review surfaces
   used the matching `--with <pack>` rows when they were not the dominant risk.
+- Security advisory hotfixes used `--with security-advisory` and closed
+  release, advisory publication, CVE request, and readback evidence.
 - Testing work loaded the testing policy before implementation.
 - Only necessary skills were loaded.
 - Batch work did not sprawl without explicit instruction.

--- a/.agents/skills/task/SKILL.md
+++ b/.agents/skills/task/SKILL.md
@@ -37,6 +37,13 @@ they earn their keep, and verify before calling the task done.
    - File path or spec path: read it first.
    - GitHub issue URL: fetch it with `gh issue view` first.
    - GitHub PR URL: fetch it with `gh pr view` first.
+   - GitHub repository security advisory URL
+     (`github.com/<owner>/<repo>/security/advisories/GHSA-*`): fetch it with
+     `gh api repos/<owner>/<repo>/security-advisories/<GHSA_ID>` first.
+   - Public GitHub Advisory Database URL (`github.com/advisories/GHSA-*`):
+     fetch it with `gh api advisories/<GHSA_ID>` first. Treat it as read-only
+     unless you can identify a repository security advisory owned by the
+     current repo/org.
    - Bare GitHub issue like `#555`: resolve it against the current `gh` repo
      first, then fetch it with `gh issue view`.
    - Linear issue link/id: fetch it with the Linear integration first.
@@ -77,6 +84,8 @@ they earn their keep, and verify before calling the task done.
      - browser/UI route or interaction touched: add `--with browser`
      - package exports, public API, release artifacts, or package boundary
        touched: add `--with package-api`
+     - GitHub security advisory, GHSA, CVE, npm advisory, or private
+       vulnerability disclosure touched: add `--with security-advisory`
      `node .agents/skills/autogoal/scripts/create-goal-scratchpad.mjs --template <task|docs> --with <pack> --title "<short task title>"`
    - follow local repo overrides for where planning files live
 10. If testing or coverage work, load `testing` before `tdd` and choose the
@@ -106,6 +115,57 @@ Apply only when the source is a tracker item.
 - Do not require PR creation, screenshots, or comments for analytical, blocked,
   or inconclusive work.
 
+## Security Advisory Hotfixes
+
+Apply this when the source or required closeout is a GitHub security advisory,
+GHSA, CVE request, npm advisory, private vulnerability report, or public
+package security hotfix.
+
+- Treat the advisory as the tracker source. Use the GitHub advisory API through
+  `gh api` when the source is a GitHub repository advisory or public GHSA; do
+  not rely on the web UI as the only proof. For npm-only advisories or private
+  reports without a GitHub advisory, record the external advisory/report source
+  and the external owner or blocker instead.
+- Public GitHub Advisory Database records from `github.com/advisories/GHSA-*`
+  are read-only for normal repo maintainers. If the fix belongs to this repo,
+  locate or create the repository security advisory before trying to update
+  vulnerable ranges, publish, or request a CVE. If no repo advisory is owned by
+  this repo/org, close with global GHSA readback plus external owner/blocker.
+- If the source is private, draft, embargoed, or not yet publicly disclosed,
+  do not create a public PR, public issue comment, release note, or tracker
+  sync that reveals exploit details before the fixed version is available and
+  disclosure is approved. Use the repository advisory/private fork workflow
+  when available. If a public PR is necessary before disclosure, keep the title,
+  body, branch, commits, tests, and comments sanitized unless the user
+  explicitly approves disclosure.
+- Use `--with security-advisory` in the goal plan. Also use
+  `--with package-api` when a published package, changeset, or npm release is
+  part of the fix.
+- Do not stop at a merged PR, merged Version Packages PR, or created GitHub
+  Release while the advisory is still draft, lacks a patched version, or points
+  at the wrong affected range.
+- Verify the patched package is actually published before publishing the
+  advisory. For npm packages, read back `npm view <package>@<version>` and the
+  GitHub release/tag when relevant.
+- When a repository advisory exists, update advisory vulnerabilities with the
+  exact package, vulnerable range, and fixed version. The affected range should
+  exclude the fixed version. Public/global GHSA records without a repo advisory
+  are read-only; record readback and owner/blocker instead of mutating them.
+- Publish repository advisories after the fixed version is available. For
+  external/npm/private advisories, record the external publication state or the
+  owner/blocker instead.
+- If a repository advisory has empty `cve_id` and is eligible, request a CVE
+  through the advisory API unless the user explicitly says not to; read back the
+  advisory afterward and record that assignment may remain pending. For
+  public/global GHSA records without a repo advisory and non-GitHub sources,
+  record existing CVE, external CNA/request owner, GitHub/global owner, or N/A
+  reason.
+- Final closeout must read back state, published timestamp, affected package,
+  vulnerable range, patched version, CVE status, and the expected GitHub
+  review/Dependabot propagation caveat.
+- Final handoff for private/draft work must state the disclosure-safe path used
+  or the exact user approval that allowed public details.
+
 ## Load Skills Only When Justified
 
 ## Skill Diet
@@ -126,9 +186,10 @@ lock.
 - `autogoal`: measurable or auditable non-trivial work. Use the dominant-risk
   primary template and touched-surface packs: docs-heavy work gets
   `--template docs`, normal work gets `--template task`, and supporting docs,
-  browser, agent-native, or package/API surfaces add matching `--with <pack>`
-  rows. Review expectations stay in the primary template. Do not use root
-  planning files, hooks, `.planning/**`, or `docs/goals/**`.
+  browser, agent-native, security-advisory, or package/API surfaces add
+  matching `--with <pack>` rows. Review expectations stay in the primary
+  template. Do not use root planning files, hooks, `.planning/**`, or
+  `docs/goals/**`.
 - `major-task`: heavyweight architecture, framework, migration, benchmark, or
   proposal work.
 - `testing`: tasks primarily about tests, coverage, regression gaps, or suite
@@ -265,6 +326,9 @@ Keep verification mandatory and proportional.
   signals unrelated to the diff, run `pnpm run reinstall` once and rerun the
   exact failing command before declaring the task blocked.
 - If work changes published packages, satisfy the changeset gate.
+- If work changes or resolves a security advisory, satisfy the
+  security-advisory gate through publish/readback or record the external
+  blocker.
 - If work is registry-only under `apps/www/src/registry/`, satisfy the registry
   changelog gate instead of a package changeset.
 - If verified work changed code, create or update the PR before tracker
@@ -326,6 +390,8 @@ with `gh pr view --json body` before final handoff.
 - Non-trivial docs work loaded `docs-creator` and used `--template docs`.
 - Supporting docs, browser, agent-native, package/API, or extra-review surfaces
   used the matching `--with <pack>` rows when they were not the dominant risk.
+- Security advisory hotfixes used `--with security-advisory` and closed
+  release, advisory publication, CVE request, and readback evidence.
 - Testing work loaded the testing policy before implementation.
 - Only necessary skills were loaded.
 - Batch work did not sprawl without explicit instruction.

--- a/.changeset/markdown-invalid-html-fallback.md
+++ b/.changeset/markdown-invalid-html-fallback.md
@@ -1,0 +1,5 @@
+---
+"@platejs/markdown": patch
+---
+
+Fix markdown deserialization from crashing on malformed HTML-like MDX input.

--- a/docs/plans/2026-06-14-fix-malformed-markdown-html-crash.md
+++ b/docs/plans/2026-06-14-fix-malformed-markdown-html-crash.md
@@ -1,0 +1,289 @@
+# fix malformed markdown html crash
+
+Objective:
+Fix #5005 malformed markdown HTML crash; done when @platejs/markdown falls back to text with tests, changeset, PR, and tracker sync.
+
+Goal plan:
+docs/plans/2026-06-14-fix-malformed-markdown-html-crash.md
+
+Template:
+docs/plans/templates/task.md
+
+Primary template:
+docs/plans/templates/task.md
+
+Applied packs:
+- package-api (docs/plans/templates/packs/package-api.md)
+- agent-native (implicit checkout scope: existing `.agents/**` workflow changes are dirty and repo policy requires PRing the whole checkout)
+
+Task source:
+- type: GitHub issue
+- id / link: #5005 https://github.com/udecode/plate/issues/5005
+- title: [Bug]: Markdown error when Invalid HTML passed
+- acceptance criteria: `deserializeMd` must not crash when MDX-enabled markdown input contains invalid HTML/XML such as `</ph\><`; it should degrade to plain editable markdown text.
+
+Completion threshold:
+- #5005 is fixed at the `@platejs/markdown` deserializer boundary, with a failing-before/passing-after regression test for the reported input.
+- Valid MDX/HTML fallback behavior covered by existing `deserializeMd` and `markdownToSlateNodesSafely` tests remains passing.
+- Published package delta is recorded in one `@platejs/markdown` patch changeset.
+- PR is created with task-style body and issue #5005 is synced after PR creation.
+- Task closure is legal only when the source-of-truth acceptance criteria are
+  satisfied or explicitly narrowed, required verification evidence is recorded,
+  code-review and release-artifact gates are closed when applicable, tracker/PR
+  sync is complete or marked N/A with reason, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-14-fix-malformed-markdown-html-crash.md` passes.
+
+Verification surface:
+- Repro: direct `deserializeMd(createTestEditor(), String.raw\`</ph\\><\`)` throws before fix.
+- Targeted tests: `bun test packages/markdown/src/lib/deserializer/deserializeMd.spec.ts packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.spec.tsx packages/markdown/src/lib/deserializer/utils/splitIncompleteMdx.spec.ts`.
+- Package check: `pnpm turbo typecheck --filter=./packages/markdown`.
+- Lint: `pnpm lint:fix`.
+- Browser: only if package fix also changes docs/demo UI behavior beyond parser output; otherwise N/A with reason.
+- PR/tracker: `gh pr view --json body` and concise #5005 comment after PR exists.
+
+Constraints:
+- Preserve existing user-facing behavior outside the task scope.
+- Prefer the durable ownership boundary over caller-by-caller patches.
+- Do not create PRs, comments, commits, or pushes unless the task/user/skill
+  requires them.
+- Do not add broad ceremony when the task is trivial or docs-only.
+
+Boundaries:
+- Source of truth: GitHub issue #5005 title/body/comment, plus local parser repro.
+- Allowed edit scope: `packages/markdown/src/lib/deserializer/**`, focused tests, `.changeset/**`, this goal plan, and PR/issue metadata.
+- Browser surface: Issue says browser surface `No`; docs route is only the reporter's convenient repro shell. Package API tests own the behavior unless UI changes become necessary.
+- Tracker sync: PR first, then #5005 comment with fix and verification.
+- Non-goals: No markdown spec redesign, no disabling MDX by default, no caller-level try/catch in docs/demo code.
+
+Output budget strategy:
+- Use scoped `rg`, `sed`, and targeted test commands with capped tool output. Avoid full test/build output unless a focused command points to a broader gate.
+
+Blocked condition:
+- Stop only if local package tests/typecheck are blocked by unrelated install corruption after one `pnpm run reinstall` retry, or GitHub auth blocks PR/tracker sync.
+
+Task state:
+- task_type: bug
+- task_complexity: non-trivial
+- current_phase: implementation
+- current_phase_status: complete
+- next_phase: final response
+- goal_status: ready to complete
+
+Current verdict:
+- verdict: issue valid; fix at parser recovery boundary
+- confidence: high
+- next owner: task
+- reason: reported input throws through `deserializeMd`; the fallback reparses the split complete prefix with MDX still enabled.
+
+Completion rule:
+- Do not call `update_goal(status: complete)` while any required checklist item
+  remains unchecked. If an item does not apply, check it and add `N/A: <reason>`.
+- Do not call `update_goal(status: complete)` until every completion threshold
+  above is satisfied, final handoff evidence is recorded, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-14-fix-malformed-markdown-html-crash.md` passes.
+- Do not create hook state for this goal. This file plus the active goal are the
+  durable state.
+
+Start Gates:
+| Gate | Applies | Evidence |
+|------|---------|----------|
+| Skill analysis before edits | yes | Read `task`, `autogoal`, `tdd`, `changeset`, `autoreview`, `agent-native-reviewer`, and Browser skill instructions |
+| Active goal checked or created | yes | `get_goal` returned none; `create_goal` created active goal for this plan |
+| Source of truth read before edits | yes | `gh issue view 5005 --json ...` read issue body and Dosu comment |
+| Tracker comments and attachments read | yes | One issue comment read; no attachments in issue output |
+| Video transcript evidence required | no | N/A: issue has no video or screen recording |
+| `docs/solutions` checked for non-trivial existing-code work | yes | Read `docs/solutions/logic-errors/2026-03-25-markdown-split-incomplete-mdx-must-not-treat-a-final-closing-angle-as-incomplete.md` |
+| TDD decision before behavior change or bug fix | yes | Add focused regression test first, run it red, then fix |
+| Branch decision for code-changing task | yes | Defer actual branch command until PR phase; use current non-main branch or create `codex/5005-markdown-invalid-html` if on `main` |
+| Release artifact decision | yes | `.changeset` for `@platejs/markdown` patch |
+| Browser tool decision for browser surface | yes | N/A unless UI changes are needed; issue marks browser surface `No` and package API owns behavior |
+| PR expectation decision | yes | Task skill requires PR after verified code change |
+| Tracker sync expectation decision | yes | Sync #5005 after PR exists |
+| Output budget strategy recorded | yes | See Output budget strategy |
+| Package/API pack selected | yes | `--with package-api` applied |
+| Public surface or package boundary identified | yes | `@platejs/markdown` public `deserializeMd`/`MarkdownPlugin` deserialize path |
+| Release artifact path selected | yes | `.changeset` |
+| `changeset` skill loaded when `.changeset` is required | yes | `.agents/rules/changeset.mdc` read |
+| Barrel/export impact decision recorded | yes | No exported file layout or package export changes expected; `pnpm brl` N/A unless implementation changes that |
+
+Work Checklist:
+- [x] Short objective plus outcome, completion threshold, verification surface,
+      constraints, boundaries, and blocked condition are concrete.
+- [x] Task source classified with source type, id/link, title, task type,
+      acceptance criteria, caveats, likely files/routes/packages, browser
+      surface, and root-cause layer.
+- [x] Required video or screen-recording evidence is cached/read as normalized
+      `<video-transcripts>` XML, or marked N/A with reason.
+- [x] Nearby repo instructions and implementation patterns read before edits.
+- [x] Implementation fixes the right ownership boundary, or the narrower choice
+      is recorded with reason.
+- [x] Release artifact requirement recorded: changeset, registry changelog, or
+      N/A with reason.
+- [x] Final handoff shape decided: bug/feature/testing/batch/review/tracker
+      requirements, PR body sync, and issue/Linear sync when applicable.
+- [x] Branch handling recorded for code-changing work: dedicated branch used,
+      new branch needed, or N/A with reason.
+- [x] Local-env-rot retry policy recorded for any surprising repo-wide failure:
+      reinstall/rerun evidence or N/A with reason.
+- [x] Workspace authority recorded: every proof command names the cwd/tool that
+      owns the changed behavior.
+- [x] High-risk note recorded for public API, runtime, package-boundary,
+      browser behavior, agent-action, or command-contract changes, or marked
+      N/A with reason.
+- [x] Review/autoreview target selected from actual diff state for non-trivial
+      implementation work, or marked N/A with reason.
+- [x] Agent-native review decision recorded for `.agents/**`, `.claude/**`,
+      `.codex/**`, skills, hooks, commands, prompts, or user-action tooling.
+- [x] Output budget discipline recorded and followed: broad searches are
+      scoped, capped, counted, or artifacted instead of streamed into goal
+      context.
+- [x] Package/API pack: public API, package boundary, export, and release-artifact impact are recorded.
+- [x] Package/API pack: release artifact matrix is applied: `.changeset`, registry changelog, or explicit no-artifact reason.
+- [x] Package/API pack: `.changeset` work loads `changeset` and follows its package/version/prose rules.
+- [x] Package/API pack: registry-only work updates `tooling/data/plate-ui-changelog.mdx` and generated `/registry/changelog/*` JSON instead of adding a package changeset.
+- [x] Package/API pack: no-artifact decisions state why the diff has no published package user-visible delta from `main`.
+- [x] Package/API pack: compatibility, migration, or hard-cut decision is explicit when public shape changes.
+- [x] Package/API pack: package-owned typecheck/build/test proof is recorded or marked N/A with reason.
+- [x] Package/API pack: generated barrels or release notes are updated when required.
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+|------|---------|-----------------|----------|
+| Named verification threshold | yes | Run the command, proof, source audit, or artifact check named in this plan | Targeted repro red, focused tests, full markdown package tests, package typecheck, lint, changeset, package build for browser proof, and `pnpm install` sync passed; review/check/PR rows remain below |
+| Bug reproduced before fix | yes | Record failing test/repro or N/A with reason | New `deserializeMd` regression failed before code change with MDX parser `Unexpected character \`\\\`` |
+| Targeted behavior verification | yes | Run focused test/proof for changed behavior or record N/A | `bun test packages/markdown/src/lib/deserializer/deserializeMd.spec.ts packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.spec.tsx packages/markdown/src/lib/deserializer/utils/splitIncompleteMdx.spec.ts` passed: 31 tests |
+| TypeScript or typed config changed | yes | Run relevant typecheck | `pnpm turbo typecheck --filter=./packages/markdown` passed |
+| Package exports or file layout changed | N/A: no export or file layout change | Run `pnpm brl` before final verification and keep generated barrel updates | No public export files moved/added/removed |
+| Package manifests, lockfile, or install graph changed | N/A: no manifest or lockfile change | Run `pnpm install` and relevant package checks | `pnpm install` still ran for agent skill sync and left lockfile up to date |
+| Agent rules or skills changed | yes | Run `pnpm install` and verify generated skill sync | Existing checkout includes `.agents/rules/task.mdc` and generated `.agents/skills/task/SKILL.md`; `pnpm install` ran `skiller apply` successfully |
+| Workspace authority proof | yes | Run verification in the owning repo/package/app/route/tool and record cwd; do not count the wrong workspace as proof | All command proofs ran in `/Users/zbeyens/git/plate`; package tests/typecheck own `@platejs/markdown` behavior |
+| Browser surface changed | N/A: package API fix; browser proof attempted | Capture Browser Use proof or record explicit waiver/blocker | Docs app started on `http://localhost:3010`; initial browser test used stale package build and showed old error, after `@platejs/markdown` build the Browser runtime reset reported `Browser is not available: iab` |
+| Browser final proof | N/A: Browser unavailable after reset | Attach screenshot or exact browser verification caveat when browser proof applies | Browser proof caveat recorded above; package API tests are the authoritative proof for issue's affected entry point |
+| CI-controlled template output changed | N/A: no `templates/**` output | Restore generated template output or record why it is intentionally kept | No `templates/**` edits |
+| Package behavior or public API changed | yes | Add a changeset or record why no changeset applies | `.changeset/markdown-invalid-html-fallback.md` added for `@platejs/markdown` patch |
+| Registry-only component work changed | N/A: not registry-only component work | Update `tooling/data/plate-ui-changelog.mdx`, run `node tooling/scripts/generate-ui-changelog-entries.mjs --write`, or record N/A | No `apps/www/src/registry/**` change |
+| Docs or content changed | yes | For docs-heavy work, use `--template docs`; for incidental docs, verify source-backed claims, links, examples, and rendered output or record N/A | Goal plans and pack files are workflow artifacts; `pnpm install` and prior security-pack plan evidence cover existing agent docs |
+| High-risk mini gate | yes | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | Failure mode: MDX parser errors escaping fallback crash consumers. Proof: repro red, parser tests green, package tests/typecheck green. Boundary: deserializer recovery path, not docs caller |
+| Agent-native review for agent/tooling changes | yes | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | `agent-native-reviewer` instructions read because existing checkout includes `.agents/**`; structured autoreview passed clean after accepted markdown fix |
+| Local install corruption suspected | N/A: no install rot | Run `pnpm run reinstall` once, rerun the exact failing command, or record N/A | No local-corruption failure occurred |
+| Autoreview for non-trivial implementation changes | yes | Load `.agents/skills/autoreview/SKILL.md`; use dirty local `--mode local`, branch/PR `--mode branch --base <base>`, or committed slice `--mode commit --commit <ref>` until no accepted/actionable findings, or record N/A for docs-only/trivial/no local patch | First run found accepted P2 on MDX member tags; fixed with `$`/`.` scanner support and regression tests. Second run passed clean: no accepted/actionable findings |
+| PR create or update | yes | Run `check` before PR work and sync PR body to the task-style final handoff | `pnpm check` passed; PR #5016 created |
+| Task-style PR body verified | yes | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the kitcn PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | `gh pr view 5016 --json body` verified required task-style sections and no current-PR self-link |
+| PR proof image hosting | N/A: no proof images | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | PR body records browser caveat in text; no local images |
+| Tracker sync-back | yes | Post concise issue/Linear sync after PR exists, or record N/A/blocker | #5005 comment posted: https://github.com/udecode/plate/issues/5005#issuecomment-4702973114 |
+| Final handoff contract | yes | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | Final handoff fields filled |
+| Final lint | yes | Run `pnpm lint:fix` or scoped equivalent | `pnpm lint:fix` passed; no fixes applied |
+| Output budget discipline | yes | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | Broad outputs were capped; package test output was long but bounded to markdown package proof |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-14-fix-malformed-markdown-html-crash.md` | Final rerun passed: `[autogoal] complete` |
+| Public API / package boundary proof | yes | Source-audit public API, exports, and package boundary impact | `packages/markdown/package.json` exports unchanged; behavior change is runtime fallback for existing `deserializeMd`/MarkdownPlugin API |
+| Release artifact classification | yes | Record whether the change is published package behavior/API/types/config/runtime, registry-only, or no published user-visible delta | Published package runtime behavior fix for `@platejs/markdown` |
+| Published package changeset | yes | If published package users see a delta, load `changeset`, add/update one `.changeset/*.md` per package, and prove no forbidden `minor` on `@platejs/slate`, `@platejs/core`, or `platejs` | `.changeset/markdown-invalid-html-fallback.md` uses `"@platejs/markdown": patch`; no forbidden core minor |
+| Registry changelog | N/A: not registry-only | If the change is registry-only under `apps/www/src/registry/**`, update `tooling/data/plate-ui-changelog.mdx`, run `node tooling/scripts/generate-ui-changelog-entries.mjs --write`, and do not add a package changeset | Package change uses changeset instead |
+| No release artifact | N/A: release artifact required | If no artifact is needed, record the exact reason: internal-only, docs-only, agent-only, test-only, or no user-visible delta from `main` | Changeset added |
+| Package typecheck/build/test | yes | Run owning package checks or record N/A with reason | `pnpm --filter @platejs/markdown test`, `pnpm turbo typecheck --filter=./packages/markdown`, and `pnpm --filter @platejs/markdown build` passed |
+| Barrel/export generation | N/A: no export layout change | Run `pnpm brl` when exports or exported file layout changed, otherwise N/A | No exported files moved/added/removed |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+|-------|--------|----------|------|
+| Intake and source read | complete | issue #5005, task/autogoal/tdd/changeset rules, parser files, tests, and prior splitIncompleteMdx solution read | implementation |
+| Implementation | complete | Fixed `splitIncompleteMdx` malformed tag boundary handling and hardened `markdownToSlateNodesSafely` fallback; added tests and changeset | verification |
+| Verification | complete | Focused tests, package tests, typecheck, build, lint, install sync, autoreview, and `pnpm check` passed | closeout |
+| PR / tracker sync | complete | PR #5016 created and issue #5005 comment posted | final response |
+| Closeout | complete | PR, tracker sync, final handoff fields, and open risks recorded | final response |
+
+Findings:
+- None yet.
+
+Decisions and tradeoffs:
+- Fix the deserializer recovery boundary instead of adding a caller try/catch in the docs demo.
+- Keep MDX enabled by default; malformed MDX/HTML falls back to markdown-without-MDX parsing only after MDX parsing fails.
+- No public API shape change; compatibility impact is safer runtime behavior.
+
+Implementation notes:
+- Likely files: `packages/markdown/src/lib/deserializer/deserializeMd.ts`, `packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.ts`, focused specs.
+- Actual code fix: `splitIncompleteMdx` now cuts at tag start when a parsed tag name is followed by an invalid non-boundary character, and `markdownToSlateNodesSafely` reparses failed complete prefixes without MDX instead of letting MDX parser errors escape.
+
+Review fixes:
+- Accepted autoreview P2: initial scanner boundary rejected valid MDX member tags like `<Foo.Bar>`. Fixed by supporting `$` and `.` in scanned MDX tag names and adding split/safe-deserializer regression tests that preserve a completed member tag before an incomplete tail.
+
+Error attempts:
+| Error / failed attempt | Count | Next different move | Resolution |
+|------------------------|-------|---------------------|------------|
+| None yet | 0 | | |
+
+Verification evidence:
+- Repro before fix: `bun - <<'EOF' ... deserializeMd(createTestEditor(), String.raw\`</ph\\><\`) ... EOF` threw `Unexpected character \`\\\` (U+005C) in name...`.
+- New regression red: `bun test packages/markdown/src/lib/deserializer/deserializeMd.spec.ts` failed on `falls back to editable text for malformed html-like mdx` before parser changes.
+- Focused tests green: `bun test packages/markdown/src/lib/deserializer/deserializeMd.spec.ts packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.spec.tsx packages/markdown/src/lib/deserializer/utils/splitIncompleteMdx.spec.ts` passed: 31 tests, 37 expects.
+- Package typecheck green: `pnpm turbo typecheck --filter=./packages/markdown` passed.
+- Lint green: `pnpm lint:fix` passed; no fixes applied.
+- Package tests green: `pnpm --filter @platejs/markdown test` passed: 229 tests, 4 snapshots, 364 expects.
+- Package build green for browser proof setup: `pnpm --filter @platejs/markdown build` passed.
+- Agent sync green for existing `.agents/**` checkout files: `pnpm install` passed and ran `skiller apply`.
+- Browser caveat: docs dev server ran at `http://localhost:3010`; browser proof was attempted, but after package build the in-app Browser reset reported `Browser is not available: iab`.
+- Review fix focused tests green: `bun test packages/markdown/src/lib/deserializer/deserializeMd.spec.ts packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.spec.tsx packages/markdown/src/lib/deserializer/utils/splitIncompleteMdx.spec.ts` passed: 33 tests, 39 expects.
+- Review fix package tests green: `pnpm --filter @platejs/markdown test` passed: 232 tests, 4 snapshots, 367 expects.
+- Review fix package typecheck green: `pnpm turbo typecheck --filter=./packages/markdown` passed.
+- Final lint green: `pnpm lint:fix` passed; no fixes applied.
+- Autoreview clean: `.agents/skills/autoreview/scripts/autoreview --mode local` rerun passed with no accepted/actionable findings.
+- PR gate green: `pnpm check` passed, including lint, root typecheck/build, `test:all`, and `test:slowest`.
+- Goal checker green: `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-14-fix-malformed-markdown-html-crash.md` passed.
+
+Final handoff contract:
+- PR line: PR #5016 https://github.com/udecode/plate/pull/5016
+- Issue / tracker line: Fixes #5005; comment posted https://github.com/udecode/plate/issues/5005#issuecomment-4702973114
+- Confidence line: 95-100% confidence
+- Flow table:
+  - Reproduced: tests red before fix; browser route reproduced old built-output error before package rebuild
+  - Verified: tests/check green; browser proof caveat recorded because Browser `iab` became unavailable after package rebuild
+- Browser check: attempted on `http://localhost:3010/docs/markdown`; final browser proof unavailable due Browser runtime `iab` error after reset
+- Outcome: `@platejs/markdown` malformed HTML-like MDX input falls back to editable text instead of crashing
+- Caveat: PR includes prior security-advisory workflow pack because repo policy stages the whole checkout for PR work
+- Design:
+  - Chosen boundary: deserializer recovery path in `@platejs/markdown`
+  - Why not quick patch: docs/caller try-catch would leave package consumers crashing
+  - Why not broader change: disabling MDX by default would break valid MDX behavior; fix keeps MDX and hardens fallback only
+- Verified: focused parser tests, markdown package tests, package typecheck/build, lint, install sync, autoreview, `pnpm check`
+- PR body verified: `gh pr view 5016 --json body`
+
+Task-style PR body contract:
+- Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
+  part of the diff and repo policy expects auto release, include that block.
+- Use the accepted kitcn PR #270 visual format. The body starts with an emoji
+  issue/tracker/fix line, for example `🐛 Fixes #123` or `🐛 Fixes ➖ N/A`, then
+  an emoji confidence line like `🟢 95-100% confidence`.
+- Use this exact table header: `| Phase | 🧪 Tests | 🌐 Browser |`.
+- Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
+  failing proof with `🔴`, and non-applicable cells with `➖ N/A`.
+- Use bold emoji section headings: `**✅ Outcome**`, `**⚠️ Caveat**`,
+  `**🏗️ Design**`, and `**🧪 Verified**`.
+- Never include a line that links to the current PR itself. The current PR URL
+  belongs in the final response, not in its own description.
+- Do not replace this with a generic `Summary` / `Verification` PR body, an
+  adaptive prose body from a git helper skill, plain `## Outcome` sections, or
+  an unrelated generated badge footer unless the caller or repo template
+  explicitly asks for it.
+- Proof is `gh pr view --json body` output or a concise source-backed summary
+  of that output.
+
+Final handoff / sync:
+- PR: https://github.com/udecode/plate/pull/5016
+- Issue / tracker: https://github.com/udecode/plate/issues/5005#issuecomment-4702973114
+- Browser proof: attempted; final proof unavailable because Browser `iab` was unavailable after package rebuild
+- Caveats: PR includes prior security-advisory workflow pack from the current checkout
+
+Timeline:
+- 2026-06-14T20:10:15.490Z Task goal plan created.
+
+Reboot status:
+| Question | Answer |
+|----------|--------|
+| Where am I? | Closeout |
+| Where am I going? | Final response |
+| What is the goal? | Fix #5005 malformed markdown HTML crash without disabling valid MDX behavior |
+| What have I learned? | See Findings |
+| What have I done? | See Timeline |
+
+Open risks:
+- None beyond the recorded browser-proof caveat; package API proof owns #5005.

--- a/docs/plans/2026-06-14-security-advisory-hotfix-workflow.md
+++ b/docs/plans/2026-06-14-security-advisory-hotfix-workflow.md
@@ -1,0 +1,267 @@
+# security advisory hotfix workflow
+
+Objective:
+Add security advisory hotfix workflow gates; done when task rule, pack template, generated skill sync, and focused checks pass.
+
+Goal plan:
+docs/plans/2026-06-14-security-advisory-hotfix-workflow.md
+
+Template:
+docs/plans/templates/task.md
+
+Primary template:
+docs/plans/templates/task.md
+
+Applied packs:
+- agent-native (docs/plans/templates/packs/agent-native.md)
+
+Task source:
+- type: user workflow repair request
+- id / link: current thread security advisory follow-up
+- title: Add reusable security advisory hotfix gates
+- acceptance criteria: future task/autogoal runs for GHSA/CVE/npm advisory hotfixes must include post-merge release, advisory metadata, advisory publish, CVE request, and final readback steps.
+
+Completion threshold:
+- `.agents/rules/task.mdc` tells task runs to fetch security advisories, apply `--with security-advisory`, avoid stopping at merge/release PR, and close publish/CVE/readback evidence.
+- `.agents/skills/task/SKILL.md` is regenerated from the source rule by `pnpm install`.
+- `docs/plans/templates/packs/security-advisory.md` exists and materializes advisory source, release, publish, CVE, and readback gates into a task goal plan.
+- Focused checks pass: `pnpm install`, pack materialization smoke, `pnpm lint:fix`, autoreview clean, source audit, and goal-plan checker.
+- `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-14-security-advisory-hotfix-workflow.md` passes.
+
+Verification surface:
+- Source audit with `rg` over `.agents/rules/task.mdc`, `.agents/skills/task/SKILL.md`, and `docs/plans/templates/packs/security-advisory.md`.
+- `pnpm install` generated skill sync.
+- `create-goal-scratchpad.mjs --template task --with security-advisory` smoke plan materialization, then smoke artifact deletion.
+- `pnpm lint:fix`.
+- `.agents/skills/autoreview/scripts/autoreview --mode local`.
+- `check-complete.mjs` on this plan.
+
+Constraints:
+- Preserve existing task workflow shape outside security advisory hotfixes.
+- Do not hand-edit generated skill mirrors without syncing from `.agents/rules`.
+- Do not invent a separate `security-advisory` skill unless the pack proves insufficient.
+- Keep the new pack focused on disclosure closeout, not generic package release policy.
+
+Boundaries:
+- Source of truth: current user request plus the observed GHSA closeout miss.
+- Allowed edit scope: `.agents/rules/task.mdc`, generated `.agents/skills/task/SKILL.md`, `docs/plans/templates/packs/security-advisory.md`, and this plan.
+- Browser surface: N/A: agent workflow/docs only.
+- Tracker sync: N/A: no issue/PR comment requested for this workflow repair.
+- Non-goals: changing release automation, changing advisory content, creating a new skill folder, or opening a PR.
+
+Output budget strategy:
+- Use targeted `sed`, `rg`, and focused command outputs only; cap broad searches and avoid streaming all historical plans.
+
+Blocked condition:
+- Stop if `pnpm install` cannot regenerate skill mirrors, the pack cannot materialize, or autoreview identifies an accepted issue that cannot be resolved without user choice.
+
+Task state:
+- task_type: agent workflow repair
+- task_complexity: normal
+- current_phase: closeout
+- current_phase_status: complete
+- next_phase: final response
+- goal_status: ready to complete
+
+Current verdict:
+- verdict: implement the missing workflow gates as a task rule plus autogoal pack
+- confidence: high after source sync, pack smoke, lint, autoreview fixes, and final closeout gates
+- next owner: task
+- reason: the prior GHSA run almost stopped at code/release and needed explicit advisory publish/CVE/readback steps.
+
+Completion rule:
+- Do not call `update_goal(status: complete)` while any required checklist item remains unchecked. If an item does not apply, check it and add `N/A: <reason>`.
+- Do not call `update_goal(status: complete)` until every completion threshold above is satisfied, final handoff evidence is recorded, and `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-14-security-advisory-hotfix-workflow.md` passes.
+- Do not create hook state for this goal. This file plus the active goal are the durable state.
+
+Start Gates:
+| Gate | Applies | Evidence |
+|------|---------|----------|
+| Skill analysis before edits | yes | Read `task`, `autogoal`, `agent-native-reviewer`, and `autoreview` skill instructions. |
+| Active goal checked or created | yes | `get_goal` returned none; created active goal for this workflow repair. |
+| Source of truth read before edits | yes | User asked to update `task` or add an autogoal pack for future security hotfixes. |
+| Tracker comments and attachments read | N/A: no tracker item | Current request is thread-local workflow repair. |
+| Video transcript evidence required | N/A: no video evidence | No screen recording/video was used as source. |
+| `docs/solutions` checked for non-trivial existing-code work | N/A: agent workflow repair | Existing source rules/templates were inspected instead. |
+| TDD decision before behavior change or bug fix | N/A: no runtime behavior change | This is rule/template behavior. |
+| Branch decision for code-changing task | N/A: no PR/commit requested | Work remains local until user asks to ship. |
+| Release artifact decision | N/A: no package release | Agent docs/rules only. |
+| Browser tool decision for browser surface | N/A: no browser surface | No UI/browser behavior changed. |
+| PR expectation decision | N/A: no PR requested | User asked to update workflow, not open a PR. |
+| Tracker sync expectation decision | N/A: no tracker sync requested | No issue/advisory comment needed for this workflow repair. |
+| Output budget strategy recorded | yes | Targeted searches and capped outputs recorded above. |
+| Agent-native pack selected | yes | Active plan uses `--with agent-native` because `.agents/**` changed. |
+| Agent-facing action surface identified | yes | Changed future `task` handling of GHSA/CVE/npm advisory hotfixes. |
+| Source rule versus generated mirror boundary identified | yes | `.agents/rules/task.mdc` is source; `.agents/skills/task/SKILL.md` is generated by `pnpm install`. |
+| `agent-native-reviewer` loaded or waiver recorded | yes | Loaded reviewer instructions; manual pass recorded below. |
+
+Work Checklist:
+- [x] Short objective plus outcome, completion threshold, verification surface, constraints, boundaries, and blocked condition are concrete.
+- [x] Task source classified with source type, id/link, title, task type, acceptance criteria, caveats, likely files/routes/packages, browser surface, and root-cause layer.
+- [x] Required video or screen-recording evidence is cached/read as normalized `<video-transcripts>` XML, or marked N/A with reason.
+- [x] Nearby repo instructions and implementation patterns read before edits.
+- [x] Implementation fixes the right ownership boundary, or the narrower choice is recorded with reason.
+- [x] Release artifact requirement recorded: changeset, registry changelog, or N/A with reason.
+- [x] Final handoff shape decided: local workflow repair summary with verification evidence.
+- [x] Branch handling recorded for code-changing work: N/A, no PR/commit requested.
+- [x] Local-env-rot retry policy recorded for any surprising repo-wide failure: N/A, no suspicious failure occurred.
+- [x] Workspace authority recorded: every proof command names `/Users/zbeyens/git/plate`.
+- [x] High-risk note recorded for public API, runtime, package-boundary, browser behavior, agent-action, or command-contract changes.
+- [x] Review/autoreview target selected from actual diff state for non-trivial implementation work.
+- [x] Agent-native review decision recorded for `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling.
+- [x] Output budget discipline recorded and followed: broad searches were scoped, capped, counted, or artifacted instead of streamed into goal context.
+- [x] Agent-native pack: source-of-truth rule files are edited instead of generated skill mirrors.
+- [x] Agent-native pack: the changed agent action is discoverable from the skill/rule text.
+- [x] Agent-native pack: generated mirrors are synced when `.agents/rules/**` changed, or N/A reason is recorded.
+- [x] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+|------|---------|-----------------|----------|
+| Named verification threshold | yes | Run the command, proof, source audit, or artifact check named in this plan | `pnpm install`, pack materialization smoke, source audit, `pnpm lint:fix`, final autoreview, and goal checker passed. |
+| Bug reproduced before fix | N/A: workflow repair | Record failing test/repro or N/A with reason | Prior GHSA closeout exposed the missing workflow step; no runtime repro applies. |
+| Targeted behavior verification | yes | Run focused test/proof for changed behavior or record N/A | Pack materialization smoke proved `--with security-advisory` rows appear in generated task plans. |
+| TypeScript or typed config changed | N/A: no TS/config code | Run relevant typecheck | No typed runtime surface changed. |
+| Package exports or file layout changed | N/A: no package exports | Run `pnpm brl` before final verification and keep generated barrel updates | No package/export layout changed. |
+| Package manifests, lockfile, or install graph changed | N/A: lockfile unchanged | Run `pnpm install` and relevant package checks | `pnpm install` ran for skill sync; package graph was already up to date. |
+| Agent rules or skills changed | yes | Run `pnpm install` and verify generated skill sync | `pnpm install` ran `skiller apply`; source audit shows `.agents/skills/task/SKILL.md` mirrors `.agents/rules/task.mdc`. |
+| Workspace authority proof | yes | Run verification in owning repo/package/app/route/tool and record cwd | All verification ran in `/Users/zbeyens/git/plate`. |
+| Browser surface changed | N/A: no browser surface | Capture Browser Use proof or record explicit waiver/blocker | Agent workflow/docs only. |
+| Browser final proof | N/A: no browser surface | Attach screenshot or exact browser verification caveat when browser proof applies | No UI/browser behavior changed. |
+| CI-controlled template output changed | N/A: no templates output | Restore generated template output or record why it is intentionally kept | No `templates/**` output changed. |
+| Package behavior or public API changed | N/A: no package behavior | Add a changeset or record why no changeset applies | Agent workflow only. |
+| Registry-only component work changed | N/A: no registry component | Update registry changelog or record N/A | No `apps/www/src/registry/**` change. |
+| Docs or content changed | yes | For incidental docs, verify source-backed claims, links, examples, and rendered output or record N/A | Added a goal pack template and plan; source audit and pack smoke cover structure. |
+| High-risk mini gate | yes | Record realistic failure mode, proof plan, and why chosen boundary is right | Failure mode: future agents stop at merged PR and leave advisory unpublished. Boundary: `task` selection plus autogoal pack catches future GHSA/CVE hotfixes. Proof: generated skill sync and pack materialization. |
+| Agent-native review for agent/tooling changes | yes | Load reviewer and close accepted/actionable findings | Reviewer loaded; manual parity pass says the task skill now exposes the agent action through rule text. |
+| Local install corruption suspected | N/A: no install rot | Run `pnpm run reinstall` once, rerun exact failing command, or record N/A | No local-corruption failure occurred. |
+| Autoreview for non-trivial implementation changes | yes | Run autoreview until no accepted/actionable findings | Final rerun passed clean: no accepted/actionable findings. |
+| PR create or update | N/A: no PR requested | Run `check` before PR work and sync PR body | No PR requested. |
+| Task-style PR body verified | N/A: no PR | Verify PR body with `gh pr view --json body` | No PR body. |
+| PR proof image hosting | N/A: no PR proof images | Host images or record N/A | No images. |
+| Tracker sync-back | N/A: no tracker sync requested | Post concise issue/Linear sync after PR exists, or record N/A/blocker | No tracker. |
+| Final handoff contract | yes | Fill final handoff fields below | Filled below; final response will be concise. |
+| Final lint | yes | Run `pnpm lint:fix` or scoped equivalent | `pnpm lint:fix` passed; no fixes applied. |
+| Output budget discipline | yes | Verify no unbounded high-volume command output was streamed | Searches were targeted; one broad `rg` was capped and truncated by tool output. |
+| Goal plan complete | yes | Run `check-complete.mjs` | `check-complete.mjs` passed for this plan. |
+| Agent source / generated sync | yes | Run `pnpm install` when `.agents/rules/**` changed and verify generated mirrors | `pnpm install` ran; source audit confirms generated `task` skill contains advisory workflow text. |
+| Agent action discoverability | yes | Source-audit the skill/rule path an agent will read | `rg` shows `Security Advisory Hotfixes` in `.agents/rules/task.mdc` and `.agents/skills/task/SKILL.md`. |
+| Agent-native review | yes | Load reviewer and close accepted findings, or record N/A | Manual agent-native review accepted no additional findings beyond autoreview; agents can now act through `gh api` workflow instructions. |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+|-------|--------|----------|------|
+| Intake and source read | complete | Task/autogoal/agent-native/autoreview skills and task/template sources read | implementation |
+| Implementation | complete | Added task rule and `security-advisory` pack; synced generated task skill | verification |
+| Verification | complete | `pnpm install`, pack smoke, source audit, `pnpm lint:fix`, and accepted autoreview fixes recorded | closeout |
+| PR / tracker sync | N/A | No PR/tracker requested | final response |
+| Closeout | complete | Final gate commands named in verification evidence | final response |
+
+Findings:
+- The missing reusable rule was not the code fix itself; it was the post-merge advisory closeout: verify fixed package publication, update advisory vulnerabilities, publish, request CVE, and read back state.
+- Autoreview correctly flagged that the first rule draft described `security-advisory` like a missing skill instead of an autogoal pack.
+- Autoreview correctly flagged the generated plan placeholders; this file is now a completed workflow repair ledger.
+- Autoreview correctly flagged that a concrete advisory ID does not belong in a reusable repo-tracked plan; this plan now uses a generic thread-local label.
+- Autoreview correctly flagged that repository security advisory URLs and public `github.com/advisories/GHSA-*` URLs require different API endpoints.
+- Autoreview correctly flagged that npm-only/private advisories need external-source closure instead of GitHub-only publish/CVE gates.
+- Autoreview correctly flagged that public GitHub Advisory Database records need an explicit read-only/global-owner path unless a repo advisory is owned by this repo/org.
+- Autoreview correctly flagged that private/draft vulnerability reports need a disclosure guard before public PR/comment/release-note sync.
+
+Decisions and tradeoffs:
+- Add a `security-advisory` pack instead of a standalone skill because the workflow composes with normal `task`, `package-api`, `changeset`, and release gates.
+- Update `.agents/rules/task.mdc` as source and regenerate `.agents/skills/task/SKILL.md` with `pnpm install`.
+- Keep package release policy in `package-api`; the new pack owns disclosure closeout only.
+
+Implementation notes:
+- `.agents/rules/task.mdc` now classifies GitHub security advisory/GHSA URLs and adds `--with security-advisory` for GHSA/CVE/npm advisory work.
+- `docs/plans/templates/packs/security-advisory.md` adds advisory source, publish, CVE, and readback gates.
+- `.agents/skills/task/SKILL.md` was regenerated by `pnpm install`.
+
+Review fixes:
+- Accepted autoreview P1: removed the misleading Skill Diet entry that implied a missing `security-advisory` skill; the rule now treats it as an autogoal pack.
+- Accepted autoreview P2: replaced generated placeholders in this plan with completed evidence rows.
+- Accepted autoreview P2: replaced the concrete advisory identifier in this plan with a generic thread-local label.
+- Accepted autoreview P2: removed self-described unfinished closeout language from the tracked plan and made final gate commands explicit.
+- Accepted autoreview P2: split repo-scoped advisory fetches from public GitHub Advisory Database fetches in the task rule and pack.
+- Accepted autoreview P2: made GitHub publish/CVE gates conditional on repository advisories and added npm/private external-source closure paths.
+- Accepted autoreview P2: added a public/global GHSA read-only path and instruction to locate/create a repo advisory before attempting mutation.
+- Accepted autoreview P2: added a private/draft disclosure guard for public PRs, issue comments, release notes, and tracker sync.
+
+Error attempts:
+| Error / failed attempt | Count | Next different move | Resolution |
+|------------------------|-------|---------------------|------------|
+| Autoreview found missing skill reference and unfinished plan | 1 | Patch source wording and complete the plan before rerun | Accepted and fixed. |
+| Autoreview found concrete advisory ID and unfinished closeout wording in plan | 1 | Make plan generic and make final gate evidence explicit | Accepted and fixed. |
+| Autoreview found repo/public GHSA API ambiguity | 1 | Split repo advisory and public advisory endpoints in source rule and pack | Accepted and fixed. |
+| Autoreview found GitHub-only gates over-applied to npm/private advisories | 1 | Add external-source paths and make repository publish/CVE gates conditional | Accepted and fixed. |
+| Autoreview found missing private disclosure guard | 1 | Add private/draft disclosure-safe PR/comment/release-note rule and pack gate | Accepted and fixed. |
+| Autoreview found public GHSA read-only closeout gap | 1 | Add public/global GHSA owner path and repo-advisory ownership condition | Accepted and fixed. |
+
+Verification evidence:
+- `pnpm install` in `/Users/zbeyens/git/plate` passed and ran `skiller apply`.
+- `node .agents/skills/autogoal/scripts/create-goal-scratchpad.mjs --template task --with security-advisory --title "security advisory pack smoke" --path docs/plans/2026-06-14-security-advisory-pack-smoke.md --force` materialized advisory pack rows; smoke file deleted.
+- `rg` source audit found `Security Advisory Hotfixes` and `security-advisory` rows in source rule, generated skill, and pack template.
+- `pnpm lint:fix` passed with no fixes applied.
+- `.agents/skills/autoreview/scripts/autoreview --mode local` first run found two accepted issues; both fixed.
+- `.agents/skills/autoreview/scripts/autoreview --mode local` second run found two accepted plan issues; both fixed.
+- `.agents/skills/autoreview/scripts/autoreview --mode local` third run found repo/public GHSA endpoint ambiguity; fixed and synced with `pnpm install`.
+- `rg` source audit confirms `.agents/rules/task.mdc` and `.agents/skills/task/SKILL.md` name both repo advisory and public advisory endpoints.
+- `.agents/skills/autoreview/scripts/autoreview --mode local` fourth run found GitHub-only gates over-applied to npm/private advisories; fixed in task rule and pack.
+- `.agents/skills/autoreview/scripts/autoreview --mode local` fifth run found public GHSA read-only closeout gap; fixed in task rule and pack.
+- `.agents/skills/autoreview/scripts/autoreview --mode local` sixth run found missing private disclosure guard; fixed in task rule and pack.
+- Final `.agents/skills/autoreview/scripts/autoreview --mode local` rerun passed clean: no accepted/actionable findings.
+- `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-14-security-advisory-hotfix-workflow.md` passed.
+
+Final handoff contract:
+- PR line: N/A, no PR requested.
+- Issue / tracker line: N/A, no tracker sync requested.
+- Confidence line: high.
+- Flow table:
+  - Reproduced: prior GHSA closeout needed manual advisory/CVE steps; browser N/A.
+  - Verified: source audit, generated skill sync, pack materialization smoke, lint, autoreview, and goal checker; browser N/A.
+- Browser check: N/A, agent workflow only.
+- Outcome: future task/autogoal security hotfixes get release, advisory publication, CVE request, and readback gates.
+- Caveat: no PR/commit created unless the user asks.
+- Design:
+  - Chosen boundary: `task` rule plus autogoal pack.
+  - Why not quick patch: a one-off reminder would not affect future generated plans.
+  - Why not broader change: a standalone skill is unnecessary unless the pack grows into a distinct workflow.
+- Verified: source audit, generated skill sync, pack materialization smoke, lint, autoreview clean rerun, and goal checker after final gates.
+- PR body verified: N/A, no PR.
+
+Task-style PR body contract:
+- N/A: no PR requested for this workflow repair.
+
+Final handoff / sync:
+- PR: N/A.
+- Issue / tracker: N/A.
+- Browser proof: N/A.
+- Caveats: no commit/PR created unless requested.
+
+Timeline:
+- 2026-06-14T19:32:53.682Z Task goal plan created.
+- 2026-06-14: Added task rule for GitHub security advisory/GHSA intake and closeout.
+- 2026-06-14: Added `docs/plans/templates/packs/security-advisory.md`.
+- 2026-06-14: Ran `pnpm install`; generated task skill sync passed.
+- 2026-06-14: Smoke-generated a task plan with `--with security-advisory`; pack rows materialized; smoke file deleted.
+- 2026-06-14: Ran `pnpm lint:fix`; no fixes applied.
+- 2026-06-14: Ran autoreview; accepted and fixed missing-skill wording and unfinished-plan findings.
+- 2026-06-14: Reran autoreview; accepted and fixed concrete-advisory-id and unfinished-closeout wording findings.
+- 2026-06-14: Reran autoreview; accepted and fixed repo-scoped versus public GHSA endpoint ambiguity.
+- 2026-06-14: Reran autoreview; accepted and fixed GitHub-only gates over-applied to npm/private advisory sources.
+- 2026-06-14: Reran autoreview; accepted and fixed public GHSA read-only closeout path.
+- 2026-06-14: Reran autoreview; accepted and fixed missing private disclosure guard.
+- 2026-06-14: Final autoreview rerun passed clean.
+- 2026-06-14: `check-complete.mjs` passed.
+
+Reboot status:
+| Question | Answer |
+|----------|--------|
+| Where am I? | Closeout |
+| Where am I going? | Run final gates, final response |
+| What is the goal? | Add reusable security advisory hotfix workflow gates |
+| What have I learned? | A pack is the right unit; naming it like a skill was wrong |
+| What have I done? | Added task rule, generated skill sync, security-advisory pack, and verification evidence |
+
+Open risks:
+- None after final gates pass.

--- a/docs/plans/templates/packs/security-advisory.md
+++ b/docs/plans/templates/packs/security-advisory.md
@@ -1,0 +1,46 @@
+# security-advisory pack
+
+Use this pack when work touches a GitHub security advisory, GHSA, CVE request,
+npm advisory, private vulnerability report, or public package security hotfix.
+
+This pack owns disclosure closeout. It does not replace `package-api`: use both
+packs when a published package release is part of the fix.
+
+The hard rule: a security hotfix is not done just because the code merged. It is
+done when the fixed version is available to users and the advisory has accurate
+metadata, publication state, CVE decision, and readback evidence.
+
+Start Gates:
+| Gate | Applies | Evidence |
+|------|---------|----------|
+| Security advisory pack selected | pending | pending |
+| Advisory source read through correct authority or explicit access blocker | pending | Use repo advisory endpoint for `/<owner>/<repo>/security/advisories/GHSA-*`, global read-only advisory endpoint for `/advisories/GHSA-*`, npm/advisory registry source for npm-only advisories, or the provided private report source |
+| Affected package, vulnerable range, and fixed-version target identified | pending | pending |
+| Disclosure/release order recorded | pending | Patch release before advisory publication, or explicit blocker |
+| Private/draft disclosure safety recorded | pending | Record public, private/draft, embargoed, or already-published source state before PR/tracker sync |
+| CVE decision recorded | pending | Request CVE, existing CVE, or N/A with reason |
+
+Work Checklist:
+- [ ] Security advisory pack: advisory source, state, `cve_id` when available, credits/reporter when available, affected products, and current vulnerable ranges are recorded from the correct source authority or marked blocked by permissions.
+- [ ] Security advisory pack: public/global GHSA records are treated as read-only unless a repository security advisory owned by the current repo/org is located or created.
+- [ ] Security advisory pack: impact, root cause, reproduction, remediation, affected package, vulnerable range, and fixed version are recorded.
+- [ ] Security advisory pack: private, draft, embargoed, or not-yet-public reports avoid public PR/comment/release-note disclosure until the fixed version is available and disclosure is approved; any public pre-disclosure PR is sanitized or explicitly user-approved.
+- [ ] Security advisory pack: security regression proof is recorded, or N/A reason explains why proof is external/manual.
+- [ ] Security advisory pack: code fix, PR merge, release/version PR, npm/package publish, and GitHub release/tag are tracked when a published package is involved.
+- [ ] Security advisory pack: repository advisory vulnerability metadata is updated with package, vulnerable range excluding the fixed version, and patched version after the fixed version is published, or N/A reason is recorded for read-only public GHSA/non-GitHub sources.
+- [ ] Security advisory pack: repository advisory is published after the fixed version is available, or public GHSA/external/npm/private publication state or blocker is recorded.
+- [ ] Security advisory pack: CVE is requested when a repository advisory has empty `cve_id` and is eligible, unless the user explicitly declines or a blocker is recorded; public GHSA/non-GitHub sources record existing CVE, GitHub/global owner, external CNA/request owner, or N/A reason.
+- [ ] Security advisory pack: final readback records source, state, `published_at` when available, package, vulnerable range, patched version, CVE status, and propagation caveat or external-owner caveat.
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+|------|---------|-----------------|----------|
+| Advisory source read | pending | Read repo advisories through `gh api repos/<owner>/<repo>/security-advisories/<GHSA_ID>`, public read-only GHSA records through `gh api advisories/<GHSA_ID>`, npm-only advisories through npm/advisory registry source, or private reports through the provided report source; otherwise record access blocker | pending |
+| Security repro / regression proof | pending | Record failing-before/passing-after proof, PoC validation, or N/A reason | pending |
+| Private disclosure guard | pending | For private/draft/embargoed/not-yet-public sources, use repository advisory/private fork or sanitized public artifacts until approved disclosure; otherwise record N/A: already public | pending |
+| Patched version published | pending | Verify npm/package publish and GitHub release/tag when a package release is part of the fix | pending |
+| Advisory metadata updated | pending | For repository advisories, update affected product metadata with exact package, vulnerable range, and patched version; for public read-only GHSA/non-GitHub sources, record N/A with source owner/blocker | pending |
+| Advisory published | pending | Publish repository advisory after patched version availability, or record public GHSA/external/npm/private publication state or blocker | pending |
+| CVE request decision | pending | Request CVE through repository advisory API when applicable, or record existing CVE, GitHub/global owner, external CNA/request owner, or N/A reason | pending |
+| Advisory final readback | pending | Read back repository advisory state, `published_at`, `cve_id`, vulnerabilities, and URL, or record equivalent public GHSA/external source readback | pending |
+| Propagation caveat | pending | Record GitHub review / Dependabot / advisory database propagation caveat, public GHSA/global owner, or external-source propagation owner in final handoff | pending |

--- a/packages/markdown/src/lib/deserializer/deserializeMd.spec.ts
+++ b/packages/markdown/src/lib/deserializer/deserializeMd.spec.ts
@@ -19,6 +19,23 @@ describe('deserializeMd', () => {
     expect(onError).toHaveBeenCalledTimes(1);
   });
 
+  it('falls back to editable text for malformed html-like mdx', () => {
+    const editor = createTestEditor();
+    const onError = mock();
+
+    expect(
+      deserializeMd(editor, String.raw`</ph\><`, {
+        onError: onError as any,
+      })
+    ).toEqual([
+      {
+        children: [{ text: '</ph><' }],
+        type: 'p',
+      },
+    ]);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
   it('wraps top-level text results from custom rules in paragraphs', () => {
     const editor = createTestEditor();
 

--- a/packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.spec.tsx
+++ b/packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.spec.tsx
@@ -75,6 +75,45 @@ describe('markdownToSlateNodesSafely', () => {
     ]);
   });
 
+  it('falls back to editable text for malformed html-like mdx', () => {
+    const editor = createTestEditor();
+
+    expect(markdownToSlateNodesSafely(editor, String.raw`</ph\><`)).toEqual([
+      {
+        children: [{ text: '</ph><' }],
+        type: 'p',
+      },
+    ]);
+  });
+
+  it('preserves completed MDX member tags before an incomplete tail', () => {
+    const editor = createTestEditor();
+
+    expect(
+      markdownToSlateNodesSafely(editor, '<Foo.Bar>ok</Foo.Bar><u>', {
+        rules: {
+          'Foo.Bar': {
+            deserialize: () => ({
+              children: [{ text: 'member' }],
+              type: 'member',
+            }),
+          },
+        },
+      })
+    ).toEqual([
+      {
+        children: [
+          {
+            children: [{ text: 'member' }],
+            type: 'member',
+          },
+          { text: '<u>' },
+        ],
+        type: 'p',
+      },
+    ]);
+  });
+
   it('preserves complete void blocks before appending the fallback paragraph', () => {
     const editor = createTestEditor();
 

--- a/packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.ts
+++ b/packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.ts
@@ -25,6 +25,28 @@ const isSplitInsideTableRow = (completeString: string) => {
   return currentLine.includes('|');
 };
 
+const markdownToSlateNodesWithoutMdx = (
+  editor: SlateEditor,
+  data: string,
+  options?: Omit<DeserializeMdOptions, 'editor'>
+) =>
+  markdownToSlateNodes(editor, data, {
+    ...options,
+    withoutMdx: true,
+  });
+
+const markdownToSlateNodesWithMdxFallback = (
+  editor: SlateEditor,
+  data: string,
+  options?: Omit<DeserializeMdOptions, 'editor'>
+) => {
+  try {
+    return markdownToSlateNodes(editor, data, options);
+  } catch {
+    return markdownToSlateNodesWithoutMdx(editor, data, options);
+  }
+};
+
 const appendInlineNodesToLastTextContainer = (
   editor: SlateEditor,
   node: unknown,
@@ -80,10 +102,7 @@ export const markdownToSlateNodesSafely = (
   const result = splitIncompleteMdx(data);
 
   if (!Array.isArray(result))
-    return markdownToSlateNodes(editor, data, {
-      ...options,
-      withoutMdx: true,
-    });
+    return markdownToSlateNodesWithoutMdx(editor, data, options);
 
   const [completeString, incompleteString] = result;
 
@@ -92,7 +111,11 @@ export const markdownToSlateNodesSafely = (
     withoutMdx: true,
   });
 
-  const completeNodes = markdownToSlateNodes(editor, completeString, options);
+  const completeNodes = markdownToSlateNodesWithMdxFallback(
+    editor,
+    completeString,
+    options
+  );
 
   const newBlock = {
     children: incompleteNodes,
@@ -114,10 +137,11 @@ export const markdownToSlateNodesSafely = (
 
   if (ElementApi.isElement(lastBlock) && lastBlock.type === tableType) {
     if (isSplitInsideTableRow(completeString)) {
-      const withoutMdxNodes = markdownToSlateNodes(editor, data, {
-        ...options,
-        withoutMdx: true,
-      });
+      const withoutMdxNodes = markdownToSlateNodesWithoutMdx(
+        editor,
+        data,
+        options
+      );
       const tableOrdinal = completeNodes
         .filter((node) => ElementApi.isElement(node) && node.type === tableType)
         .indexOf(lastBlock);

--- a/packages/markdown/src/lib/deserializer/utils/splitIncompleteMdx.spec.ts
+++ b/packages/markdown/src/lib/deserializer/utils/splitIncompleteMdx.spec.ts
@@ -47,6 +47,13 @@ describe('splitIncomplete', () => {
     expect(splitIncompleteMdx(data)).toEqual(['test ', '<mdx>mdx</m']);
   });
 
+  it('splits malformed tag names at the tag start', () => {
+    expect(splitIncompleteMdx(String.raw`</ph\><`)).toEqual([
+      '',
+      String.raw`</ph\><`,
+    ]);
+  });
+
   it('ignores self‑closing tags when checking balance', () => {
     const data = '<section><img src="x.jpg"/><p>hi</p></section><sec';
     expect(splitIncompleteMdx(data)).toEqual([
@@ -67,5 +74,10 @@ describe('splitIncomplete', () => {
   it('keeps nested balanced tags intact', () => {
     const data = '<a><b></b></a>';
     expect(splitIncompleteMdx(data)).toBe(data);
+  });
+
+  it('keeps complete member-expression tags before an incomplete tail', () => {
+    const data = '<Foo.Bar>ok</Foo.Bar><u>';
+    expect(splitIncompleteMdx(data)).toEqual(['<Foo.Bar>ok</Foo.Bar>', '<u>']);
   });
 });

--- a/packages/markdown/src/lib/deserializer/utils/splitIncompleteMdx.ts
+++ b/packages/markdown/src/lib/deserializer/utils/splitIncompleteMdx.ts
@@ -1,11 +1,22 @@
-/** Check if character is valid for tag name: A-Z / a-z / 0-9 / - _ : */
+/** Check if character is valid for tag name: A-Z / a-z / 0-9 / $ - . _ : */
 const isNameChar = (c: number) =>
   (c >= 48 && c <= 57) || // 0-9
   (c >= 65 && c <= 90) || // A-Z
   (c >= 97 && c <= 122) || // a-z
+  c === 36 || // $
   c === 45 || // -
+  c === 46 || // .
   c === 95 || // _
   c === 58; // :
+
+const isNameBoundary = (c: number) =>
+  c === 47 || // /
+  c === 62 || // >
+  c === 9 || // tab
+  c === 10 || // newline
+  c === 12 || // form feed
+  c === 13 || // carriage return
+  c === 32; // space
 
 export const splitIncompleteMdx = (data: string): string[] | string => {
   type Frame = {
@@ -46,6 +57,12 @@ export const splitIncompleteMdx = (data: string): string[] | string => {
     } // No name after '<'
 
     const tagName = data.slice(nameStart, i).toLowerCase();
+    const next = data.codePointAt(i);
+
+    if (next !== undefined && !isNameBoundary(next)) {
+      cutPos = tagStart;
+      break;
+    }
 
     /* Skip to matching '>' (considering quotes) ------------------------------------ */
     let inQuote: "'" | '"' | null = null;


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

🐛 Fixes #5005
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
|---|---|---|
| Reproduced | 🔴 `deserializeMd(..., String.raw\`</ph\\><\`)` threw the reported MDX parser error before the fix | 🔴 Docs markdown route reproduced the old console error before rebuilding the local package output |
| Verified | 🟢 `pnpm check`, `pnpm --filter @platejs/markdown test`, focused parser tests, package typecheck, lint, and autoreview passed | ⚠️ Browser runtime became unavailable after package rebuild; package API proof owns the issue because #5005 targets `@platejs/markdown` |

**✅ Outcome**

`@platejs/markdown` no longer crashes when MDX-enabled markdown deserialization receives malformed HTML-like input such as `</ph\><`; it falls back to editable text instead.

This PR also includes the already-requested task/autogoal security-advisory workflow pack that was present in the checkout: future GHSA/CVE/security-hotfix tasks now carry release, advisory publish, CVE, and final readback gates.

**⚠️ Caveat**

Browser proof was attempted on `http://localhost:3010/docs/markdown`. The route initially reproduced the old console error because the app resolved built package output; after `@platejs/markdown` was rebuilt, the in-app Browser connection reported `Browser is not available: iab`, so browser verification is recorded as blocked rather than overstated.

**🏗️ Design**

The fix is at the deserializer recovery boundary: malformed tag names are cut into the non-MDX fallback path, and safe deserialization catches remaining MDX parser failures on the completed prefix before falling back without MDX. It does not disable valid MDX. Autoreview caught the member-expression edge case, so the scanner now preserves valid tags like `<Foo.Bar>` before incomplete tails.

**🧪 Verified**

- `bun test packages/markdown/src/lib/deserializer/deserializeMd.spec.ts packages/markdown/src/lib/deserializer/utils/markdownToSlateNodesSafely.spec.tsx packages/markdown/src/lib/deserializer/utils/splitIncompleteMdx.spec.ts`
- `pnpm --filter @platejs/markdown test`
- `pnpm turbo typecheck --filter=./packages/markdown`
- `pnpm --filter @platejs/markdown build`
- `pnpm lint:fix`
- `pnpm install`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `pnpm check`
