### PR TITLE
feat(yjs): add indexeddb provider

### DIFF
--- a/.changeset/yjs-indexeddb-provider.md
+++ b/.changeset/yjs-indexeddb-provider.md
@@ -1,0 +1,5 @@
+---
+"@platejs/yjs": minor
+---
+
+Add built-in IndexedDB provider support.

--- a/content/docs/(plugins)/(collaboration)/yjs.cn.mdx
+++ b/content/docs/(plugins)/(collaboration)/yjs.cn.mdx
@@ -10,9 +10,9 @@ toc: true
 
 ## 功能特性
 
-- **多提供者支持:** 使用 [Yjs](https://github.com/yjs/yjs) 和 [slate-yjs](https://docs.slate-yjs.dev/) 实现实时协作。支持同时使用多个同步提供者（例如 Hocuspocus + WebRTC）共享同一个 `Y.Doc`。
-- **内置提供者:** 开箱即用地支持 [Hocuspocus](https://tiptap.dev/hocuspocus)（服务器端）和 [WebRTC](https://github.com/yjs/y-webrtc)（点对点）提供者。
-- **自定义提供者:** 可扩展架构允许通过实现 `UnifiedProvider` 接口添加自定义提供者（例如用于离线存储的 IndexedDB）。
+- **多提供者支持:** 使用 [Yjs](https://github.com/yjs/yjs) 和 [slate-yjs](https://docs.slate-yjs.dev/) 实现实时协作。支持同时使用多个同步提供者（例如 IndexedDB + Hocuspocus + WebRTC）共享同一个 `Y.Doc`。
+- **内置提供者:** 开箱即用地支持 [IndexedDB](https://github.com/yjs/y-indexeddb) 本地持久化、[Hocuspocus](https://tiptap.dev/hocuspocus)（服务器端）和 [WebRTC](https://github.com/yjs/y-webrtc)（点对点）提供者。
+- **自定义提供者:** 可扩展架构允许通过实现 `UnifiedProvider` 接口添加自定义提供者。
 - **感知与光标:** 集成 Yjs Awareness 协议，用于在用户之间共享光标位置和其他临时状态。包含 [`RemoteCursorOverlay`](/docs/components/remote-cursor-overlay) 用于渲染远程光标。
 - **可自定义光标:** 可通过 `cursors` 自定义光标外观（名称、颜色）。
 - **手动生命周期:** 提供显式的 `init` 和 `destroy` 方法来管理 Yjs 连接生命周期。
@@ -25,7 +25,7 @@ toc: true
 
 ### 安装
 
-安装核心 Yjs 插件和您打算使用的特定提供者包：
+安装核心 Yjs 插件。
 
 ```bash
 npm install @platejs/yjs
@@ -89,6 +89,13 @@ const editor = createPlateEditor({
         },
         // 配置提供者。所有提供者共享同一个 Y.Doc 和 Awareness 实例。
         providers: [
+          // 示例：用于本地持久化的 IndexedDB 提供者
+          {
+            type: 'indexeddb',
+            options: {
+              docName: 'my-document-id', // 唯一的 IndexedDB 数据库名称
+            },
+          },
           // 示例：Hocuspocus 提供者
           {
             type: 'hocuspocus',
@@ -275,6 +282,19 @@ type WebRTCProviderConfig = {
 }
 ```
 
+### IndexedDB 提供者
+
+使用 [y-indexeddb](https://github.com/yjs/y-indexeddb) 的浏览器本地持久化。当编辑器需要在远程同步完成前恢复本地状态时，将它与网络提供者一起使用。
+
+```tsx
+type IndexeddbProviderConfig = {
+  type: 'indexeddb',
+  options: {
+    docName: string; // 此文档稳定的 IndexedDB 数据库名称
+  }
+}
+```
+
 ### 自定义提供者
 
 通过实现 `UnifiedProvider` 接口创建自定义提供者：
@@ -305,6 +325,21 @@ YjsPlugin.configure({
 ```
 
 ## 后端设置
+
+### IndexedDB 本地持久化
+
+IndexedDB 在浏览器中运行，并使用 `YjsPlugin` 创建的共享 `Y.Doc`。组合多个提供者时，`docName` 应与网络提供者的 room/name 使用同一个文档标识符：
+
+```tsx
+{
+  type: 'indexeddb',
+  options: {
+    docName: 'document-1',
+  },
+}
+```
+
+IndexedDB 不传输远程 Awareness 或光标。它只在本地持久化文档更新；Hocuspocus 或 WebRTC 仍然负责多用户传输。
 
 ### Hocuspocus 服务器
 
@@ -422,7 +457,7 @@ YjsPlugin.configure({
 
 **检查 URL 和名称：**
 - 验证 `url`（Hocuspocus）和 `signaling` URL（WebRTC）是否正确
-- 确保 `name` 或 `roomName` 在所有协作者之间完全匹配
+- 确保共享同一个文档的 `docName`、`name` 或 `roomName` 完全匹配
 - 本地开发使用 `ws://`，生产环境使用 `wss://`
 
 **服务器状态：**
@@ -464,6 +499,7 @@ YjsPlugin.configure({
 
 - [Yjs](https://github.com/yjs/yjs) - 用于协作的 CRDT 框架
 - [slate-yjs](https://docs.slate-yjs.dev/) - Slate 的 Yjs 绑定
+- [y-indexeddb](https://github.com/yjs/y-indexeddb) - IndexedDB 持久化提供者
 - [Hocuspocus](https://tiptap.dev/hocuspocus) - Yjs 后端服务器
 - [y-webrtc](https://github.com/yjs/y-webrtc) - WebRTC 提供者
 - [RemoteCursorOverlay](/docs/components/remote-cursor-overlay) - 远程光标组件
@@ -478,7 +514,7 @@ YjsPlugin.configure({
 <API name="YjsPlugin">
 <APIOptions>
   <APIItem name="providers" type="(UnifiedProvider | YjsProviderConfig)[]">
-    提供者配置数组或预实例化的提供者实例。插件将从配置创建实例并直接使用现有实例。所有提供者将共享同一个 Y.Doc 和 Awareness。每个配置对象指定提供者 `type`（例如 `'hocuspocus'`、`'webrtc'`）及其特定的 `options`。自定义提供者实例必须符合 `UnifiedProvider` 接口。
+    提供者配置数组或预实例化的提供者实例。插件将从配置创建实例并直接使用现有实例。所有提供者将共享同一个 Y.Doc 和 Awareness。每个配置对象指定提供者 `type`（例如 `'indexeddb'`、`'hocuspocus'` 或 `'webrtc'`）及其特定的 `options`。自定义提供者实例必须符合 `UnifiedProvider` 接口。
   </APIItem>
   <APIItem name="cursors" type="WithCursorsOptions | null" optional>
     远程光标配置。设置为 `null` 可显式禁用光标。如果省略，当指定了提供者时默认启用光标。传递给 `withTCursors`。参见 [WithCursorsOptions API](https://docs.slate-yjs.dev/api/slate-yjs-core/cursor-plugin#withcursors)。包括 `data`（本地用户信息）和 `autoSend`（默认 `true`）。

--- a/content/docs/(plugins)/(collaboration)/yjs.mdx
+++ b/content/docs/(plugins)/(collaboration)/yjs.mdx
@@ -10,9 +10,9 @@ toc: true
 
 ## Features
 
-- **Multi-Provider Support:** Enables real-time collaboration using [Yjs](https://github.com/yjs/yjs) and [slate-yjs](https://docs.slate-yjs.dev/). Supports multiple synchronization providers simultaneously (e.g., Hocuspocus + WebRTC) working on a shared `Y.Doc`.
-- **Built-in Providers:** Includes support for [Hocuspocus](https://tiptap.dev/hocuspocus) (server-based) and [WebRTC](https://github.com/yjs/y-webrtc) (peer-to-peer) providers out-of-the-box.
-- **Custom Providers:** Extensible architecture allows adding custom providers (e.g., for offline storage like IndexedDB) by implementing the `UnifiedProvider` interface.
+- **Multi-Provider Support:** Enables real-time collaboration using [Yjs](https://github.com/yjs/yjs) and [slate-yjs](https://docs.slate-yjs.dev/). Supports multiple synchronization providers simultaneously (e.g., IndexedDB + Hocuspocus + WebRTC) working on a shared `Y.Doc`.
+- **Built-in Providers:** Includes support for [IndexedDB](https://github.com/yjs/y-indexeddb) local persistence, [Hocuspocus](https://tiptap.dev/hocuspocus) server-based collaboration, and [WebRTC](https://github.com/yjs/y-webrtc) peer-to-peer collaboration.
+- **Custom Providers:** Extensible architecture allows adding custom providers by implementing the `UnifiedProvider` interface.
 - **Awareness & Cursors:** Integrates Yjs Awareness protocol for sharing cursor locations and other ephemeral state between users. Includes [`RemoteCursorOverlay`](/docs/components/remote-cursor-overlay) for rendering remote cursors.
 - **Customizable Cursors:** Cursor appearance (name, color) can be customized via `cursors`.
 - **Manual Lifecycle:** Provides explicit `init` and `destroy` methods for managing the Yjs connection lifecycle.
@@ -25,7 +25,7 @@ toc: true
 
 ### Installation
 
-Install the core Yjs plugin and the specific provider packages you intend to use:
+Install the core Yjs plugin.
 
 ```bash
 npm install @platejs/yjs
@@ -89,6 +89,13 @@ const editor = createPlateEditor({
         },
         // Configure providers. All providers share the same Y.Doc and Awareness instance.
         providers: [
+          // Example: IndexedDB provider for local persistence
+          {
+            type: 'indexeddb',
+            options: {
+              docName: 'my-document-id', // Unique IndexedDB database name
+            },
+          },
           // Example: Hocuspocus provider
           {
             type: 'hocuspocus',
@@ -275,6 +282,19 @@ type WebRTCProviderConfig = {
 }
 ```
 
+### IndexedDB Provider
+
+Local browser persistence using [y-indexeddb](https://github.com/yjs/y-indexeddb). Use it alongside a network provider when the editor should restore local state before remote sync finishes.
+
+```tsx
+type IndexeddbProviderConfig = {
+  type: 'indexeddb',
+  options: {
+    docName: string; // Stable IndexedDB database name for this document
+  }
+}
+```
+
 ### Custom Provider
 
 Create custom providers by implementing the `UnifiedProvider` interface:
@@ -305,6 +325,21 @@ YjsPlugin.configure({
 ```
 
 ## Backend Setup
+
+### IndexedDB Local Persistence
+
+IndexedDB runs in the browser and uses the shared `Y.Doc` created by `YjsPlugin`. Use the same document identifier for `docName` and your network provider room/name when you combine providers:
+
+```tsx
+{
+  type: 'indexeddb',
+  options: {
+    docName: 'document-1',
+  },
+}
+```
+
+IndexedDB does not transport remote awareness or cursors. It persists document updates locally; Hocuspocus or WebRTC still own multi-user transport.
 
 ### Hocuspocus Server
 
@@ -422,7 +457,7 @@ YjsPlugin.configure({
 
 **Check URLs and Names:**
 - Verify `url` (Hocuspocus) and `signaling` URLs (WebRTC) are correct
-- Ensure `name` or `roomName` matches exactly across all collaborators
+- Ensure `docName`, `name`, or `roomName` matches exactly across providers that share one document
 - Use `ws://` for local development, `wss://` for production
 
 **Server Status:**
@@ -464,6 +499,7 @@ YjsPlugin.configure({
 
 - [Yjs](https://github.com/yjs/yjs) - CRDT framework for collaboration
 - [slate-yjs](https://docs.slate-yjs.dev/) - Yjs bindings for Slate
+- [y-indexeddb](https://github.com/yjs/y-indexeddb) - IndexedDB persistence provider
 - [Hocuspocus](https://tiptap.dev/hocuspocus) - Backend server for Yjs
 - [y-webrtc](https://github.com/yjs/y-webrtc) - WebRTC provider
 - [RemoteCursorOverlay](/docs/components/remote-cursor-overlay) - Remote cursor component
@@ -478,8 +514,8 @@ Enables real-time collaboration using Yjs with support for multiple providers an
 <API name="YjsPlugin">
 <APIOptions>
   <APIItem name="providers" type="(UnifiedProvider | YjsProviderConfig)[]">
-    Array of provider configurations or pre-instantiated provider instances. The plugin will create instances from configurations and use existing instances directly. All providers will share the same Y.Doc and Awareness. Each configuration object specifies a provider `type` (e.g., `'hocuspocus'`,
-    `'webrtc'`) and its specific `options`. Custom provider instances must conform to the
+    Array of provider configurations or pre-instantiated provider instances. The plugin will create instances from configurations and use existing instances directly. All providers will share the same Y.Doc and Awareness. Each configuration object specifies a provider `type` (for example `'indexeddb'`, `'hocuspocus'`,
+    or `'webrtc'`) and its specific `options`. Custom provider instances must conform to the
     `UnifiedProvider` interface.
   </APIItem>
   <APIItem name="cursors" type="WithCursorsOptions | null" optional>

--- a/docs/plans/2026-06-15-4650-indexeddb-yjs-provider.md
+++ b/docs/plans/2026-06-15-4650-indexeddb-yjs-provider.md
@@ -1,0 +1,351 @@
+# 4650 indexeddb yjs provider
+
+Objective:
+Complete #4650 replacement IndexedDB Yjs provider; done when provider/docs/changeset/tests/check/PR are complete.
+
+Goal plan:
+docs/plans/2026-06-15-4650-indexeddb-yjs-provider.md
+
+Template:
+docs/plans/templates/task.md
+
+Primary template:
+docs/plans/templates/task.md
+
+Applied packs:
+- package-api (docs/plans/templates/packs/package-api.md)
+- docs (docs/plans/templates/packs/docs.md)
+
+Task source:
+- type: GitHub PR
+- id / link: https://github.com/udecode/plate/pull/4650
+- title: yjs: wip adding indexeddb yjs provider wrapper
+- acceptance criteria: add a first-party IndexedDB provider for `@platejs/yjs`, address stale PR review concerns, wire registry/types/exports, update docs, add a changeset, verify package behavior, and open a replacement PR crediting @dpnova.
+
+Completion threshold:
+- `@platejs/yjs` exposes a built-in `indexeddb` provider that shares the plugin-owned `Y.Doc`, tracks connect/sync/destroy state honestly, and is covered by focused tests.
+- Collaboration docs and package README show the current `providers` API and IndexedDB provider shape without stale `providerConfigs` / `customProviders` drift.
+- `.changeset` exists for `@platejs/yjs`, generated barrels are current, package install graph resolves, focused tests/typecheck/lint/check pass or any blocker is recorded, and a task-style PR is opened against `main` with @dpnova credit.
+- Task closure is legal only when the source-of-truth acceptance criteria are
+  satisfied or explicitly narrowed, required verification evidence is recorded,
+  code-review and release-artifact gates are closed when applicable, tracker/PR
+  sync is complete or marked N/A with reason, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-15-4650-indexeddb-yjs-provider.md` passes.
+
+Verification surface:
+- `bun test ./packages/yjs/src/lib/providers/indexeddb-provider.spec.ts`
+- `bun test ./packages/yjs/src/lib/providers/registry.spec.ts ./packages/yjs/src/lib/providers/indexeddb-provider.spec.ts`
+- `pnpm turbo typecheck --filter=./packages/yjs`
+- `pnpm lint:fix`
+- `pnpm check`
+- `pnpm brl`
+- `pnpm --filter www build:source` for MDX/docs parse if `content/docs/**` changes.
+- `gh pr view --json body` after PR creation.
+
+Constraints:
+- Preserve existing user-facing behavior outside the task scope.
+- Prefer the durable ownership boundary over caller-by-caller patches.
+- Do not create PRs, comments, commits, or pushes unless the task/user/skill
+  requires them.
+- Do not add broad ceremony when the task is trivial or docs-only.
+
+Boundaries:
+- Source of truth: PR #4650 body/comments/review/diff, current `packages/yjs` provider registry, `BaseYjsPlugin`, current Collaboration docs, `y-indexeddb@9.0.12` types.
+- Allowed edit scope: `packages/yjs/**`, `content/docs/(plugins)/(collaboration)/yjs*.mdx`, generated barrels/lockfile, `.changeset/**`, this plan.
+- Browser surface: docs text/API change only; user waived demo if env setup is required. Browser proof N/A unless docs route check is cheap after content build.
+- Tracker sync: open replacement PR and comment back on #4650 after PR exists.
+- Non-goals: no Yjs demo wiring, no new custom provider API, no broader collaboration rewrite.
+
+Output budget strategy:
+- Use exact file reads and targeted `rg` only. Avoid broad `docs/solutions` output; if broad search is needed, use file lists/counts first and then open exact hits.
+
+Blocked condition:
+- Stop only if current package checks reveal a real upstream `y-indexeddb`/Bun/browser API limitation that prevents a safe provider contract, or if `check` fails for unrelated repo-wide breakage after one reinstall/rerun pass.
+
+Task state:
+- task_type: feature completion from stale public PR
+- task_complexity: normal, package/API plus docs
+- current_phase: closeout
+- current_phase_status: complete
+- next_phase: final response
+- goal_status: ready for completion
+
+Current verdict:
+- verdict: partially valid
+- confidence: high
+- next owner: task
+- reason: #4650 correctly identifies an IndexedDB provider gap, but its implementation is incomplete and stale: conflicting draft, optional `ydoc` mismatch, no registry/barrel, no tests, no changeset, and stale docs/API names.
+
+Pre-solution issue challenge:
+- reporter claim: add IndexedDB Yjs provider wrapper.
+- suggested diagnosis or fix: PR adds `IndexeddbProviderWrapper` but passes `options.ydoc` to `IndexeddbPersistence`, keeps stale state after destroy, stores unused awareness without explanation, and omits registry/export/test/release wiring.
+  - repro ladder:
+  - tests / source-level repro: N/A for feature request; current source audit proves no built-in `indexeddb` provider exists.
+  - Playwright / automated browser: N/A; no browser-visible bug claim.
+  - Browser plugin: N/A; user explicitly waived demo if env setup is required and this is package API/docs work.
+  - screenshot / visual proof: N/A; no layout/native visual state.
+- reproduction verdict: N/A: feature completion, not a behavior bug.
+- validity verdict: partially valid.
+- best long-term fix boundary: provider registry/type union/docs/changelog in `@platejs/yjs`, not a one-off custom-provider recipe.
+- harsh honest feedback: the old PR is a good seed but not mergeable; taking it as-is would ship silent doc/document mismatch and stale lifecycle state.
+- hard-stop decision: pivot, do not merge/rebase the stale draft.
+
+Completion rule:
+- Do not call `update_goal(status: complete)` while any required checklist item
+  remains unchecked. If an item does not apply, check it and add `N/A: <reason>`.
+- Do not call `update_goal(status: complete)` until every completion threshold
+  above is satisfied, final handoff evidence is recorded, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-15-4650-indexeddb-yjs-provider.md` passes.
+- Do not create hook state for this goal. This file plus the active goal are the
+  durable state.
+
+Start Gates:
+| Gate | Applies | Evidence |
+|------|---------|----------|
+| Skill analysis before edits | yes | Loaded `task`, `autogoal`, `autoreview`, `tdd`, `changeset`, and `docs-creator` because this is issue-backed package/API/docs work. |
+| Active goal checked or created | yes | `get_goal` returned none; `create_goal` created active goal for this plan. |
+| Source of truth read before edits | yes | `gh pr view 4650 --json ...` read body, reviews, comments, commits, conflict/draft state. |
+| Tracker comments and attachments read | yes | PR comments and review were read; no attachments/videos. |
+| Video transcript evidence required | no | N/A: no video/screen recording evidence. |
+| Pre-solution issue challenge required | yes | Public PR with suggested fix reviewed before code. |
+| Reproduction verdict before implementation | yes | N/A feature request; source audit confirms missing built-in provider. |
+| Repro escalation ladder selected | yes | Tests/source-level source audit only; browser levels N/A for feature request. |
+| Suggested fix reviewed against durable boundary | yes | Old implementation rejected; provider registry/type/docs boundary selected. |
+| `docs/solutions` checked for non-trivial existing-code work | yes | Relevant exact hit read: `docs/solutions/test-failures/2026-03-22-yjs-slow-tests-need-explicit-bun-paths-and-bootstrapped-shared-types.md`. |
+| TDD decision before behavior change or bug fix | yes | Focused provider behavior spec added first and failed on missing module before implementation. |
+| Branch decision for code-changing task | yes | Current branch was `main`; pulled and created `codex/4650-indexeddb-yjs-provider`. |
+| Release artifact decision | yes | `.changeset` required for published `@platejs/yjs` feature. |
+| Browser tool decision for browser surface | yes | N/A unless docs route check is cheap; user waived demo if env setup required. |
+| PR expectation decision | yes | Task requires replacement PR before tracker sync-back. |
+| Tracker sync expectation decision | yes | Comment on #4650 after replacement PR exists. |
+| Output budget strategy recorded | yes | Exact file reads after one broad-search miss; avoid broad streamed output. |
+| Package/API pack selected | yes | `--with package-api` applied. |
+| Public surface or package boundary identified | yes | `@platejs/yjs` provider config/type/registry/export/public docs. |
+| Release artifact path selected | yes | `.changeset` for `@platejs/yjs`. |
+| `changeset` skill loaded when `.changeset` is required | yes | Loaded `changeset` before writing changeset. |
+| Barrel/export impact decision recorded | yes | New exported provider file requires `pnpm brl`. |
+| Docs pack selected | yes | `--with docs` applied. |
+| `docs-creator` loaded | yes | Loaded before docs edits. |
+| Docs lane selected | yes | Plugin/feature docs plus package README. |
+| Target docs and nearest sibling docs read | yes | Read `content/docs/(plugins)/(collaboration)/yjs.mdx` and `packages/yjs/README.md`; source owner is `packages/yjs`. |
+| Docs style doctrine read | yes | Read full `docs-creator` skill. |
+| Documented source owner identified | yes | `BaseYjsPlugin`, provider registry, provider types, and provider wrappers own behavior. |
+
+Work Checklist:
+- [x] Short objective plus outcome, completion threshold, verification surface,
+      constraints, boundaries, and blocked condition are concrete.
+- [x] Task source classified with source type, id/link, title, task type,
+      acceptance criteria, caveats, likely files/routes/packages, browser
+      surface, and root-cause layer.
+- [x] Required video or screen-recording evidence is cached/read as normalized
+      `<video-transcripts>` XML, or marked N/A with reason.
+- [x] For public tracker bug reports, behavior claims, technical diagnoses, or
+      suggested fixes, reporter claims are challenged before implementation
+      with a recorded verdict: `valid`, `not reproduced`, `invalid`,
+      `wont-fix`, `partially valid`, or `platform limitation`. Feature, docs,
+      support, or cleanup requests with no bug claim may mark reproduction
+      `N/A` with reason.
+- [x] Repro escalation ladder followed for bug/behavior claims: focused
+      test/source-level repro first when applicable; existing repo-owned
+      Playwright regression/test harness next when available and useful as
+      executable coverage; do not use standalone Playwright, Puppeteer, or raw
+      DevTools as a substitute for the repo Browser policy;
+      `[@Browser](plugin://browser@openai-bundled)` next when tests or
+      Playwright cannot reproduce or cannot model the surface honestly;
+      screenshot or explicit visual-proof waiver when visual/native state
+      matters.
+- [x] Hard-stop rule followed for bug/behavior claims: no code when the issue
+      is not reproduced, invalid, or won't-fix; partial validity pivots to the
+      best long-term fix and records what was wrong or incomplete in the issue's
+      proposed path.
+- [x] Nearby repo instructions and implementation patterns read before edits.
+- [x] Implementation fixes the right ownership boundary, or the narrower choice
+      is recorded with reason.
+- [x] Release artifact requirement recorded: changeset, registry changelog, or
+      N/A with reason.
+- [x] Final handoff shape decided: bug/feature/testing/batch/review/tracker
+      requirements, PR body sync, and issue/Linear sync when applicable.
+- [x] Branch handling recorded for code-changing work: dedicated branch used,
+      new branch needed, or N/A with reason.
+- [x] Local-env-rot retry policy recorded for any surprising repo-wide failure:
+      reinstall/rerun evidence or N/A with reason.
+- [x] Workspace authority recorded: every proof command names the cwd/tool that
+      owns the changed behavior.
+- [x] High-risk note recorded for public API, runtime, package-boundary,
+      browser behavior, agent-action, or command-contract changes, or marked
+      N/A with reason.
+- [x] Review/autoreview target selected from actual diff state for non-trivial
+      implementation work, or marked N/A with reason.
+- [x] Agent-native review decision recorded for `.agents/**`, `.claude/**`,
+      `.codex/**`, skills, hooks, commands, prompts, or user-action tooling.
+- [x] Output budget discipline recorded and followed: broad searches are
+      scoped, capped, counted, or artifacted instead of streamed into goal
+      context.
+- [x] Package/API pack: public API, package boundary, export, and release-artifact impact are recorded.
+- [x] Package/API pack: release artifact matrix is applied: `.changeset`, registry changelog, or explicit no-artifact reason.
+- [x] Package/API pack: `.changeset` work loads `changeset` and follows its package/version/prose rules.
+- [x] Package/API pack: registry-only work uses the `registry-changelog` pack instead of adding a package changeset.
+- [x] Package/API pack: no-artifact decisions state why the diff has no published package user-visible delta from `main`.
+- [x] Package/API pack: compatibility, migration, or hard-cut decision is explicit when public shape changes.
+- [x] Package/API pack: package-owned typecheck/build/test proof is recorded or marked N/A with reason.
+- [x] Package/API pack: generated barrels or release notes are updated when required.
+- [x] Docs pack: docs lane, target docs, nearest sibling docs, and source owner are recorded.
+- [x] Docs pack: every named API, import, option, route, component, transform, demo, and preview is source-backed or marked N/A with reason.
+- [x] Docs pack: docs use current-state reference voice, not changelog voice.
+- [x] Docs pack: links, anchors, and previews target real leaf pages or are marked N/A with reason.
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+|------|---------|-----------------|----------|
+| Named verification threshold | yes | Run the command, proof, source audit, or artifact check named in this plan | `pnpm check` passed in `/Users/zbeyens/git/plate`. |
+| Pre-solution issue challenge verdict | yes | Record reporter claim, suggested fix, repro verdict, validity verdict, durable boundary, and hard-stop/pivot decision before implementation | Recorded above: #4650 is partially valid; stale draft rejected in favor of current provider boundary. |
+| Repro escalation ladder | yes | For bug/behavior claims, record test/source-level, Playwright, Browser, and screenshot/visual-proof outcomes or N/A/blocker reasons before `not reproduced` | Feature completion, not a bug repro; source audit plus focused tests used. Browser and screenshot N/A. |
+| Bug reproduced before fix | no | Record failing test/repro or N/A with reason | N/A feature gap; RED test proved missing provider file before implementation. |
+| Targeted behavior verification | yes | Run focused test/proof for changed behavior or record N/A | `bun test ./packages/yjs/src/lib/BaseYjsPlugin.init.spec.ts ./packages/yjs/src/lib/providers/hocuspocus-provider.spec.ts ./packages/yjs/src/lib/providers/indexeddb-provider.spec.ts ./packages/yjs/src/lib/providers/registry.spec.ts ./packages/yjs/src/lib/providers/webrtc-provider.spec.ts` passed: 36 tests, 186 expects. |
+| TypeScript or typed config changed | yes | Run relevant typecheck | `pnpm turbo typecheck --filter=./packages/yjs` passed. |
+| Package exports or file layout changed | yes | Run `pnpm brl` before final verification and keep generated barrel updates | `pnpm brl` passed and updated `packages/yjs/src/lib/providers/index.ts`. |
+| Package manifests, lockfile, or install graph changed | yes | Run `pnpm install` and relevant package checks | `pnpm install` updated lockfile; `pnpm check` passed. |
+| Agent rules or skills changed | no | Run `pnpm install` and verify generated skill sync | N/A: no `.agents/**` or generated skill changes. |
+| Workspace authority proof | yes | Run verification in the owning repo/package/app/route/tool and record cwd; do not count the wrong workspace as proof | All commands ran in `/Users/zbeyens/git/plate`; focused tests target `packages/yjs`. |
+| Browser surface changed | no | Capture Browser Use proof or record explicit waiver/blocker | N/A: package API/docs text change; user explicitly said no demo needed if env setup is required. |
+| Browser final proof | no | Attach screenshot or exact browser verification caveat when browser proof applies | N/A: no browser proof required for this package/docs API task. |
+| CI-controlled template output changed | no | Restore generated template output or record why it is intentionally kept | N/A: no `templates/**` changes. |
+| Package behavior or public API changed | yes | Add a changeset or record why no changeset applies | `.changeset/yjs-indexeddb-provider.md` adds a minor changeset for `@platejs/yjs`. |
+| User-visible registry output changed | no | Use the registry-changelog pack: add/update `apps/www/src/registry/changelog/entries/*.mdx`, run `node tooling/scripts/generate-ui-changelog-entries.mjs --write`, run `node tooling/scripts/generate-ui-changelog-entries.mjs --check`, or record N/A | N/A: no `apps/www/src/registry/**` user-visible registry output changed. |
+| Docs or content changed | yes | For docs-heavy work, use `--template docs`; for incidental docs, verify source-backed claims, links, examples, and rendered output or record N/A | Docs claim audit against `BaseYjsPlugin`, provider types, registry, and wrappers; `pnpm --filter www build:source` passed. |
+| High-risk mini gate | yes | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | Risks: doc mismatch, fallback seeding over local persistence, DB-open leaks. Covered by provider/init tests and clean autoreview. |
+| Agent-native review for agent/tooling changes | no | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | N/A: no agent/tooling changes. |
+| Local install corruption suspected | no | Run `pnpm run reinstall` once, rerun the exact failing command, or record N/A | N/A: no install-corruption signature; normal `pnpm install` handled dependency graph. |
+| Autoreview for non-trivial implementation changes | yes | Load `.agents/skills/autoreview/SKILL.md`; use dirty local `--mode local`, branch/PR `--mode branch --base <base>`, or committed slice `--mode commit --commit <ref>` until no accepted/actionable findings, or record N/A for docs-only/trivial/no local patch | `.agents/skills/autoreview/scripts/autoreview --mode local` passed clean after accepted lifecycle/data-safety fixes. |
+| PR create or update | yes | Run `check` before PR work and sync PR body to the task-style final handoff | `pnpm check` passed before PR creation. |
+| Task-style PR body verified | yes | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the kitcn PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | `gh pr view 5027 --json url,title,body,headRefName,baseRefName,isDraft` verified auto-release block, `Completes udecode/plate#4650`, confidence line, required phase table, Outcome/Caveat/Design/Verified sections, and no current-PR self-link. |
+| PR proof image hosting | no | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | N/A: no browser proof image. |
+| Tracker sync-back | yes | Post concise issue/Linear sync after PR exists, or record N/A/blocker | Commented on #4650: https://github.com/udecode/plate/pull/4650#issuecomment-4711461056 |
+| Final handoff contract | yes | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | Filled below with PR #5027, tracker comment, confidence, browser N/A, and verification list. |
+| Final lint | yes | Run `pnpm lint:fix` or scoped equivalent | `pnpm lint:fix` passed; `pnpm check` lint passed with one existing sidebar warning. |
+| Output budget discipline | yes | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | One early broad `rg` over docs produced too much output; recovered with targeted reads. |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-15-4650-indexeddb-yjs-provider.md` | Running as the final closeout check. |
+| Public API / package boundary proof | yes | Source-audit public API, exports, and package boundary impact | `DefaultYjsProviderType`, `YjsProviderConfig`, provider registry, barrel export, docs, README, and package dependency updated. |
+| Release artifact classification | yes | Record whether the change is published package behavior/API/types/config/runtime, registry-only, or no published user-visible delta | Published package behavior/API/types/runtime delta for `@platejs/yjs`. |
+| Published package changeset | yes | If published package users see a delta, load `changeset`, add/update one `.changeset/*.md` per package, and prove no forbidden `minor` on `@platejs/slate`, `@platejs/core`, or `platejs` | `.changeset/yjs-indexeddb-provider.md` minor for `@platejs/yjs`; no forbidden core/slate/platejs minor. |
+| Registry changelog | no | If the change is registry-only under `apps/www/src/registry/**`, use the `registry-changelog` pack and do not add a package changeset | N/A: package feature, not registry-only. |
+| No release artifact | no | If no artifact is needed, record the exact reason: internal-only, docs-only, agent-only, test-only, or no user-visible delta from `main` | N/A: release artifact required and added. |
+| Package typecheck/build/test | yes | Run owning package checks or record N/A with reason | Focused Yjs suite, `pnpm turbo typecheck --filter=./packages/yjs`, and full `pnpm check` passed. |
+| Barrel/export generation | yes | Run `pnpm brl` when exports or exported file layout changed, otherwise N/A | `pnpm brl` passed. |
+| Docs source-backed claim audit | yes | Verify docs claims against current source or record N/A | Docs examples match `providers: [{ type: 'indexeddb', options: { docName } }]`, registry/type exports, and package dependency shape. |
+| Docs links / routes / previews | yes | Verify leaf links, routes, anchors, and preview names or record N/A | Docs edit adds package/API reference prose only; no new preview route. Existing links kept. |
+| Docs MDX/content parser | yes | Run `pnpm --filter www build:contentlayer` for MDX/content changes, or record N/A | `pnpm --filter www build:source` passed for Fumadocs source generation. |
+| Plugin page specifics | yes | For plugin pages, apply `docs-creator` kit/manual/API rules; otherwise N/A | `docs-creator` loaded; docs written as current-state reference, not migration/changelog prose. |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+|-------|--------|----------|------|
+| Intake and source read | complete | PR #4650 source/review/diff, provider registry/types, BaseYjsPlugin, docs page/README, y-indexeddb types, relevant Yjs solution note. | implementation |
+| Implementation | complete | `IndexeddbProviderWrapper`, provider lifecycle state, registry/types/export, package dependency, README/docs, and changeset added. | verification |
+| Verification | complete | Focused Yjs suite, package typecheck, docs source build, lint, autoreview, `pnpm brl`, and `pnpm check` passed. | PR / tracker sync |
+| PR / tracker sync | complete | PR #5027 opened and body verified; #4650 sync-back comment posted. | closeout |
+| Closeout | complete | This plan records final evidence and is ready for autogoal completion check. | final response |
+
+Findings:
+- PR #4650 is a conflicting draft with useful intent but incomplete/stale implementation.
+- `y-indexeddb@9.0.12` exports `IndexeddbPersistence(name: string, doc: Y.Doc)`, not `IndexeddbProvider`.
+- Current `BaseYjsPlugin` creates providers through `createProvider({ awareness, doc: ydoc, options, type, handlers })`; IndexedDB must use that shared `doc`, not an options-owned `ydoc`.
+- `packages/yjs/README.md` still teaches removed `providerConfigs`, `customProviders`, and `waitForAllProviders`; the docs page uses the current `providers` option.
+- Peer-only `y-indexeddb` would make the exported provider import unsafe for consumers; `y-indexeddb` belongs in `dependencies`.
+
+Decisions and tradeoffs:
+- Defer `IndexeddbPersistence` construction until `connect()` so `autoConnect: false` does not silently start local persistence.
+- Keep `docName` as the only IndexedDB option; the plugin owns `Y.Doc` and `Awareness`.
+- `disconnect()` destroys the local persistence binding and allows reconnect to create a fresh binding; `destroy()` permanently prevents reconnect.
+- Awareness is retained only to satisfy `UnifiedProvider`; IndexedDB does not transport awareness.
+- Local persistence is not a network sync source: it can unblock init only when it restores real shared state, and fallback seeding is skipped while local persistence is still loading.
+
+Implementation notes:
+- Added `packages/yjs/src/lib/providers/indexeddb-provider.spec.ts`.
+- Added `packages/yjs/src/lib/providers/indexeddb-provider.ts`.
+- Added `indexeddb` to `DefaultYjsProviderType`, `YjsProviderConfig`, and provider registry.
+- Added `y-indexeddb` dependency and ran `pnpm install`.
+- Rewrote the package README around the current `providers` API and documented IndexedDB in the docs page and Chinese docs page.
+
+Review fixes:
+- Autoreview P1: empty local persistence could satisfy the network sync gate; fixed by treating IndexedDB as local persistence and gating initial sync/fallback seeding.
+- Autoreview P2: exported provider import made peer-only `y-indexeddb` unsafe; fixed by making `y-indexeddb` a direct dependency.
+- Autoreview P1/P2 follow-ups: persisted empty Yjs content, including custom `sharedType`, could be overwritten; fixed with shared-root state/tombstone detection and tests.
+- Autoreview P2/P3 follow-ups: IndexedDB open failure and fast disconnect before open could leak listeners or report false connection state; fixed with connection/sync-loading lifecycle signals, cleanup, and tests.
+
+Error attempts:
+| Error / failed attempt | Count | Next different move | Resolution |
+|------------------------|-------|---------------------|------------|
+| Broad `rg` over `docs/solutions docs/plans` streamed too much output | 1 | Use exact solution file reads and capped targeted searches only | Recovered by reading only the Yjs slow-test solution hit. |
+| Registry-first test run could cache the provider before the provider spec mock | 1 | Import provider spec with a unique query per harness | Fixed; registry-first combined test now passes. |
+
+Verification evidence:
+- RED: `bun test ./packages/yjs/src/lib/providers/indexeddb-provider.spec.ts` failed with missing `./indexeddb-provider` before implementation.
+- GREEN: `bun test ./packages/yjs/src/lib/providers/indexeddb-provider.spec.ts` passed: 4 tests, 32 expects.
+- GREEN: `bun test ./packages/yjs/src/lib/providers/registry.spec.ts ./packages/yjs/src/lib/providers/indexeddb-provider.spec.ts` passed: 8 tests, 40 expects, including registry-first order.
+- GREEN: `bun test ./packages/yjs/src/lib/BaseYjsPlugin.init.spec.ts ./packages/yjs/src/lib/providers/hocuspocus-provider.spec.ts ./packages/yjs/src/lib/providers/indexeddb-provider.spec.ts ./packages/yjs/src/lib/providers/registry.spec.ts ./packages/yjs/src/lib/providers/webrtc-provider.spec.ts` passed: 36 tests, 186 expects.
+- GREEN: `pnpm turbo typecheck --filter=./packages/yjs` passed.
+- GREEN: `pnpm --filter www build:source` passed.
+- GREEN: `pnpm lint:fix` passed.
+- GREEN: `.agents/skills/autoreview/scripts/autoreview --mode local` passed clean after accepted fixes.
+- GREEN: `pnpm brl` passed.
+- GREEN: `pnpm check` passed. Existing warnings only: `apps/www/src/components/ui/sidebar.tsx` hook warning and the known multiple `@platejs/core` instance test log.
+- GREEN: `gh pr view 5027 --json url,title,body,headRefName,baseRefName,isDraft` verified PR body format.
+
+Final handoff contract:
+- PR line: https://github.com/udecode/plate/pull/5027
+- Issue / tracker line: https://github.com/udecode/plate/pull/4650#issuecomment-4711461056
+- Confidence line: 95% confidence
+- Flow table:
+  - Reproduced: source audit plus RED provider test; browser N/A.
+  - Verified: focused tests, package typecheck, docs source build, lint, autoreview, `pnpm brl`, `pnpm check`; browser N/A.
+- Browser check: N/A: package API/docs work; user waived demo if env setup required.
+- Outcome: `@platejs/yjs` exposes built-in `indexeddb` provider support through current provider config/types/registry/docs.
+- Caveat: no demo/browser proof; package behavior is covered by provider/init tests and full repo check.
+- Design:
+  - Chosen boundary: `@platejs/yjs` provider registry/types/wrapper/docs.
+  - Why not quick patch: stale PR implementation had doc ownership/lifecycle/release/doc gaps.
+  - Why not broader change: no need to redesign the collaboration API; current `providers` API is sufficient.
+- Verified: see verification evidence above.
+- PR body verified: yes, with `gh pr view 5027 --json url,title,body,headRefName,baseRefName,isDraft`.
+
+Task-style PR body contract:
+- Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
+  part of the diff and repo policy expects auto release, include that block.
+- Use the accepted kitcn PR #270 visual format. The body starts with an emoji
+  issue/tracker/fix line, for example `🐛 Fixes #123` or `🐛 Fixes ➖ N/A`, then
+  an emoji confidence line like `🟢 95-100% confidence`.
+- Use this exact table header: `| Phase | 🧪 Tests | 🌐 Browser |`.
+- Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
+  failing proof with `🔴`, and non-applicable cells with `➖ N/A`.
+- Use bold emoji section headings: `**✅ Outcome**`, `**⚠️ Caveat**`,
+  `**🏗️ Design**`, and `**🧪 Verified**`.
+- Never include a line that links to the current PR itself. The current PR URL
+  belongs in the final response, not in its own description.
+- Do not replace this with a generic `Summary` / `Verification` PR body, an
+  adaptive prose body from a git helper skill, plain `## Outcome` sections, or
+  an unrelated generated badge footer unless the caller or repo template
+  explicitly asks for it.
+- Proof is `gh pr view --json body` output or a concise source-backed summary
+  of that output.
+
+Final handoff / sync:
+- PR: https://github.com/udecode/plate/pull/5027
+- Issue / tracker: https://github.com/udecode/plate/pull/4650#issuecomment-4711461056
+- Browser proof: N/A: package API/docs work; no demo needed per user.
+- Caveats: PR has one existing lint warning from `apps/www/src/components/ui/sidebar.tsx` during `pnpm check`; no failing checks locally.
+
+Timeline:
+- 2026-06-15T18:07:42.254Z Task goal plan created.
+
+Reboot status:
+| Question | Answer |
+|----------|--------|
+| Where am I? | Intake and source read |
+| Where am I going? | Final response |
+| What is the goal? | Complete #4650 replacement IndexedDB Yjs provider with package docs, changeset, checks, PR, and tracker sync. |
+| What have I learned? | #4650 is partially valid but stale; durable boundary is `@platejs/yjs` provider registry/type/docs/lifecycle. |
+| What have I done? | Implemented and verified the replacement provider, opened PR #5027, and synced back to #4650. |
+
+Open risks:
+- Remote CI still needs to run on PR #5027.

--- a/packages/yjs/README.md
+++ b/packages/yjs/README.md
@@ -1,385 +1,175 @@
-# Plate yjs plugin
+# Plate Yjs plugin
 
-This package implements the yjs plugin for Plate with support for both Hocuspocus and WebRTC providers.
+`@platejs/yjs` binds Plate editors to a shared Yjs document. It ships provider wrappers for IndexedDB, Hocuspocus, and WebRTC, and accepts custom providers that implement the same `UnifiedProvider` interface.
 
-## Documentation
+Read the main docs at [platejs.org/docs/yjs](https://platejs.org/docs/yjs).
 
-Check out [Collaboration](https://platejs.org/docs/yjs) for the main documentation.
+## Installation
 
-### Installation
-
-This package only requires the providers you actually use. Each provider package is an optional dependency:
+Install the plugin.
 
 ```bash
-# Base installation
 npm install @platejs/yjs
+```
 
-# For Hocuspocus server-based collaboration
+Install network provider packages as needed:
+
+```bash
 npm install @hocuspocus/provider
+```
 
-# For WebRTC peer-to-peer collaboration
+```bash
 npm install y-webrtc
-
-# For IndexedDB persistence (optional)
-npm install y-indexeddb
 ```
 
-### Provider Configuration
+## Usage
 
-The plugin supports two types of providers out of the box, with full type safety:
+Configure `YjsPlugin` with a `providers` array. Every configured provider receives the same plugin-owned `Y.Doc` and `Awareness` instance.
 
-1. **Hocuspocus Provider**
+```tsx
+import { YjsPlugin } from '@platejs/yjs/react';
+import { createPlateEditor } from 'platejs/react';
 
-   - Server-based collaboration using WebSocket
-   - Suitable for large-scale applications
-   - Requires a Hocuspocus server
-
-2. **WebRTC Provider**
-   - Peer-to-peer collaboration using WebRTC
-   - No server required (except for signaling)
-   - Best for small to medium-sized groups
-
-Configuration is done using the `providerConfigs` array with provider-specific type checking:
-
-```typescript
-import { YjsPlugin } from '@platejs/yjs';
-import * as Y from 'yjs';
-
-// Create a Y.Doc (or use an existing one)
-const ydoc = new Y.Doc();
-
-const plugins = [
-  // ... other plugins
-  YjsPlugin({
-    ydoc, // Pass your Y.Doc
-    providerConfigs: [
-      // Hocuspocus provider with type-checked options
-      {
-        type: 'hocuspocus',
-        options: {
-          url: 'ws://localhost:1234',
-          name: 'document-name',
-        },
+const editor = createPlateEditor({
+  plugins: [
+    YjsPlugin.configure({
+      options: {
+        providers: [
+          {
+            type: 'indexeddb',
+            options: {
+              docName: 'document-1',
+            },
+          },
+          {
+            type: 'hocuspocus',
+            options: {
+              name: 'document-1',
+              url: 'wss://collab.example.com',
+            },
+          },
+          {
+            type: 'webrtc',
+            options: {
+              roomName: 'document-1',
+            },
+          },
+        ],
       },
-      // WebRTC provider with type-checked options
-      {
-        type: 'webrtc',
-        options: {
-          roomName: 'document-1',
-          signaling: ['ws://127.0.0.1:4444'],
-        },
-      },
-    ],
-    // Optional: wait for all providers to sync before showing content
-    waitForAllProviders: false, // Default is false
-  }),
-];
+    }),
+  ],
+  skipInitialization: true,
+});
 ```
 
-The configuration is fully type-safe, so you'll get autocomplete and type checking for provider-specific options.
+Call `init` after the editor mounts, and call `destroy` when it unmounts:
 
-### Using Custom Providers (Like IndexedDB)
+```tsx
+await editor.getApi(YjsPlugin).yjs.init({
+  id: 'document-1',
+  value: initialValue,
+});
 
-The plugin now supports passing in pre-instantiated providers that implement the `UnifiedProvider` interface. This is especially useful for:
+editor.getApi(YjsPlugin).yjs.destroy();
+```
 
-1. **Using providers that aren't built-in**, like IndexedDB for offline persistence
-2. **Configuring providers with custom logic** beyond what the built-in options support
-3. **Sharing provider instances** across different parts of your application
+## Providers
 
-Here's an example using IndexedDB for offline persistence:
+| Type | Package | Purpose | Options |
+| --- | --- | --- | --- |
+| `indexeddb` | `y-indexeddb` | Browser-local document persistence | `{ docName: string }` |
+| `hocuspocus` | `@hocuspocus/provider` | WebSocket server collaboration | `HocuspocusProviderConfiguration` |
+| `webrtc` | `y-webrtc` | Peer-to-peer collaboration | `{ roomName: string; signaling?: string[]; password?: string; maxConns?: number; peerOpts?: object }` |
 
-```typescript
-import { YjsPlugin } from '@platejs/yjs';
+Use the same document identifier across providers that should share one document. For example, pair `docName: 'document-1'` with `name: 'document-1'` or `roomName: 'document-1'`.
+
+IndexedDB only persists Yjs updates locally. It does not transport awareness, cursors, or remote users; combine it with Hocuspocus or WebRTC for multi-user collaboration.
+
+## Shared Documents
+
+Pass `ydoc` when another part of your app owns the document:
+
+```tsx
 import * as Y from 'yjs';
-import { IndexeddbProvider } from 'y-indexeddb';
-import { Awareness } from 'y-protocols/awareness';
 
-// Create a Y.Doc
 const ydoc = new Y.Doc();
 
-// First, create the actual IndexedDB provider
-const indexedDBInstance = new IndexeddbProvider('my-document', ydoc);
-
-// Then wrap it to implement the UnifiedProvider interface
-const indexedDBProvider = {
-  // Required properties
-  type: 'indexeddb',
-  document: ydoc,
-  awareness: new Awareness(ydoc),
-  isConnected: true,
-  isSynced: false,
-
-  // Store the actual provider instance
-  _provider: indexedDBInstance,
-
-  // Required methods
-  connect: function () {
-    // IndexedDB is always "connected" locally
-    this.isConnected = true;
-    // Mark as synced once connected
-    this.isSynced = true;
-  },
-  disconnect: function () {
-    this.isConnected = false;
-    this.isSynced = false;
-  },
-  destroy: function () {
-    // Clean up the actual provider
-    this._provider.destroy();
-    this.disconnect();
-  },
-};
-
-// Use your custom provider with the plugin
-const plugins = [
-  YjsPlugin({
+YjsPlugin.configure({
+  options: {
     ydoc,
-    // Pass your pre-instantiated providers
-    customProviders: [indexedDBProvider],
-    // You can still use built-in providers alongside custom ones
-    providerConfigs: [
+    providers: [
       {
-        type: 'webrtc',
+        type: 'indexeddb',
         options: {
-          roomName: 'document-1',
+          docName: 'document-1',
         },
       },
     ],
-  }),
-];
+  },
+});
 ```
 
-The plugin will handle initializing, connecting, and synchronizing with all providers, regardless of whether they're built-in or custom. State tracking is maintained across all provider types.
+Use `sharedType` when the editor content lives inside a nested `Y.XmlText`:
 
-### Multiple Providers and Fallbacks
-
-You can use multiple providers simultaneously with the same Y.Doc for different synchronization strategies:
-
-```typescript
-import { YjsPlugin } from '@platejs/yjs';
-import * as Y from 'yjs';
-
-// Create a shared Y.Doc
-const ydoc = new Y.Doc();
-
-const plugins = [
-  // ... other plugins
-  YjsPlugin({
-    ydoc,
-    providerConfigs: [
-      {
-        type: 'webrtc',
-        options: {
-          roomName: 'document-1',
-        },
-      },
-      {
-        type: 'hocuspocus',
-        options: {
-          url: 'ws://localhost:1234',
-          name: 'document-1',
-        },
-      },
-    ],
-    // Wait for all providers to sync before showing content
-    waitForAllProviders: true,
-  }),
-];
-```
-
-#### How Multiple Providers Work Together
-
-When you configure multiple providers:
-
-1. All providers share the same Y.Doc instance
-2. Data changes are automatically synced between all connected providers
-3. If one provider (e.g., Hocuspocus server) goes down, other providers (e.g., WebRTC) continue to work
-4. When a provider reconnects, it automatically syncs with the latest state
-5. The plugin keeps track of how many providers are synced using a counter system
-
-This lets you create robust setups like:
-
-- WebRTC for fast peer-to-peer editing with Hocuspocus for server persistence
-- Multiple Hocuspocus providers for fallback server connections
-- Custom IndexedDB provider for offline persistence
-- Any combination that suits your reliability and performance needs
-
-By default, content will be shown as soon as at least one provider is synced. If `waitForAllProviders` is set to `true`, content will only appear when all configured providers are in sync.
-
-### Using Nested Y.Doc Structures
-
-By default, the plugin uses `ydoc.get('content', Y.XmlText)` for storing editor content. However, you can use the `sharedType` option to work with nested structures from a parent Y.Doc:
-
-```typescript
-import { YjsPlugin } from '@platejs/yjs';
-import * as Y from 'yjs';
-
-// Create a parent document with multiple nested editors
+```tsx
 const parentDoc = new Y.Doc();
+const editors = parentDoc.getMap('editors');
+const mainContent = new Y.XmlText();
 
-// Create nested structures for different editors
-const editorsMap = parentDoc.getMap('editors');
-const mainEditorContent = new Y.XmlText();
-const sidebarEditorContent = new Y.XmlText();
+editors.set('main', mainContent);
 
-// Store them in the parent doc
-editorsMap.set('main', mainEditorContent);
-editorsMap.set('sidebar', sidebarEditorContent);
-
-// You can also store other data in the parent doc
-const metadata = parentDoc.getMap('metadata');
-metadata.set('title', 'My Document');
-metadata.set('author', 'John Doe');
-metadata.set('createdAt', Date.now());
-
-// Create the main editor with the nested shared type
-const mainEditor = createPlateEditor({
-  plugins: [
-    YjsPlugin.configure({
-      ydoc: parentDoc, // Pass the parent doc for provider sync
-      sharedType: mainEditorContent, // Use the specific nested content
-      providers: [
-        {
-          type: 'webrtc',
-          options: { roomName: 'my-document' },
+YjsPlugin.configure({
+  options: {
+    sharedType: mainContent,
+    ydoc: parentDoc,
+    providers: [
+      {
+        type: 'indexeddb',
+        options: {
+          docName: 'document-1',
         },
-      ],
-    }),
-  ],
-});
-
-// Create a sidebar editor with its own nested shared type
-const sidebarEditor = createPlateEditor({
-  plugins: [
-    YjsPlugin.configure({
-      ydoc: parentDoc, // Same parent doc
-      sharedType: sidebarEditorContent, // Different nested content
-      providers: [], // Don't create new providers, parent is already synced
-    }),
-  ],
-});
-
-// Initialize with initial values - they'll be applied to the correct sharedTypes
-await mainEditor.api.yjs.init({
-  autoConnect: true,
-  value: [{ type: 'p', children: [{ text: 'Main editor content' }] }],
-});
-await sidebarEditor.api.yjs.init({
-  autoConnect: false,
-  value: [{ type: 'p', children: [{ text: 'Sidebar content' }] }],
-});
-```
-
-**Important:** When using a custom `sharedType`, the initial `value` passed to `init()` will be applied directly to that specific `sharedType`, not to the default `ydoc.get('content', Y.XmlText)`. This ensures each editor's initial content goes to the correct location in your nested structure.
-
-### Cursor Support
-
-Collaborative cursors are enabled by default. You can customize their appearance and behavior:
-
-```typescript
-YjsPlugin({
-  ydoc,
-  providerConfigs: [/* providers */],
-  cursorOptions: {
-    // Custom cursor options
-    cursorData: {
-      name: 'User Name',
-      color: '#f00',
-    },
+      },
+    ],
   },
-  // Alternatively, set disableCursors: true to disable cursors completely
-}),
+});
 ```
 
-### Custom Provider Registration
+## Custom Providers
 
-For more complex scenarios, you can register your own provider types for the plugin to create automatically:
+Use a pre-instantiated provider directly when you need behavior outside the built-in wrappers:
 
-```typescript
+```tsx
+import type { UnifiedProvider } from '@platejs/yjs';
+
+const provider: UnifiedProvider = new MyProvider({ awareness, doc: ydoc });
+
+YjsPlugin.configure({
+  options: {
+    providers: [provider],
+  },
+});
+```
+
+Register reusable provider classes with `registerProviderType`:
+
+```tsx
 import { registerProviderType } from '@platejs/yjs';
-import * as Y from 'yjs';
-import { Awareness } from 'y-protocols/awareness';
-import { ProviderEventHandlers } from '@platejs/yjs';
 
-// Create a custom provider class that implements UnifiedProvider interface
-class CustomProviderWrapper {
-  type = 'custom';
-  private _awareness: Awareness;
-  private _document: Y.Doc;
-  private _isConnected = false;
-  private _isSynced = false;
-  private handlers?: ProviderEventHandlers;
-
-  constructor(options, handlers, ydoc, awareness) {
-    this.handlers = handlers;
-    this._document = ydoc || new Y.Doc();
-    this._awareness = awareness || new Awareness(this._document);
-    // Setup your provider using the options...
-  }
-
-  // Required methods from UnifiedProvider interface
-  connect() {
-    // Implementation that connects to your service
-    this._isConnected = true;
-    // When you connect and become synced:
-    this._isSynced = true;
-    this.handlers?.onSyncChange?.(true);
-  }
-
-  disconnect() {
-    // Implementation to disconnect
-    this._isConnected = false;
-
-    // If we were synced, report sync state change
-    if (this._isSynced) {
-      this._isSynced = false;
-      this.handlers?.onSyncChange?.(false);
-    }
-  }
-
-  destroy() {
-    // Clean up resources
-    this.disconnect();
-  }
-
-  get awareness() {
-    return this._awareness;
-  }
-
-  get document() {
-    return this._document;
-  }
-
-  get isConnected() {
-    return this._isConnected;
-  }
-
-  get isSynced() {
-    return this._isSynced;
-  }
-}
-
-// Register your custom provider type
 registerProviderType('custom', CustomProviderWrapper);
 
-// Then use it in your config just like built-in providers
-YjsPlugin({
-  ydoc,
-  providerConfigs: [
-    {
-      type: 'custom', // Use your registered type
-      options: {
-        // Custom options for your provider
+YjsPlugin.configure({
+  options: {
+    providers: [
+      {
+        type: 'custom',
+        options: {
+          roomName: 'document-1',
+        },
       },
-    },
-  ],
+    ],
+  },
 });
 ```
-
-> **Note:** There are two ways to use custom providers:
->
-> 1. Use `customProviders` to pass pre-instantiated provider objects (simpler for one-off usage)
-> 2. Use `registerProviderType` to register a provider class that can be created via `providerConfigs` (better for reusable providers)
 
 ## License
 

--- a/packages/yjs/package.json
+++ b/packages/yjs/package.json
@@ -44,6 +44,7 @@
     "@slate-yjs/core": "^1.0.2",
     "react-compiler-runtime": "^1.0.0",
     "y-protocols": "^1.0.7",
+    "y-indexeddb": "^9.0.12",
     "yjs": "^13.6.29"
   },
   "devDependencies": {

--- a/packages/yjs/src/lib/BaseYjsPlugin.init.spec.ts
+++ b/packages/yjs/src/lib/BaseYjsPlugin.init.spec.ts
@@ -23,6 +23,7 @@ const createEditor = (options: Record<string, unknown> = {}) => {
   spyOn(editor.tf, 'init').mockImplementation(() => {});
   spyOn(editor.api, 'onChange').mockImplementation(() => {});
   spyOn(YjsEditor, 'connect').mockImplementation(() => {});
+  spyOn(YjsEditor, 'disconnect').mockImplementation(() => {});
 
   return editor;
 };
@@ -314,6 +315,360 @@ describe('BaseYjsPlugin init', () => {
       'editor.api.onChange',
       'onReady',
     ]);
+  });
+
+  it('keeps pre-instantiated IndexedDB providers as provider instances', async () => {
+    const ydoc = new Y.Doc({ guid: 'doc-1' });
+    const provider = new providersModule.IndexeddbProviderWrapper({
+      doc: ydoc,
+      options: { docName: 'document-1' },
+    });
+    const connectSpy = spyOn(provider, 'connect').mockImplementation(() => {});
+    const editor = createEditor({
+      providers: [provider],
+      ydoc,
+    });
+
+    await editor.api.yjs.init({
+      autoConnect: false,
+      value: [{ type: 'p', children: [{ text: 'hello' }] }] as any,
+    });
+
+    expect(connectSpy).not.toHaveBeenCalled();
+    expect(provider.provider).toBeNull();
+
+    editor.api.yjs.connect();
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up providers with pending connection attempts', async () => {
+    const disconnectProvider = createMockProvider({ type: 'indexeddb' });
+    let disconnectPending = false;
+    Object.defineProperty(disconnectProvider, 'isConnectionPending', {
+      get: () => disconnectPending,
+    });
+    disconnectProvider.connect.mockImplementation(() => {
+      disconnectPending = true;
+    });
+    disconnectProvider.disconnect.mockImplementation(() => {
+      disconnectPending = false;
+    });
+    const disconnectEditor = createEditor({
+      providers: [disconnectProvider],
+    });
+
+    await disconnectEditor.api.yjs.init({
+      autoConnect: false,
+      value: [{ type: 'p', children: [{ text: 'hello' }] }] as any,
+    });
+
+    disconnectEditor.api.yjs.connect('indexeddb');
+    disconnectEditor.api.yjs.disconnect('indexeddb');
+
+    expect(disconnectProvider.disconnect).toHaveBeenCalledTimes(1);
+
+    const destroyProvider = createMockProvider({ type: 'indexeddb' });
+    Object.defineProperty(destroyProvider, 'isConnectionPending', {
+      get: () => true,
+    });
+    const destroyEditor = createEditor({
+      providers: [destroyProvider],
+    });
+
+    await destroyEditor.api.yjs.init({
+      autoConnect: false,
+      value: [{ type: 'p', children: [{ text: 'hello' }] }] as any,
+    });
+
+    destroyEditor.api.yjs.destroy();
+
+    expect(destroyProvider.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let empty local persistence sync satisfy the initial network sync gate', async () => {
+    const localProvider = createMockProvider({ type: 'indexeddb' });
+    localProvider.isLocalPersistence = true;
+    const remoteProvider = createMockProvider({ type: 'webrtc' });
+    const localType = registerTestProviderType(({ onSyncChange }) => {
+      localProvider.connect.mockImplementation(() => {
+        localProvider.setConnected(true);
+        localProvider.setSynced(true);
+        onSyncChange?.(true);
+      });
+
+      return localProvider;
+    });
+    const remoteType = registerTestProviderType(() => {
+      remoteProvider.connect.mockImplementation(() => {
+        remoteProvider.setConnected(true);
+      });
+
+      return remoteProvider;
+    });
+    const realSetTimeout = globalThis.setTimeout;
+    let timeoutCallback: () => void = () => {
+      throw new Error('timeout callback was not captured');
+    };
+    spyOn(globalThis, 'setTimeout').mockImplementation(((
+      callback: TimerHandler
+    ) => {
+      timeoutCallback = callback as () => void;
+
+      return 1 as any;
+    }) as any);
+    const editor = createEditor({
+      providers: [
+        { options: { docName: 'document-1' }, type: localType },
+        { options: { roomName: 'document-1' }, type: remoteType },
+      ],
+    });
+
+    const initPromise = editor.api.yjs.init({
+      autoConnect: true,
+      value: [{ type: 'p', children: [{ text: 'local value' }] }] as any,
+    });
+    let settled = false;
+    void initPromise.then(() => {
+      settled = true;
+    });
+
+    await new Promise<void>((resolve) => realSetTimeout(resolve, 0));
+
+    expect(localProvider.connect).toHaveBeenCalledTimes(1);
+    expect(remoteProvider.connect).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
+    expect(YjsEditor.connect).not.toHaveBeenCalled();
+
+    timeoutCallback();
+    await initPromise;
+
+    expect(YjsEditor.connect).toHaveBeenCalledTimes(1);
+    expect(
+      getSharedChildren(editor.getPlugin(BaseYjsPlugin).options.ydoc)
+    ).toEqual([{ type: 'p', children: [{ text: 'local value' }] }]);
+  });
+
+  it('does not seed fallback content while local persistence is still pending', async () => {
+    const localProvider = createMockProvider({ type: 'indexeddb' });
+    localProvider.isLocalPersistence = true;
+    Object.defineProperty(localProvider, 'isSyncPending', {
+      get: () => true,
+    });
+    const remoteProvider = createMockProvider({ type: 'webrtc' });
+    const localType = registerTestProviderType(() => {
+      localProvider.connect.mockImplementation(() => {
+        localProvider.setConnected(true);
+      });
+
+      return localProvider;
+    });
+    const remoteType = registerTestProviderType(() => {
+      remoteProvider.connect.mockImplementation(() => {
+        remoteProvider.setConnected(true);
+      });
+
+      return remoteProvider;
+    });
+    let timeoutCallback: () => void = () => {
+      throw new Error('timeout callback was not captured');
+    };
+    spyOn(globalThis, 'setTimeout').mockImplementation(((
+      callback: TimerHandler
+    ) => {
+      timeoutCallback = callback as () => void;
+
+      return 1 as any;
+    }) as any);
+    const editor = createEditor({
+      providers: [
+        { options: { docName: 'document-1' }, type: localType },
+        { options: { roomName: 'document-1' }, type: remoteType },
+      ],
+    });
+    const deterministicSpy = spyOn(
+      deterministicStateModule,
+      'slateToDeterministicYjsState'
+    );
+
+    const initPromise = editor.api.yjs.init({
+      autoConnect: true,
+      value: [{ type: 'p', children: [{ text: 'fallback value' }] }] as any,
+    });
+
+    timeoutCallback();
+    await initPromise;
+
+    expect(deterministicSpy).not.toHaveBeenCalled();
+    expect(YjsEditor.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses local persistence sync immediately when it hydrates shared content', async () => {
+    const localProvider = createMockProvider({ type: 'indexeddb' });
+    localProvider.isLocalPersistence = true;
+    const remoteProvider = createMockProvider({ type: 'webrtc' });
+    const localType = registerTestProviderType(({ doc, onSyncChange }) => {
+      localProvider.connect.mockImplementation(() => {
+        const sharedRoot = doc.get('content', Y.XmlText) as Y.XmlText;
+
+        sharedRoot.insert(0, 'restored');
+        localProvider.setConnected(true);
+        localProvider.setSynced(true);
+        onSyncChange?.(true);
+      });
+
+      return localProvider;
+    });
+    const remoteType = registerTestProviderType(() => {
+      remoteProvider.connect.mockImplementation(() => {
+        remoteProvider.setConnected(true);
+      });
+
+      return remoteProvider;
+    });
+    const realSetTimeout = globalThis.setTimeout;
+    spyOn(globalThis, 'setTimeout').mockImplementation((() => 1) as any);
+    const editor = createEditor({
+      providers: [
+        { options: { docName: 'document-1' }, type: localType },
+        { options: { roomName: 'document-1' }, type: remoteType },
+      ],
+    });
+    const deterministicSpy = spyOn(
+      deterministicStateModule,
+      'slateToDeterministicYjsState'
+    );
+
+    const initPromise = editor.api.yjs.init({
+      autoConnect: true,
+      value: [{ type: 'p', children: [{ text: 'local value' }] }] as any,
+    });
+    let settled = false;
+    void initPromise.then(() => {
+      settled = true;
+    });
+
+    await new Promise<void>((resolve) => realSetTimeout(resolve, 0));
+    await initPromise;
+
+    expect(settled).toBe(true);
+    expect(deterministicSpy).not.toHaveBeenCalled();
+    expect(YjsEditor.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves empty content restored from local persistence', async () => {
+    const localProvider = createMockProvider({ type: 'indexeddb' });
+    localProvider.isLocalPersistence = true;
+    const remoteProvider = createMockProvider({ type: 'webrtc' });
+    const localType = registerTestProviderType(({ doc, onSyncChange }) => {
+      localProvider.connect.mockImplementation(() => {
+        const sharedRoot = doc.get('content', Y.XmlText) as Y.XmlText;
+
+        sharedRoot.insert(0, 'deleted offline');
+        sharedRoot.delete(0, 'deleted offline'.length);
+        localProvider.setConnected(true);
+        localProvider.setSynced(true);
+        onSyncChange?.(true);
+      });
+
+      return localProvider;
+    });
+    const remoteType = registerTestProviderType(() => {
+      remoteProvider.connect.mockImplementation(() => {
+        remoteProvider.setConnected(true);
+      });
+
+      return remoteProvider;
+    });
+    const realSetTimeout = globalThis.setTimeout;
+    spyOn(globalThis, 'setTimeout').mockImplementation((() => 1) as any);
+    const editor = createEditor({
+      providers: [
+        { options: { docName: 'document-1' }, type: localType },
+        { options: { roomName: 'document-1' }, type: remoteType },
+      ],
+    });
+    const deterministicSpy = spyOn(
+      deterministicStateModule,
+      'slateToDeterministicYjsState'
+    );
+
+    const initPromise = editor.api.yjs.init({
+      autoConnect: true,
+      value: [{ type: 'p', children: [{ text: 'fallback value' }] }] as any,
+    });
+    let settled = false;
+    void initPromise.then(() => {
+      settled = true;
+    });
+
+    await new Promise<void>((resolve) => realSetTimeout(resolve, 0));
+    await initPromise;
+
+    expect(settled).toBe(true);
+    expect(deterministicSpy).not.toHaveBeenCalled();
+    expect(
+      getSharedChildren(editor.getPlugin(BaseYjsPlugin).options.ydoc)
+    ).toEqual([{ text: '' }]);
+    expect(YjsEditor.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves empty custom sharedType content restored from local persistence', async () => {
+    const ydoc = new Y.Doc({ guid: 'doc-1' });
+    const customSharedType = new Y.XmlText();
+    ydoc.getMap('editors').set('main', customSharedType);
+    const localProvider = createMockProvider({ type: 'indexeddb' });
+    localProvider.isLocalPersistence = true;
+    const remoteProvider = createMockProvider({ type: 'webrtc' });
+    const localType = registerTestProviderType(({ onSyncChange }) => {
+      localProvider.connect.mockImplementation(() => {
+        customSharedType.insert(0, 'deleted offline');
+        customSharedType.delete(0, 'deleted offline'.length);
+        localProvider.setConnected(true);
+        localProvider.setSynced(true);
+        onSyncChange?.(true);
+      });
+
+      return localProvider;
+    });
+    const remoteType = registerTestProviderType(() => {
+      remoteProvider.connect.mockImplementation(() => {
+        remoteProvider.setConnected(true);
+      });
+
+      return remoteProvider;
+    });
+    const realSetTimeout = globalThis.setTimeout;
+    spyOn(globalThis, 'setTimeout').mockImplementation((() => 1) as any);
+    const editor = createEditor({
+      providers: [
+        { options: { docName: 'document-1' }, type: localType },
+        { options: { roomName: 'document-1' }, type: remoteType },
+      ],
+      sharedType: customSharedType,
+      ydoc,
+    });
+    const deterministicSpy = spyOn(
+      deterministicStateModule,
+      'slateToDeterministicYjsState'
+    );
+
+    const initPromise = editor.api.yjs.init({
+      autoConnect: true,
+      value: [{ type: 'p', children: [{ text: 'fallback value' }] }] as any,
+    });
+    let settled = false;
+    void initPromise.then(() => {
+      settled = true;
+    });
+
+    await new Promise<void>((resolve) => realSetTimeout(resolve, 0));
+    await initPromise;
+
+    expect(settled).toBe(true);
+    expect(deterministicSpy).not.toHaveBeenCalled();
+    expect(getSharedChildren(ydoc, customSharedType)).toEqual([{ text: '' }]);
+    expect(YjsEditor.connect).toHaveBeenCalledTimes(1);
   });
 
   it('forwards auto-connect provider errors through onError and still finishes init', async () => {

--- a/packages/yjs/src/lib/BaseYjsPlugin.ts
+++ b/packages/yjs/src/lib/BaseYjsPlugin.ts
@@ -27,6 +27,13 @@ const isProviderConfig = (
   'type' in item &&
   'options' in item;
 
+const hasSharedRootState = (sharedRoot: Y.XmlText) =>
+  sharedRoot.length > 0 ||
+  // Y.XmlText exposes no public "has tombstone history" check. `_start`
+  // stays set after content is deleted, which lets us preserve persisted
+  // empty documents instead of reseeding fallback content.
+  (sharedRoot as Y.XmlText & { _start?: unknown })._start != null;
+
 export const BaseYjsPlugin = createTSlatePlugin<YjsConfig>({
   key: KEYS.yjs,
   extendEditor: withPlateYjs,
@@ -113,7 +120,7 @@ export const BaseYjsPlugin = createTSlatePlugin<YjsConfig>({
 
       for (const provider of [..._providers].reverse()) {
         try {
-          if (provider.isConnected) {
+          if (provider.isConnected || provider.isConnectionPending) {
             provider.destroy();
           }
         } catch (error) {
@@ -150,7 +157,7 @@ export const BaseYjsPlugin = createTSlatePlugin<YjsConfig>({
       for (const provider of [..._providers].reverse()) {
         try {
           if (
-            provider.isConnected &&
+            (provider.isConnected || provider.isConnectionPending) &&
             (typesToDisconnect === null ||
               typesToDisconnect.includes(provider.type))
           ) {
@@ -196,6 +203,9 @@ export const BaseYjsPlugin = createTSlatePlugin<YjsConfig>({
         sharedType: customSharedType,
         ydoc,
       } = options;
+      const getSharedRoot = () =>
+        customSharedType ?? (ydoc.get('content', Y.XmlText) as Y.XmlText);
+      const hasSharedDocumentState = () => hasSharedRootState(getSharedRoot());
 
       // Validate configuration
       if (providerConfigsOrInstances.length === 0) {
@@ -206,6 +216,12 @@ export const BaseYjsPlugin = createTSlatePlugin<YjsConfig>({
 
       // Final providers array that will contain both configured and custom providers
       const finalProviders: UnifiedProvider[] = [];
+      const hasPendingLocalPersistence = () =>
+        finalProviders.some(
+          (provider) =>
+            provider.isLocalPersistence &&
+            (provider.isConnectionPending || provider.isSyncPending)
+        );
 
       // Track sync state for waiting
       let syncResolve: (() => void) | null = null;
@@ -217,6 +233,7 @@ export const BaseYjsPlugin = createTSlatePlugin<YjsConfig>({
       for (const item of providerConfigsOrInstances) {
         if (isProviderConfig(item)) {
           const { options: providerOptions, type } = item;
+          let providerRef: UnifiedProvider | null = null;
 
           if (!providerOptions) {
             continue;
@@ -252,12 +269,21 @@ export const BaseYjsPlugin = createTSlatePlugin<YjsConfig>({
                 setOption('_isSynced', isSynced);
 
                 // Resolve sync promise on first sync
-                if (isSynced && syncResolve) {
+                const hasNonLocalProvider = finalProviders.some(
+                  (provider) => !provider.isLocalPersistence
+                );
+                const canResolveInitialSync =
+                  !providerRef?.isLocalPersistence ||
+                  !hasNonLocalProvider ||
+                  hasSharedDocumentState();
+
+                if (isSynced && syncResolve && canResolveInitialSync) {
                   syncResolve();
                   syncResolve = null;
                 }
               },
             });
+            providerRef = provider;
             finalProviders.push(provider);
           } catch {
             // Provider creation failed
@@ -295,13 +321,12 @@ export const BaseYjsPlugin = createTSlatePlugin<YjsConfig>({
         ]);
       }
 
-      // After sync, check if ydoc has content from server
-      // Use custom sharedType if provided, otherwise use default 'content' key
-      const sharedRoot =
-        customSharedType ?? (ydoc.get('content', Y.XmlText) as Y.XmlText);
-
-      // Only apply initial value if ydoc is empty (no content from server)
-      if (sharedRoot.length === 0 && value !== null) {
+      // Only apply initial value if ydoc has no existing shared state.
+      if (
+        !hasSharedDocumentState() &&
+        !hasPendingLocalPersistence() &&
+        value !== null
+      ) {
         let initialNodes = value as Value;
 
         if (typeof value === 'string') {

--- a/packages/yjs/src/lib/providers/index.ts
+++ b/packages/yjs/src/lib/providers/index.ts
@@ -3,6 +3,7 @@
  */
 
 export * from './hocuspocus-provider';
+export * from './indexeddb-provider';
 export * from './registry';
 export * from './types';
 export * from './webrtc-provider';

--- a/packages/yjs/src/lib/providers/indexeddb-provider.spec.ts
+++ b/packages/yjs/src/lib/providers/indexeddb-provider.spec.ts
@@ -1,0 +1,283 @@
+import * as Y from 'yjs';
+
+import { mockFn } from '../__tests__/mockFn';
+
+type IndexeddbHarnessOptions = {
+  constructorError?: Error;
+  destroyError?: Error;
+  openError?: Error;
+};
+
+let importId = 0;
+
+const createDeferred = <T>() => {
+  let reject!: (error: unknown) => void;
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, reject, resolve };
+};
+
+const createIndexeddbHarness = async ({
+  constructorError,
+  destroyError,
+  openError,
+}: IndexeddbHarnessOptions = {}) => {
+  const constructorCalls: any[] = [];
+  const instances: any[] = [];
+
+  class FakeIndexeddbPersistence {
+    readonly doc: Y.Doc;
+    readonly docName: string;
+    destroyed = false;
+    _db: Promise<IDBDatabase>;
+    synced = false;
+    whenSynced: Promise<FakeIndexeddbPersistence>;
+
+    constructor(docName: string, doc: Y.Doc) {
+      this.docName = docName;
+      this.doc = doc;
+      constructorCalls.push({ doc, docName });
+
+      if (constructorError) {
+        throw constructorError;
+      }
+
+      const open = createDeferred<IDBDatabase>();
+      this._db = open.promise;
+      (this as any).open = open;
+      queueMicrotask(() => {
+        if (openError) {
+          open.reject(openError);
+        } else {
+          open.resolve({} as IDBDatabase);
+        }
+      });
+
+      const sync = createDeferred<FakeIndexeddbPersistence>();
+      this.whenSynced = sync.promise.then((value) => {
+        this.synced = true;
+        return value;
+      });
+      (this as any).sync = sync;
+      instances.push(this);
+    }
+
+    destroy = mock(async () => {
+      if (destroyError) {
+        throw destroyError;
+      }
+
+      this.destroyed = true;
+    });
+  }
+
+  mock.module('y-indexeddb', () => ({
+    IndexeddbPersistence: FakeIndexeddbPersistence,
+  }));
+
+  const module = await import(`./indexeddb-provider?test=${importId++}`);
+
+  return {
+    IndexeddbProviderWrapper: module.IndexeddbProviderWrapper,
+    constructorCalls,
+    instances,
+  };
+};
+
+describe('IndexeddbProviderWrapper', () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('persists the plugin-owned document with the configured docName', async () => {
+    const { IndexeddbProviderWrapper, constructorCalls, instances } =
+      await createIndexeddbHarness();
+    const doc = new Y.Doc({ guid: 'doc-1' });
+    const awareness = { id: 'awareness-1' } as any;
+    const wrapper = new IndexeddbProviderWrapper({
+      awareness,
+      doc,
+      options: { docName: 'document-1' },
+    });
+
+    expect(constructorCalls).toHaveLength(0);
+
+    wrapper.connect();
+
+    expect(constructorCalls).toEqual([{ doc, docName: 'document-1' }]);
+    expect(wrapper.document).toBe(doc);
+    expect(wrapper.awareness).toBe(awareness);
+    expect(wrapper.isConnected).toBe(false);
+    expect(wrapper.isConnectionPending).toBe(true);
+    expect(wrapper.isSyncPending).toBe(true);
+
+    await instances[0]._db;
+
+    expect(wrapper.isConnected).toBe(true);
+    expect(wrapper.isConnectionPending).toBe(false);
+    expect(wrapper.isSyncPending).toBe(true);
+    expect(wrapper.isSynced).toBe(false);
+  });
+
+  it('creates a fallback document and awareness when none are provided', async () => {
+    const { IndexeddbProviderWrapper, constructorCalls } =
+      await createIndexeddbHarness();
+    const wrapper = new IndexeddbProviderWrapper({
+      options: { docName: 'document-1' },
+    });
+
+    wrapper.connect();
+
+    expect(wrapper.document).toBeInstanceOf(Y.Doc);
+    expect(wrapper.awareness.doc).toBe(wrapper.document);
+    expect(constructorCalls[0].doc).toBe(wrapper.document);
+  });
+
+  it('tracks sync, disconnect, and destroy state transitions', async () => {
+    const onConnect = mockFn(() => {});
+    const onDisconnect = mockFn(() => {});
+    const onSyncChange = mockFn((_: boolean) => {});
+    const { IndexeddbProviderWrapper, instances } =
+      await createIndexeddbHarness();
+    const wrapper = new IndexeddbProviderWrapper({
+      onConnect,
+      onDisconnect,
+      onSyncChange,
+      options: { docName: 'document-1' },
+    });
+
+    wrapper.connect();
+    wrapper.connect();
+
+    expect(instances).toHaveLength(1);
+    await instances[0]._db;
+    expect(onConnect).toHaveBeenCalledTimes(1);
+
+    instances[0].sync.resolve(instances[0]);
+    await instances[0].whenSynced;
+
+    expect(wrapper.isSynced).toBe(true);
+    expect(wrapper.isSyncPending).toBe(false);
+    expect(onSyncChange).toHaveBeenCalledTimes(1);
+    expect(onSyncChange).toHaveBeenLastCalledWith(true);
+
+    wrapper.disconnect();
+
+    expect(wrapper.isConnected).toBe(false);
+    expect(wrapper.isSynced).toBe(false);
+    expect(instances[0].destroy).toHaveBeenCalledTimes(1);
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+    expect(onSyncChange).toHaveBeenCalledTimes(2);
+    expect(onSyncChange).toHaveBeenLastCalledWith(false);
+
+    wrapper.connect();
+
+    expect(instances).toHaveLength(2);
+    await instances[1]._db;
+
+    instances[1].sync.resolve(instances[1]);
+    await instances[1].whenSynced;
+
+    wrapper.destroy();
+    wrapper.connect();
+
+    expect(wrapper.isConnected).toBe(false);
+    expect(wrapper.isSynced).toBe(false);
+    expect(instances).toHaveLength(2);
+    expect(instances[1].destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces provider creation and destroy failures through onError', async () => {
+    const onCreateError = mockFn((_: Error) => {});
+    const { IndexeddbProviderWrapper: FailingWrapper } =
+      await createIndexeddbHarness({
+        constructorError: new Error('create failed'),
+      });
+    const failed = new FailingWrapper({
+      onError: onCreateError,
+      options: { docName: 'document-1' },
+    });
+
+    failed.connect();
+
+    expect(failed.isConnected).toBe(false);
+    expect(failed.isSynced).toBe(false);
+    expect(onCreateError).toHaveBeenCalledTimes(1);
+    expect((onCreateError.mock.calls[0] as any[])[0].message).toBe(
+      'create failed'
+    );
+
+    const onDestroyError = mockFn((_: Error) => {});
+    const { IndexeddbProviderWrapper, instances } =
+      await createIndexeddbHarness({
+        destroyError: new Error('destroy failed'),
+      });
+    const wrapper = new IndexeddbProviderWrapper({
+      onError: onDestroyError,
+      options: { docName: 'document-2' },
+    });
+
+    wrapper.connect();
+    await instances[0]._db;
+    wrapper.disconnect();
+    await Promise.resolve();
+
+    expect(instances[0].destroy).toHaveBeenCalledTimes(1);
+    expect(onDestroyError).toHaveBeenCalledTimes(1);
+    expect((onDestroyError.mock.calls[0] as any[])[0].message).toBe(
+      'destroy failed'
+    );
+  });
+
+  it('surfaces IndexedDB open failures through onError', async () => {
+    const onError = mockFn((_: Error) => {});
+    const { IndexeddbProviderWrapper, instances } =
+      await createIndexeddbHarness({
+        openError: new Error('open failed'),
+      });
+    const wrapper = new IndexeddbProviderWrapper({
+      onError,
+      options: { docName: 'document-1' },
+    });
+
+    wrapper.connect();
+
+    await instances[0]._db.catch(() => {});
+    await Promise.resolve();
+
+    expect(wrapper.isConnected).toBe(false);
+    expect(wrapper.isConnectionPending).toBe(false);
+    expect(wrapper.isSyncPending).toBe(false);
+    expect(wrapper.isSynced).toBe(false);
+    expect(instances[0].destroy).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0] as any[])[0].message).toBe('open failed');
+  });
+
+  it('cleans up an immediate disconnect before IndexedDB opens', async () => {
+    const { IndexeddbProviderWrapper, instances } =
+      await createIndexeddbHarness();
+    const wrapper = new IndexeddbProviderWrapper({
+      options: { docName: 'document-1' },
+    });
+
+    wrapper.connect();
+
+    expect(wrapper.isConnectionPending).toBe(true);
+
+    wrapper.disconnect();
+
+    expect(instances[0].destroy).toHaveBeenCalledTimes(1);
+    expect(wrapper.isConnected).toBe(false);
+    expect(wrapper.isConnectionPending).toBe(false);
+    expect(wrapper.isSyncPending).toBe(false);
+
+    await instances[0]._db;
+
+    expect(wrapper.isConnected).toBe(false);
+  });
+});

--- a/packages/yjs/src/lib/providers/indexeddb-provider.ts
+++ b/packages/yjs/src/lib/providers/indexeddb-provider.ts
@@ -1,0 +1,196 @@
+import type { Awareness } from 'y-protocols/awareness';
+import type * as Y from 'yjs';
+
+import { Awareness as YAwareness } from 'y-protocols/awareness';
+import { IndexeddbPersistence } from 'y-indexeddb';
+import * as Yjs from 'yjs';
+
+import type {
+  IndexeddbProviderOptions,
+  ProviderEventHandlers,
+  UnifiedProvider,
+  YjsProviderType,
+} from './types';
+
+export class IndexeddbProviderWrapper implements UnifiedProvider {
+  private _isConnected = false;
+  private _isDestroyed = false;
+  private _isSynced = false;
+  private readonly onConnect?: () => void;
+  private readonly onDisconnect?: () => void;
+  private readonly onError?: (error: Error) => void;
+  private readonly onSyncChange?: (isSynced: boolean) => void;
+  private readonly providerOptions: IndexeddbProviderOptions;
+  private _provider: IndexeddbPersistence | null = null;
+
+  readonly awareness: Awareness;
+  readonly document: Y.Doc;
+  readonly isLocalPersistence = true;
+  type: YjsProviderType = 'indexeddb';
+
+  constructor({
+    awareness,
+    doc,
+    options,
+    onConnect,
+    onDisconnect,
+    onError,
+    onSyncChange,
+  }: {
+    awareness?: Awareness;
+    doc?: Y.Doc;
+    options: IndexeddbProviderOptions;
+  } & ProviderEventHandlers) {
+    this.document = doc ?? new Yjs.Doc();
+    // IndexedDB does not transport awareness; this exists for UnifiedProvider.
+    this.awareness = awareness ?? new YAwareness(this.document);
+    this.providerOptions = options;
+    this.onConnect = onConnect;
+    this.onDisconnect = onDisconnect;
+    this.onError = onError;
+    this.onSyncChange = onSyncChange;
+  }
+
+  connect = () => {
+    if (this._isDestroyed) {
+      return;
+    }
+
+    if (!this._provider) {
+      try {
+        const provider = new IndexeddbPersistence(
+          this.providerOptions.docName,
+          this.document
+        );
+
+        this._provider = provider;
+
+        void provider._db
+          .then(() => {
+            if (this._provider === provider && !this._isDestroyed) {
+              this.setConnected(true);
+            }
+          })
+          .catch((error) => {
+            if (this._provider === provider && !this._isDestroyed) {
+              this._provider = null;
+              this.destroyProvider(provider, false);
+              this.handleError(error);
+              this.setSynced(false);
+              this.setConnected(false);
+            }
+          });
+
+        void provider.whenSynced
+          .then(() => {
+            if (
+              this._provider === provider &&
+              this._isConnected &&
+              !this._isDestroyed
+            ) {
+              this.setSynced(true);
+            }
+          })
+          .catch((error) => {
+            this.handleError(error);
+          });
+      } catch (error) {
+        this.handleError(error);
+        this.setConnected(false);
+        this.setSynced(false);
+        return;
+      }
+    }
+
+    if (this._provider.synced) {
+      this.setConnected(true);
+      this.setSynced(true);
+    }
+  };
+
+  destroy = () => {
+    if (this._isDestroyed) {
+      return;
+    }
+
+    this._isDestroyed = true;
+    this.disconnect();
+  };
+
+  disconnect = () => {
+    const provider = this._provider;
+
+    if (!provider && !this._isConnected && !this._isSynced) {
+      return;
+    }
+
+    this._provider = null;
+    this.setSynced(false);
+    this.setConnected(false);
+
+    if (provider) {
+      this.destroyProvider(provider);
+    }
+  };
+
+  get isConnected() {
+    return this._isConnected;
+  }
+
+  get isConnectionPending() {
+    return !!this._provider && !this._isConnected && !this._isDestroyed;
+  }
+
+  get isSyncPending() {
+    return !!this._provider && !this._isSynced && !this._isDestroyed;
+  }
+
+  get isSynced() {
+    return this._isSynced;
+  }
+
+  get provider() {
+    return this._provider;
+  }
+
+  private destroyProvider(provider: IndexeddbPersistence, reportErrors = true) {
+    try {
+      void provider.destroy().catch((error) => {
+        if (reportErrors) {
+          this.handleError(error);
+        }
+      });
+    } catch (error) {
+      if (reportErrors) {
+        this.handleError(error);
+      }
+    }
+  }
+
+  private handleError(error: unknown) {
+    this.onError?.(error instanceof Error ? error : new Error(String(error)));
+  }
+
+  private setConnected(isConnected: boolean) {
+    if (this._isConnected === isConnected) {
+      return;
+    }
+
+    this._isConnected = isConnected;
+
+    if (isConnected) {
+      this.onConnect?.();
+    } else {
+      this.onDisconnect?.();
+    }
+  }
+
+  private setSynced(isSynced: boolean) {
+    if (this._isSynced === isSynced) {
+      return;
+    }
+
+    this._isSynced = isSynced;
+    this.onSyncChange?.(isSynced);
+  }
+}

--- a/packages/yjs/src/lib/providers/registry.spec.ts
+++ b/packages/yjs/src/lib/providers/registry.spec.ts
@@ -9,6 +9,9 @@ describe('provider registry', () => {
     expect(getProviderClass('hocuspocus')?.name).toBe(
       'HocuspocusProviderWrapper'
     );
+    expect(getProviderClass('indexeddb')?.name).toBe(
+      'IndexeddbProviderWrapper'
+    );
     expect(getProviderClass('webrtc')?.name).toBe('WebRTCProviderWrapper');
   });
 

--- a/packages/yjs/src/lib/providers/registry.ts
+++ b/packages/yjs/src/lib/providers/registry.ts
@@ -6,11 +6,13 @@ import type {
 } from './types';
 
 import { HocuspocusProviderWrapper } from './hocuspocus-provider';
+import { IndexeddbProviderWrapper } from './indexeddb-provider';
 import { WebRTCProviderWrapper } from './webrtc-provider';
 
 // Provider registry for extensibility
 const providerRegistry: ProviderRegistry = {
   hocuspocus: HocuspocusProviderWrapper,
+  indexeddb: IndexeddbProviderWrapper,
   webrtc: WebRTCProviderWrapper,
 };
 

--- a/packages/yjs/src/lib/providers/types.ts
+++ b/packages/yjs/src/lib/providers/types.ts
@@ -16,12 +16,22 @@ export interface BaseYjsProviderConfig extends ProviderEventHandlers {
 }
 
 // Built-in provider types
-export type DefaultYjsProviderType = 'hocuspocus' | 'webrtc';
+export type DefaultYjsProviderType = 'hocuspocus' | 'indexeddb' | 'webrtc';
 
 export type HocuspocusProviderConfig = BaseYjsProviderConfig & {
   options: HocuspocusProviderConfiguration;
   type: 'hocuspocus';
   wsOptions?: HocuspocusProviderWebsocketConfiguration;
+};
+
+export type IndexeddbProviderConfig = BaseYjsProviderConfig & {
+  options: IndexeddbProviderOptions;
+  type: 'indexeddb';
+};
+
+export type IndexeddbProviderOptions = {
+  /** Stable IndexedDB database name for this document. */
+  docName: string;
 };
 
 // Provider constructor type
@@ -58,6 +68,16 @@ export type UnifiedProvider = {
   connect: () => void;
   destroy: () => void;
   disconnect: () => void;
+  /**
+   * Whether this provider only reads/writes local persistence. Local
+   * persistence should not satisfy the initial remote-sync gate when a network
+   * provider is also configured.
+   */
+  isLocalPersistence?: boolean;
+  /** Whether the provider owns a live connection attempt that needs cleanup. */
+  isConnectionPending?: boolean;
+  /** Whether the provider may still apply initial synced state. */
+  isSyncPending?: boolean;
   /**
    * Whether this provider is currently connected Used for provider-specific
    * connection status
@@ -160,7 +180,10 @@ export type YjsConfig = PluginConfig<
 >;
 
 // Union type for all known provider configurations
-export type YjsProviderConfig = HocuspocusProviderConfig | WebRTCProviderConfig; // Add custom config types here if needed
+export type YjsProviderConfig =
+  | HocuspocusProviderConfig
+  | IndexeddbProviderConfig
+  | WebRTCProviderConfig; // Add custom config types here if needed
 
 // Extensible provider type that can include custom types
 export type YjsProviderType = DefaultYjsProviderType | string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1856,6 +1856,9 @@ importers:
       react-compiler-runtime:
         specifier: ^1.0.0
         version: 1.0.0(react@19.2.4)
+      y-indexeddb:
+        specifier: ^9.0.12
+        version: 9.0.12(yjs@13.6.29)
       y-protocols:
         specifier: ^1.0.7
         version: 1.0.7(yjs@13.6.29)
@@ -5549,7 +5552,6 @@ packages:
 
   bun@1.3.9:
     resolution: {integrity: sha512-v5hkh1us7sMNjfimWE70flYbD5I1/qWQaqmJ45q2qk5H/7muQVa478LSVRSFyGTBUBog2LsPQnfIRdjyWJRY+A==}
-    cpu: [arm64, x64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -10515,6 +10517,12 @@ packages:
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
+
+  y-indexeddb@9.0.12:
+    resolution: {integrity: sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      yjs: ^13.0.0
 
   y-protocols@1.0.7:
     resolution: {integrity: sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==}
@@ -20246,6 +20254,11 @@ snapshots:
   xmlhttprequest-ssl@2.1.2: {}
 
   xtend@4.0.2: {}
+
+  y-indexeddb@9.0.12(yjs@13.6.29):
+    dependencies:
+      lib0: 0.2.117
+      yjs: 13.6.29
 
   y-protocols@1.0.7(yjs@13.6.29):
     dependencies:


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

🐛 Completes udecode/plate#4650, crediting @dpnova

🟢 95% confidence

| Phase | 🧪 Tests | 🌐 Browser |
|---|---|---|
| Reproduced | 🔴 Source audit + red provider spec showed no built-in `indexeddb` provider | ➖ N/A |
| Verified | 🟢 Focused Yjs provider/init suite, package typecheck, docs source build, lint, autoreview, `pnpm brl`, `pnpm check` | ➖ N/A |

**✅ Outcome**

`@platejs/yjs` now ships a first-party `indexeddb` provider config using the current `providers` API:

```ts
YjsPlugin.configure({
  options: {
    providers: [
      { type: 'indexeddb', options: { docName: 'my-document-id' } },
    ],
  },
});
```

The provider shares the plugin-owned `Y.Doc`, defers IndexedDB persistence until `connect()`, participates in the provider registry/types/barrel exports, and documents the current package API in both the docs page and package README.

Credit: this completes the original IndexedDB provider direction from @dpnova in #4650.

**⚠️ Caveat**

No browser demo was added. This is package API/docs work, and the local proof is the provider/init behavior suite plus full repo check.

**🏗️ Design**

The durable boundary is the `@platejs/yjs` provider registry, not a one-off custom-provider recipe. IndexedDB is local persistence, so the init gate distinguishes local persistence from network sync: it prevents empty local sync from seeding over remote docs, preserves restored empty Yjs state, waits out pending local persistence before fallback seeding, and cleans up pending/failed IndexedDB instances.

`y-indexeddb` is a direct package dependency because the exported provider imports it at module load; making it peer-only would make `@platejs/yjs` unsafe to import unless every consumer installed the optional provider dependency manually.

**🧪 Verified**

- `bun test ./packages/yjs/src/lib/BaseYjsPlugin.init.spec.ts ./packages/yjs/src/lib/providers/hocuspocus-provider.spec.ts ./packages/yjs/src/lib/providers/indexeddb-provider.spec.ts ./packages/yjs/src/lib/providers/registry.spec.ts ./packages/yjs/src/lib/providers/webrtc-provider.spec.ts`
- `pnpm turbo typecheck --filter=./packages/yjs`
- `pnpm --filter www build:source`
- `pnpm lint:fix`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `pnpm brl`
- `pnpm check`
