### PR TITLE
fix(utils): keep placeholders on empty list items

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -6,6 +6,7 @@
 ## Git
 
 - **Git:** Never git add, commit, push, or create PR unless the user explicitly asks, or the active command/skill explicitly requires it.
+- **Open PR follow-up:** If the current branch already has an open PR and you make any change, treat that PR as explicit authorization to commit and push the entire checkout before handoff. Do not leave local-only follow-up changes on an open PR branch.
 - **Push scope:** When you do commit and push, include unrelated dirty files outside src; those are often manual user changes or synced skill/docs updates, so do not silently leave them behind.
 - **PR:** Before creating or updating a PR, run `check`. If it fails, stop and fix it or report the blocker. Do not open a PR with failing `check` unless the user explicitly says to.
 - **PR branch:** If the user explicitly says to open or create a PR, do not ask for confirmation. If the current branch is `main`, create a new `codex/` branch first, then commit/push/open the PR. If already on a non-`main` branch, proceed directly.

--- a/.agents/rules/changeset.mdc
+++ b/.agents/rules/changeset.mdc
@@ -64,7 +64,21 @@ Never combine packages in one changeset.
 .changeset/utils-add-helper.md
 ```
 
-### 3. Relative to `main`, not to your thought process
+### 3. Always relative to `main`, never last commit
+
+NEVER write a changeset relative to the last commit, staged diff, current
+working tree, branch-local plan, or the change you just made. Those are agent
+breadcrumbs, not release truth.
+
+Before creating or editing a changeset, answer one question:
+
+> What will a user upgrading from current `main` observe?
+
+Use `main` / `origin/main` as the release baseline. If a symbol, option,
+behavior, file, or bug only existed inside the current branch and never existed
+on `main`, do **not** write a removal, migration, or breaking changeset for it.
+Instead, describe only the final user-visible delta from `main`, or write no
+changeset if there is no published package delta.
 
 Write changesets for the user-visible delta from the current `main` branch.
 
@@ -73,9 +87,13 @@ That means:
 - describe what users upgrading from `main` need to know
 - describe migration steps only when the user actually has to do something
 - prefer API shape, runtime behavior, serialized data shape, or config changes
+- check whether any named removed/renamed API actually exists on `main` before
+  writing removal or migration prose
 
 Do not write:
 
+- last-commit-relative removals for APIs introduced and deleted on the same
+  branch
 - implementation diary
 - architecture rationale
 - internal ownership or seam language
@@ -194,7 +212,10 @@ Before shipping:
 
 - [ ] Used `minor` for `@platejs/slate`, `@platejs/core`, or `platejs`? Change to `patch`
 - [ ] Multiple packages in frontmatter? Split files
-- [ ] Describes internals instead of the user-visible delta from `main`? Rewrite it
+- [ ] Describes the last commit, working tree, or branch-only API instead of the
+      user-visible delta from `main`? Rewrite it
+- [ ] Claims an API was removed or needs migration without proving that API
+      exists on `main`? Delete that claim
 - [ ] Past tense verbs? Fix them
 - [ ] Multiple paragraphs? Condense
 - [ ] Too much explanation? Cut it

--- a/.agents/rules/task.mdc
+++ b/.agents/rules/task.mdc
@@ -88,6 +88,11 @@ they earn their keep, and verify before calling the task done.
        vulnerability disclosure touched: add `--with security-advisory`
      `node .agents/skills/autogoal/scripts/create-goal-scratchpad.mjs --template <task|docs> --with <pack> --title "<short task title>"`
    - follow local repo overrides for where planning files live
+   - supporting docs means `content/**`, docs/API/reference pages, docs nav,
+     docs examples, or public ownership/API claims changed by a code task.
+     Load `docs-creator` before editing those docs and include the docs pack.
+     If docs enter scope after the plan already exists, stop before closeout,
+     read `docs-creator`, and copy the docs-pack gates into the active plan.
 10. If testing or coverage work, load `testing` before `tdd` and choose the
     smallest honest slice.
 11. If program or batch work, restate the ordered scope and finish one slice at
@@ -269,11 +274,12 @@ lock.
 - `plate-ui`: authoring or refactoring Plate registry UI/components, static/live
   renderers, kits, registry wiring, or ownership/extraction decisions under
   `apps/www/src/registry/**`.
-- `docs-creator`: non-trivial docs/content work, new or rewritten pages,
-  plugin/API/spec/serialization docs, route moves, example changes, or docs with
-  source-backed ownership/API claims. Use `--template docs` when docs dominate;
-  use `--with docs` when docs are a supporting touched surface under a normal or
-  major task.
+- `docs-creator`: mandatory for non-trivial docs/content work, new or rewritten
+  pages, plugin/API/spec/serialization docs, route moves, example changes,
+  public docs under `content/**`, or docs with source-backed ownership/API
+  claims. Use `--template docs` when docs dominate. Use `--with docs` and still
+  load `docs-creator` when docs are a supporting touched surface under a normal
+  or major task. Tiny typo/link-only edits may skip it with an explicit reason.
 - `git-commit-push-pr`: verified code should ship as a PR.
 - Review skills: load only for risky, large, user-facing, or
   architecture-sensitive changes.
@@ -353,7 +359,10 @@ the patch is risky.
 1. Skip engineering ceremony.
 2. For non-trivial docs, load `docs-creator` and use the docs goal template.
 3. If docs are only a supporting touched surface on another task, add the docs
-   pack instead of switching the primary template.
+   pack instead of switching the primary template. Still load `docs-creator`
+   before writing docs. If supporting docs are discovered late, add the docs
+   pack rows to the active plan before closeout; do not hide them under the
+   generic "Docs or content changed" gate.
 4. For tiny copy edits, skip the docs goal and keep verification proportional.
 5. Verify links, examples, formatting, source-backed claims, and rendered output
    as appropriate.
@@ -389,6 +398,11 @@ Keep verification mandatory and proportional.
   signals unrelated to the diff, run `pnpm run reinstall` once and rerun the
   exact failing command before declaring the task blocked.
 - If work changes published packages, satisfy the changeset gate.
+- If work changes public docs/content/API reference/examples, satisfy the
+  `docs-creator` gate. Supporting docs under a code task still need
+  `docs-creator`, docs-pack evidence, `pnpm --filter www build:source`, and
+  `pnpm --filter www check:docs` when source parity or generated docs can be
+  affected.
 - If work changes user-visible registry output under
   `apps/www/src/registry/**`, satisfy the registry changelog gate.
 - If work changes or resolves a security advisory, satisfy the
@@ -455,8 +469,10 @@ with `gh pr view --json body` before final handoff.
 - Non-trivial measurable work loaded `autogoal` and used the right goal
   template.
 - Non-trivial docs work loaded `docs-creator` and used `--template docs`.
-- Supporting docs, browser, agent-native, package/API, or extra-review surfaces
-  used the matching `--with <pack>` rows when they were not the dominant risk.
+- Supporting docs loaded `docs-creator`, used `--with docs`, and closed the docs
+  pack unless the change was truly typo/link-only with an explicit reason.
+- Browser, agent-native, package/API, or extra-review surfaces used the matching
+  `--with <pack>` rows when they were not the dominant risk.
 - Supporting user-visible registry surfaces used `--with registry-changelog`.
 - Security advisory hotfixes used `--with security-advisory` and closed
   release, advisory publication, CVE request, and readback evidence.

--- a/.agents/skills/autogoal/SKILL.md
+++ b/.agents/skills/autogoal/SKILL.md
@@ -295,6 +295,11 @@ A strong goal defines eight things:
 8. Blocked stop condition: when to stop and report the blocker, evidence, and
    next input needed.
 
+If the user requested a timed checkpoint, the plan must also define the
+duration, whether it is minimum active work or an explicit hard stop, the
+initial confidence scorecard when no better metric exists, and how the current
+loop will finish cleanly after the checkpoint is reached.
+
 The `create_goal.objective` field is only a short handle for the active goal.
 Keep it under 240 characters. Put the full contract in the goal plan, not in
 the tool objective.
@@ -347,6 +352,52 @@ Reject or rewrite:
 - "finish"
 - "absolute best" without score rows, pass gates, or evidence
 - "review and decide" without an artifact and acceptance criteria
+
+## Timed Checkpoints
+
+When the user gives a duration such as `30m`, `1h`, `2 hours`, or `10h`,
+treat it as a minimum active-work checkpoint unless they explicitly say
+`max`, `stop at`, `budget cap`, or `timebox hard stop`.
+
+Timed checkpoints are not permission to stop early because the first obvious
+gates passed. They mean: keep increasing confidence until the duration is
+reached, then finish the current loop cleanly.
+
+If the goal already has concrete metrics, use those metrics during the timed
+loop and keep looking for the next highest-value confidence gap until the
+duration elapses.
+
+If there is no concrete metric, create an initial scorecard in the plan before
+substantive work. Use a simple 0-100 confidence score with dimensions that fit
+the task, for example correctness, proof strength, simplicity,
+maintainability, docs/source alignment, risk, and slop removal. Record:
+
+- initial score and dimension scores;
+- what would raise the score;
+- what would lower or cap confidence;
+- next improvement packet;
+- final score at handoff.
+
+After the main implementation gates close, continue with confidence-building
+work until the timed checkpoint is reached:
+
+- review the diff/output against the newest prompt;
+- remove slop, dead code, fake aliases, stale docs, and weak abstractions;
+- refactor toward the durable owner when it reduces real complexity;
+- add or repair missing tests, proof, diagnostics, and source audits;
+- run focused verification again after meaningful changes;
+- repair the owning skill/template when the workflow itself missed the user's
+  expectation.
+
+Do not start a large risky packet near the end unless there is enough time to
+finish, verify, and keep/revert/quarantine it. When the requested duration is
+reached, finish the active loop to a clean boundary: complete the current
+packet, verify it, revert or quarantine unsafe partial work, update the plan,
+and hand off. Never leave dirty half-work merely because the clock expired.
+
+Stop before the timed checkpoint only for a real blocker, an explicit user
+interruption, or an unsafe ambiguity that would make further autonomous work
+harmful. Passing the first checks is not a stop condition.
 
 ## Completion Gate Policy
 
@@ -578,9 +629,12 @@ Gate closure rules:
     searches or reads are allowed, which high-volume paths are excluded, and
     how large results will be capped, counted, or saved as artifacts instead of
     streamed into the goal context.
-12. Use that exact path for
+12. Record timed-checkpoint semantics when the prompt includes a duration. If
+    the duration is not explicitly a hard stop, treat it as minimum active work
+    and add the initial scorecard when no concrete metric exists.
+13. Use that exact path for
    `check-complete.mjs`.
-13. Do not start durable work until the goal is set, verified as already matching,
+14. Do not start durable work until the goal is set, verified as already matching,
    or the user explicitly resolves the missing-goal path.
 
 Set or verify the goal before mutable lane state when the workflow depends on a

--- a/.agents/skills/autogoal/assets/templates/docs.md
+++ b/.agents/skills/autogoal/assets/templates/docs.md
@@ -23,6 +23,13 @@ First checkpoint:
 - Do not continue into implementation until this extraction is complete or
   explicitly marked N/A with reason.
 
+Timed checkpoint:
+- requested duration: pending
+- semantics: pending
+- initial confidence score: pending
+- improvement loop: pending
+- final score / loop closure: pending
+
 Completion threshold:
 - TODO: Define the exact docs done state.
 
@@ -51,6 +58,7 @@ Start Gates:
 | Gate | Applies | Evidence |
 |------|---------|----------|
 | Prompt requirements captured before work | pending | pending |
+| Timed checkpoint parsed | pending | pending |
 | Active goal checked or created | pending | pending |
 | Target docs read | pending | pending |
 | Nearest sibling docs read | pending | pending |
@@ -62,6 +70,9 @@ Work Checklist:
       section, verification surface, and success criterion is copied into this
       plan as checkable checkpoints before implementation.
 - [ ] Target docs and nearest sibling docs were read before writing.
+- [ ] If a duration was requested, it is recorded as minimum active work unless
+      explicitly marked hard stop; when no better metric exists, initial and
+      final confidence scores are recorded.
 - [ ] Documented behavior or API was verified against current source.
 - [ ] Fastest success path appears before deeper mechanics or API reference.
 - [ ] Named APIs, imports, routes, options, and examples are exact and current.
@@ -74,6 +85,7 @@ Completion Gates:
 | Docs links / routes / previews | pending | Verify or record N/A | pending |
 | Docs parser/build | pending | Run relevant docs parser/build or record N/A | pending |
 | Autoreview | pending | Review final docs against objective, constraints, source truth, and newest user request | pending |
+| Timed checkpoint | pending | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | pending |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs {{PLAN_PATH}}` | pending |
 
 Phase / pass table:

--- a/.agents/skills/autogoal/assets/templates/goal-repair.md
+++ b/.agents/skills/autogoal/assets/templates/goal-repair.md
@@ -23,6 +23,13 @@ First checkpoint:
 - Do not continue into implementation until this extraction is complete or
   explicitly marked N/A with reason.
 
+Timed checkpoint:
+- requested duration: pending
+- semantics: pending
+- initial confidence score: pending
+- improvement loop: pending
+- final score / loop closure: pending
+
 Completion threshold:
 - TODO: Define what proves the repair is complete.
 
@@ -48,6 +55,7 @@ Start Gates:
 | Gate | Applies | Evidence |
 |------|---------|----------|
 | Prompt requirements captured before work | pending | pending |
+| Timed checkpoint parsed | pending | pending |
 
 Work Checklist:
 - [ ] First checkpoint complete: every explicit prompt requirement, scope
@@ -55,6 +63,9 @@ Work Checklist:
       section, verification surface, and success criterion is copied into this
       plan as checkable checkpoints before implementation.
 - [ ] Expected behavior and observed miss are concrete.
+- [ ] If a duration was requested, it is recorded as minimum active work unless
+      explicitly marked hard stop; when no better metric exists, initial and
+      final confidence scores are recorded.
 - [ ] Source of truth for the missed rule is identified.
 - [ ] Root cause is recorded before repair.
 - [ ] Repair updates the canonical surface.
@@ -68,6 +79,7 @@ Completion Gates:
 | Canonical source repaired | pending | Patch the real source of truth | pending |
 | Verification proof | pending | Run named proof or record blocker | pending |
 | Autoreview | pending | Review repair against expected behavior, observed miss, and newest user request | pending |
+| Timed checkpoint | pending | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | pending |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs {{PLAN_PATH}}` | pending |
 
 Phase / pass table:

--- a/.agents/skills/autogoal/assets/templates/goal.md
+++ b/.agents/skills/autogoal/assets/templates/goal.md
@@ -17,6 +17,13 @@ First checkpoint:
 - Do not continue into implementation until this extraction is complete or
   explicitly marked N/A with reason.
 
+Timed checkpoint:
+- requested duration: pending
+- semantics: pending
+- initial confidence score: pending
+- improvement loop: pending
+- final score / loop closure: pending
+
 Completion threshold:
 - TODO: Define the exact measurable or auditable done state.
 
@@ -40,6 +47,7 @@ Start Gates:
 | Gate | Applies | Evidence |
 |------|---------|----------|
 | Prompt requirements captured before work | pending | pending |
+| Timed checkpoint parsed | pending | pending |
 | Active goal checked or created | pending | pending |
 | Source of truth read before edits | pending | pending |
 | TDD decision before behavior change or bug fix | pending | pending |
@@ -51,6 +59,9 @@ Work Checklist:
       section, verification surface, and success criterion is copied into this
       plan as checkable checkpoints before implementation.
 - [ ] Objective, threshold, verification surface, constraints, boundaries, and blocked condition are concrete.
+- [ ] If a duration was requested, it is recorded as minimum active work unless
+      explicitly marked hard stop; when no better metric exists, initial and
+      final confidence scores are recorded.
 - [ ] Work phases are updated with evidence.
 - [ ] Decisions and tradeoffs are recorded.
 - [ ] Failed attempts and next different moves are recorded.
@@ -62,6 +73,7 @@ Completion Gates:
 | Typecheck/build/test proof | pending | Run relevant owner checks or record N/A | pending |
 | Browser proof | pending | Exercise the affected browser surface or record N/A | pending |
 | Autoreview | pending | Review final diff/output against objective, constraints, and newest user request | pending |
+| Timed checkpoint | pending | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | pending |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs {{PLAN_PATH}}` | pending |
 
 Phase / pass table:

--- a/.agents/skills/autogoal/assets/templates/major-task.md
+++ b/.agents/skills/autogoal/assets/templates/major-task.md
@@ -24,6 +24,13 @@ First checkpoint:
 - Do not continue into implementation until this extraction is complete or
   explicitly marked N/A with reason.
 
+Timed checkpoint:
+- requested duration: pending
+- semantics: pending
+- initial confidence score: pending
+- improvement loop: pending
+- final score / loop closure: pending
+
 Completion threshold:
 - TODO: Define the decision, proposal, benchmark, architecture, or migration done state.
 
@@ -52,6 +59,7 @@ Start Gates:
 | Gate | Applies | Evidence |
 |------|---------|----------|
 | Prompt requirements captured before work | pending | pending |
+| Timed checkpoint parsed | pending | pending |
 | Active goal checked or created | pending | pending |
 | Source of truth read before analysis | pending | pending |
 | Decision criteria stated | pending | pending |
@@ -64,6 +72,9 @@ Work Checklist:
       section, verification surface, and success criterion is copied into this
       plan as checkable checkpoints before implementation.
 - [ ] Current state is mapped before proposing a new architecture, migration, benchmark, or plan.
+- [ ] If a duration was requested, it is recorded as minimum active work unless
+      explicitly marked hard stop; when no better metric exists, initial and
+      final confidence scores are recorded.
 - [ ] Existing repo patterns and prior decisions are recorded before external research.
 - [ ] Options, recommendation, tradeoffs, blast radius, and rejection reasons are recorded.
 - [ ] Facts, inference, and recommendation are separated.
@@ -76,6 +87,7 @@ Completion Gates:
 | Source audit complete | pending | Record repo evidence and external evidence | pending |
 | Review / pressure pass | pending | Record review lens or N/A | pending |
 | Autoreview | pending | Review final artifact against objective, criteria, constraints, and newest user request | pending |
+| Timed checkpoint | pending | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | pending |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs {{PLAN_PATH}}` | pending |
 
 Phase / pass table:

--- a/.agents/skills/autogoal/assets/templates/task.md
+++ b/.agents/skills/autogoal/assets/templates/task.md
@@ -23,6 +23,13 @@ First checkpoint:
 - Do not continue into implementation until this extraction is complete or
   explicitly marked N/A with reason.
 
+Timed checkpoint:
+- requested duration: pending
+- semantics: pending
+- initial confidence score: pending
+- improvement loop: pending
+- final score / loop closure: pending
+
 Completion threshold:
 - TODO: Define the exact task done state.
 
@@ -41,6 +48,26 @@ Boundaries:
 - Tracker sync: TODO.
 - Non-goals: TODO.
 
+Current verdict:
+- verdict: pending
+- confidence: pending
+- next owner: task
+- reason: pending
+
+Pre-solution issue challenge:
+- reporter claim: pending
+- suggested diagnosis or fix: pending
+- repro ladder:
+  - tests / source-level repro: pending
+  - repo-owned automated browser or integration proof: pending
+  - Browser plugin: pending
+  - screenshot / visual proof: pending
+- reproduction verdict: pending
+- validity verdict: pending
+- best long-term fix boundary: pending
+- harsh honest feedback: pending
+- hard-stop decision: pending
+
 Blocked condition:
 - TODO: Name the missing source context, repro, access, command, or decision that stops autonomous work.
 
@@ -52,9 +79,14 @@ Start Gates:
 | Gate | Applies | Evidence |
 |------|---------|----------|
 | Prompt requirements captured before work | pending | pending |
+| Timed checkpoint parsed | pending | pending |
 | Active goal checked or created | pending | pending |
 | Source of truth read before edits | pending | pending |
 | Acceptance criteria captured | pending | pending |
+| Pre-solution issue challenge required | pending | pending |
+| Reproduction verdict before implementation | pending | pending |
+| Repro escalation ladder selected | pending | pending |
+| Suggested fix reviewed against durable boundary | pending | pending |
 | TDD decision before behavior change or bug fix | pending | pending |
 | Browser proof decision for browser surface | pending | pending |
 
@@ -64,20 +96,48 @@ Work Checklist:
       section, verification surface, and success criterion is copied into this
       plan as checkable checkpoints before implementation.
 - [ ] Short objective plus threshold, verification surface, constraints, boundaries, and blocked condition are concrete.
+- [ ] If a duration was requested, it is recorded as minimum active work unless
+      explicitly marked hard stop; when no better metric exists, initial and
+      final confidence scores are recorded.
 - [ ] Task source and acceptance criteria are captured.
+- [ ] For public tracker bug reports, behavior claims, technical diagnoses, or
+      suggested fixes, reporter claims are challenged before implementation
+      with a recorded verdict: `valid`, `not reproduced`, `invalid`,
+      `wont-fix`, `partially valid`, or `platform limitation`. Feature, docs,
+      support, or cleanup requests with no bug claim may mark reproduction
+      `N/A` with reason.
+- [ ] Repro escalation ladder followed for bug/behavior claims: focused
+      test/source-level repro first when applicable; existing repo-owned
+      automated browser or integration proof next when available and useful as
+      executable coverage; the repo-approved Browser tool next when tests or
+      automation cannot reproduce or cannot model the surface honestly;
+      screenshot or explicit visual-proof waiver when visual/native state
+      matters.
+- [ ] Hard-stop rule followed for bug/behavior claims: no code when the issue
+      is not reproduced, invalid, or won't-fix; partial validity pivots to the
+      best long-term fix and records what was wrong or incomplete in the
+      issue's proposed path.
 - [ ] Nearby implementation patterns are read before edits.
-- [ ] Implementation fixes the right ownership boundary.
+- [ ] Implementation fixes the right ownership boundary, or the narrower choice
+      is recorded with reason.
+- [ ] Review/autoreview target selected from actual diff state for non-trivial
+      implementation work, or marked N/A with reason.
 - [ ] Verification evidence is recorded beside each relevant gate.
 
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
 |------|---------|-----------------|----------|
 | Named verification threshold | pending | Run the named proof or record blocker | pending |
+| Pre-solution issue challenge verdict | pending | Record reporter claim, suggested fix, repro verdict, validity verdict, durable boundary, and hard-stop/pivot decision before implementation | pending |
+| Repro escalation ladder | pending | For bug/behavior claims, record test/source-level, automated browser/integration, Browser, and screenshot/visual-proof outcomes or N/A/blocker reasons before `not reproduced` | pending |
+| Bug reproduced before fix | pending | Record failing test/repro or N/A with reason | pending |
+| Targeted behavior verification | pending | Run focused test/proof for changed behavior or record N/A | pending |
 | TypeScript or typed config changed | pending | Run relevant typecheck | pending |
 | Build-sensitive behavior changed | pending | Run relevant build/check | pending |
 | Browser surface changed | pending | Capture browser proof | pending |
 | Final lint/format | pending | Run relevant lint/format command or record N/A | pending |
 | Autoreview | pending | Review final diff/output against objective, acceptance criteria, constraints, and newest user request | pending |
+| Timed checkpoint | pending | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | pending |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs {{PLAN_PATH}}` | pending |
 
 Phase / pass table:

--- a/.agents/skills/changeset/SKILL.md
+++ b/.agents/skills/changeset/SKILL.md
@@ -68,7 +68,21 @@ Never combine packages in one changeset.
 .changeset/utils-add-helper.md
 ```
 
-### 3. Relative to `main`, not to your thought process
+### 3. Always relative to `main`, never last commit
+
+NEVER write a changeset relative to the last commit, staged diff, current
+working tree, branch-local plan, or the change you just made. Those are agent
+breadcrumbs, not release truth.
+
+Before creating or editing a changeset, answer one question:
+
+> What will a user upgrading from current `main` observe?
+
+Use `main` / `origin/main` as the release baseline. If a symbol, option,
+behavior, file, or bug only existed inside the current branch and never existed
+on `main`, do **not** write a removal, migration, or breaking changeset for it.
+Instead, describe only the final user-visible delta from `main`, or write no
+changeset if there is no published package delta.
 
 Write changesets for the user-visible delta from the current `main` branch.
 
@@ -77,9 +91,13 @@ That means:
 - describe what users upgrading from `main` need to know
 - describe migration steps only when the user actually has to do something
 - prefer API shape, runtime behavior, serialized data shape, or config changes
+- check whether any named removed/renamed API actually exists on `main` before
+  writing removal or migration prose
 
 Do not write:
 
+- last-commit-relative removals for APIs introduced and deleted on the same
+  branch
 - implementation diary
 - architecture rationale
 - internal ownership or seam language
@@ -198,7 +216,10 @@ Before shipping:
 
 - [ ] Used `minor` for `@platejs/slate`, `@platejs/core`, or `platejs`? Change to `patch`
 - [ ] Multiple packages in frontmatter? Split files
-- [ ] Describes internals instead of the user-visible delta from `main`? Rewrite it
+- [ ] Describes the last commit, working tree, or branch-only API instead of the
+      user-visible delta from `main`? Rewrite it
+- [ ] Claims an API was removed or needs migration without proving that API
+      exists on `main`? Delete that claim
 - [ ] Past tense verbs? Fix them
 - [ ] Multiple paragraphs? Condense
 - [ ] Too much explanation? Cut it

--- a/.agents/skills/task/SKILL.md
+++ b/.agents/skills/task/SKILL.md
@@ -92,6 +92,11 @@ they earn their keep, and verify before calling the task done.
        vulnerability disclosure touched: add `--with security-advisory`
      `node .agents/skills/autogoal/scripts/create-goal-scratchpad.mjs --template <task|docs> --with <pack> --title "<short task title>"`
    - follow local repo overrides for where planning files live
+   - supporting docs means `content/**`, docs/API/reference pages, docs nav,
+     docs examples, or public ownership/API claims changed by a code task.
+     Load `docs-creator` before editing those docs and include the docs pack.
+     If docs enter scope after the plan already exists, stop before closeout,
+     read `docs-creator`, and copy the docs-pack gates into the active plan.
 10. If testing or coverage work, load `testing` before `tdd` and choose the
     smallest honest slice.
 11. If program or batch work, restate the ordered scope and finish one slice at
@@ -273,11 +278,12 @@ lock.
 - `plate-ui`: authoring or refactoring Plate registry UI/components, static/live
   renderers, kits, registry wiring, or ownership/extraction decisions under
   `apps/www/src/registry/**`.
-- `docs-creator`: non-trivial docs/content work, new or rewritten pages,
-  plugin/API/spec/serialization docs, route moves, example changes, or docs with
-  source-backed ownership/API claims. Use `--template docs` when docs dominate;
-  use `--with docs` when docs are a supporting touched surface under a normal or
-  major task.
+- `docs-creator`: mandatory for non-trivial docs/content work, new or rewritten
+  pages, plugin/API/spec/serialization docs, route moves, example changes,
+  public docs under `content/**`, or docs with source-backed ownership/API
+  claims. Use `--template docs` when docs dominate. Use `--with docs` and still
+  load `docs-creator` when docs are a supporting touched surface under a normal
+  or major task. Tiny typo/link-only edits may skip it with an explicit reason.
 - `git-commit-push-pr`: verified code should ship as a PR.
 - Review skills: load only for risky, large, user-facing, or
   architecture-sensitive changes.
@@ -357,7 +363,10 @@ the patch is risky.
 1. Skip engineering ceremony.
 2. For non-trivial docs, load `docs-creator` and use the docs goal template.
 3. If docs are only a supporting touched surface on another task, add the docs
-   pack instead of switching the primary template.
+   pack instead of switching the primary template. Still load `docs-creator`
+   before writing docs. If supporting docs are discovered late, add the docs
+   pack rows to the active plan before closeout; do not hide them under the
+   generic "Docs or content changed" gate.
 4. For tiny copy edits, skip the docs goal and keep verification proportional.
 5. Verify links, examples, formatting, source-backed claims, and rendered output
    as appropriate.
@@ -393,6 +402,11 @@ Keep verification mandatory and proportional.
   signals unrelated to the diff, run `pnpm run reinstall` once and rerun the
   exact failing command before declaring the task blocked.
 - If work changes published packages, satisfy the changeset gate.
+- If work changes public docs/content/API reference/examples, satisfy the
+  `docs-creator` gate. Supporting docs under a code task still need
+  `docs-creator`, docs-pack evidence, `pnpm --filter www build:source`, and
+  `pnpm --filter www check:docs` when source parity or generated docs can be
+  affected.
 - If work changes user-visible registry output under
   `apps/www/src/registry/**`, satisfy the registry changelog gate.
 - If work changes or resolves a security advisory, satisfy the
@@ -459,8 +473,10 @@ with `gh pr view --json body` before final handoff.
 - Non-trivial measurable work loaded `autogoal` and used the right goal
   template.
 - Non-trivial docs work loaded `docs-creator` and used `--template docs`.
-- Supporting docs, browser, agent-native, package/API, or extra-review surfaces
-  used the matching `--with <pack>` rows when they were not the dominant risk.
+- Supporting docs loaded `docs-creator`, used `--with docs`, and closed the docs
+  pack unless the change was truly typo/link-only with an explicit reason.
+- Browser, agent-native, package/API, or extra-review surfaces used the matching
+  `--with <pack>` rows when they were not the dominant risk.
 - Supporting user-visible registry surfaces used `--with registry-changelog`.
 - Security advisory hotfixes used `--with security-advisory` and closed
   release, advisory publication, CVE request, and readback evidence.

--- a/.changeset/core-node-metadata-prop.md
+++ b/.changeset/core-node-metadata-prop.md
@@ -1,0 +1,5 @@
+---
+"@platejs/core": patch
+---
+
+Add `node.isMetadataProp` and `editor.api.isElementStateEmpty` for element state checks.

--- a/.changeset/utils-block-placeholder-list.md
+++ b/.changeset/utils-block-placeholder-list.md
@@ -1,0 +1,5 @@
+---
+"@platejs/utils": patch
+---
+
+Fix block placeholders on empty list items.

--- a/.changeset/utils-block-placeholder-list.md
+++ b/.changeset/utils-block-placeholder-list.md
@@ -2,4 +2,4 @@
 "@platejs/utils": patch
 ---
 
-Fix block placeholders on empty list items.
+Fix block placeholders on single empty list items.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 ## Git
 
 - **Git:** Never git add, commit, push, or create PR unless the user explicitly asks, or the active command/skill explicitly requires it.
+- **Open PR follow-up:** If the current branch already has an open PR and you make any change, treat that PR as explicit authorization to commit and push the entire checkout before handoff. Do not leave local-only follow-up changes on an open PR branch.
 - **Push scope:** When you do commit and push, include unrelated dirty files outside src; those are often manual user changes or synced skill/docs updates, so do not silently leave them behind.
 - **PR:** Before creating or updating a PR, run `check`. If it fails, stop and fix it or report the blocker. Do not open a PR with failing `check` unless the user explicitly says to.
 - **PR branch:** If the user explicitly says to open or create a PR, do not ask for confirmation. If the current branch is `main`, create a new `codex/` branch first, then commit/push/open the PR. If already on a non-`main` branch, proceed directly.

--- a/content/docs/(plugins)/(functionality)/block-placeholder.cn.mdx
+++ b/content/docs/(plugins)/(functionality)/block-placeholder.cn.mdx
@@ -112,7 +112,6 @@ BlockPlaceholderPlugin.configure({
 - `placeholders`: 块类型与占位文本的映射
 - `className`: 应用于带占位符块的 CSS 类
 - `query`: 决定哪些块应显示占位符的函数
-- `isEmptyBlockPristine`: 判断唯一空块是否仍属于初始空编辑器状态的函数
 
 </Steps>
 
@@ -125,12 +124,12 @@ BlockPlaceholderPlugin.configure({
 当满足以下所有条件时，插件会显示占位符：
 
 1. 块为空（不含内容）
-2. 编辑器不是 `isEmptyBlockPristine` 判定的初始单空块状态；带可见结构状态的空列表项也符合条件
+2. 编辑器不是初始单空块状态；带可见结构状态的空列表项也符合条件
 3. 编辑器处于聚焦状态
 4. 块符合查询函数条件
 5. 块类型匹配 placeholders 映射中的键
 
-默认 `isEmptyBlockPristine` 使用 `editor.api.isElementStateEmpty`，因此只把 `type` 和插件通过 `node.isMetadataProp` 声明为空的属性视为空状态元数据。
+初始空状态检查使用 `editor.api.isElementStateEmpty`，因此只把 `type` 和插件通过 `node.isMetadataProp` 声明为空的属性视为空状态元数据。
 
 <API name="BlockPlaceholderPlugin">
 <APIOptions>
@@ -141,9 +140,6 @@ BlockPlaceholderPlugin.configure({
   <APIItem name="query" type="(context: PlatePluginContext & { node: TElement; path: Path }) => boolean">
     决定块是否应显示占位符的函数
     - **默认值:** 对最外层块返回 true (`path.length === 1`)
-  </APIItem>
-  <APIItem name="isEmptyBlockPristine" type="(context: PlatePluginContext & { node: TElement; path: Path }) => boolean">
-    判断唯一空块是否应视为编辑器的初始空状态
   </APIItem>
   <APIItem name="className" type="string" optional>
     应用于带占位符块的 CSS 类

--- a/content/docs/(plugins)/(functionality)/block-placeholder.cn.mdx
+++ b/content/docs/(plugins)/(functionality)/block-placeholder.cn.mdx
@@ -112,6 +112,7 @@ BlockPlaceholderPlugin.configure({
 - `placeholders`: 块类型与占位文本的映射
 - `className`: 应用于带占位符块的 CSS 类
 - `query`: 决定哪些块应显示占位符的函数
+- `isEmptyBlockPristine`: 判断唯一空块是否仍属于初始空编辑器状态的函数
 
 </Steps>
 
@@ -124,10 +125,12 @@ BlockPlaceholderPlugin.configure({
 当满足以下所有条件时，插件会显示占位符：
 
 1. 块为空（不含内容）
-2. 编辑器不为空（有其他内容）
+2. 编辑器不是 `isEmptyBlockPristine` 判定的初始单空块状态；带可见结构状态的空列表项也符合条件
 3. 编辑器处于聚焦状态
 4. 块符合查询函数条件
 5. 块类型匹配 placeholders 映射中的键
+
+默认 `isEmptyBlockPristine` 使用 `editor.api.isElementStateEmpty`，因此只把 `type` 和插件通过 `node.isMetadataProp` 声明为空的属性视为空状态元数据。
 
 <API name="BlockPlaceholderPlugin">
 <APIOptions>
@@ -138,6 +141,9 @@ BlockPlaceholderPlugin.configure({
   <APIItem name="query" type="(context: PlatePluginContext & { node: TElement; path: Path }) => boolean">
     决定块是否应显示占位符的函数
     - **默认值:** 对最外层块返回 true (`path.length === 1`)
+  </APIItem>
+  <APIItem name="isEmptyBlockPristine" type="(context: PlatePluginContext & { node: TElement; path: Path }) => boolean">
+    判断唯一空块是否应视为编辑器的初始空状态
   </APIItem>
   <APIItem name="className" type="string" optional>
     应用于带占位符块的 CSS 类

--- a/content/docs/(plugins)/(functionality)/block-placeholder.mdx
+++ b/content/docs/(plugins)/(functionality)/block-placeholder.mdx
@@ -17,7 +17,6 @@ Block Placeholder injects a `placeholder` prop into the active empty block. It i
 - Active-block placeholder text.
 - Per-type placeholder map through `placeholders`.
 - Root-level filtering through `query`.
-- Custom pristine-empty block detection through `isEmptyBlockPristine`.
 - Custom placeholder styling through `className`.
 - Focus, read-only, composition, selection, and empty-editor guards.
 
@@ -126,11 +125,11 @@ The plugin shows a placeholder only when every gate passes.
 | Focus | Editor is focused and has a selection. |
 | Selection | Selection is collapsed. |
 | Active block | `editor.api.block()` returns an empty block. |
-| Whole editor | The editor is not in its pristine single-empty-block state according to `isEmptyBlockPristine`. Empty blocks with visible structural state, such as list metadata, still qualify. |
+| Whole editor | The editor is not in its pristine single-empty-block state. Empty blocks with visible structural state, such as list metadata, still qualify. |
 | Placeholder map | The block type matches one entry in `placeholders`. |
 | Query | `query({ editor, node, path, ...ctx })` returns `true`. |
 
-The default `query` returns `true` for root blocks only. The default `isEmptyBlockPristine` delegates to `editor.api.isElementStateEmpty`, so only `type` and props claimed by plugins through `node.isMetadataProp` are treated as pristine metadata.
+The default `query` returns `true` for root blocks only. The whole-editor guard uses `editor.api.isElementStateEmpty`, so only `type` and props claimed by plugins through `node.isMetadataProp` are treated as pristine metadata.
 
 ```tsx
 query: ({ path }) => path.length === 1
@@ -161,7 +160,6 @@ className:
 | `BlockPlaceholderPlugin` | `platejs/react` / `@platejs/utils/react` | Adds block placeholders through injected node props. |
 | `options.placeholders` | `Record<string, string>` | Maps plugin keys to placeholder text. Default: `{ [KEYS.p]: 'Type something...' }`. |
 | `options.query` | `(context) => boolean` | Filters eligible blocks. Default: `({ path }) => path.length === 1`. |
-| `options.isEmptyBlockPristine` | `(context) => boolean` | Controls whether the only empty block should count as the pristine editor state. |
 | `options.className` | `string` | Class applied to the block only while its placeholder is active. |
 | `options._target` | Internal runtime state | Stores the current target node and placeholder string. |
 | `selectors.placeholder(node)` | Plugin selector | Returns the placeholder string for the current target node. |

--- a/content/docs/(plugins)/(functionality)/block-placeholder.mdx
+++ b/content/docs/(plugins)/(functionality)/block-placeholder.mdx
@@ -17,6 +17,7 @@ Block Placeholder injects a `placeholder` prop into the active empty block. It i
 - Active-block placeholder text.
 - Per-type placeholder map through `placeholders`.
 - Root-level filtering through `query`.
+- Custom pristine-empty block detection through `isEmptyBlockPristine`.
 - Custom placeholder styling through `className`.
 - Focus, read-only, composition, selection, and empty-editor guards.
 
@@ -125,11 +126,11 @@ The plugin shows a placeholder only when every gate passes.
 | Focus | Editor is focused and has a selection. |
 | Selection | Selection is collapsed. |
 | Active block | `editor.api.block()` returns an empty block. |
-| Whole editor | `editor.api.isEmpty()` is false. |
+| Whole editor | The editor is not in its pristine single-empty-block state according to `isEmptyBlockPristine`. Empty blocks with visible structural state, such as list metadata, still qualify. |
 | Placeholder map | The block type matches one entry in `placeholders`. |
 | Query | `query({ editor, node, path, ...ctx })` returns `true`. |
 
-The default `query` returns `true` for root blocks only.
+The default `query` returns `true` for root blocks only. The default `isEmptyBlockPristine` delegates to `editor.api.isElementStateEmpty`, so only `type` and props claimed by plugins through `node.isMetadataProp` are treated as pristine metadata.
 
 ```tsx
 query: ({ path }) => path.length === 1
@@ -160,6 +161,7 @@ className:
 | `BlockPlaceholderPlugin` | `platejs/react` / `@platejs/utils/react` | Adds block placeholders through injected node props. |
 | `options.placeholders` | `Record<string, string>` | Maps plugin keys to placeholder text. Default: `{ [KEYS.p]: 'Type something...' }`. |
 | `options.query` | `(context) => boolean` | Filters eligible blocks. Default: `({ path }) => path.length === 1`. |
+| `options.isEmptyBlockPristine` | `(context) => boolean` | Controls whether the only empty block should count as the pristine editor state. |
 | `options.className` | `string` | Class applied to the block only while its placeholder is active. |
 | `options._target` | Internal runtime state | Stores the current target node and placeholder string. |
 | `selectors.placeholder(node)` | Plugin selector | Returns the placeholder string for the current target node. |

--- a/content/docs/api/core.cn.mdx
+++ b/content/docs/api/core.cn.mdx
@@ -651,6 +651,28 @@ const state = useEditorPluginOption(editor, plugin, 'state');
 ### `SlateExtensionPlugin & SlateReactExtensionPlugin`
 扩展核心 API 并改进默认功能。
 
+`SlateExtensionPlugin` 提供 `editor.api.isElementStateEmpty(element)`。它检查元素自身的属性状态，而不是文本内容。默认只忽略 `type` 和插件通过 `node.isMetadataProp` 声明为空的属性；任何其他属性都表示该元素带有状态。`NodeIdPlugin` 使用 `node.isMetadataProp` 处理配置的 NodeId 键。
+
+```tsx
+editor.api.isElementStateEmpty({
+  children: [{ text: '' }],
+  type: 'p',
+}); // true
+
+editor.api.isElementStateEmpty({
+  children: [{ text: '' }],
+  listStyleType: 'disc',
+  type: 'p',
+}); // false
+
+const CustomMetadataPlugin = createSlatePlugin({
+  key: 'customMetadata',
+  node: {
+    isMetadataProp: ({ key }) => key === 'customId',
+  },
+});
+```
+
 ### `DOMPlugin & ReactPlugin`
 将 React 特定功能集成到编辑器中。
 

--- a/content/docs/api/core.mdx
+++ b/content/docs/api/core.mdx
@@ -714,6 +714,32 @@ See [Debugging](/docs/debugging) for more details.
 ### `SlateExtensionPlugin & SlateReactExtensionPlugin`
 Extend core apis and improve default functionality.
 
+`SlateExtensionPlugin` exposes `editor.api.isElementStateEmpty(element)`. It
+checks the element's own props, not its text content. By default, only `type`
+and props claimed by plugins through `node.isMetadataProp` are ignored; any other
+prop means the element carries state. `NodeIdPlugin` uses `node.isMetadataProp` for
+the configured NodeId key.
+
+```tsx
+editor.api.isElementStateEmpty({
+  children: [{ text: '' }],
+  type: 'p',
+}); // true
+
+editor.api.isElementStateEmpty({
+  children: [{ text: '' }],
+  listStyleType: 'disc',
+  type: 'p',
+}); // false
+
+const CustomMetadataPlugin = createSlatePlugin({
+  key: 'customMetadata',
+  node: {
+    isMetadataProp: ({ key }) => key === 'customId',
+  },
+});
+```
+
 ### `DOMPlugin & ReactPlugin`
 Integrates React-specific functionality into the editor.
 

--- a/docs/plans/2026-06-15-4951-block-placeholder-list-item.md
+++ b/docs/plans/2026-06-15-4951-block-placeholder-list-item.md
@@ -1,0 +1,321 @@
+# 4951 block placeholder list item
+
+Objective:
+Fix #4951 block placeholder list-item bug; done when repro fails before fix, passes after fix, checks/review pass, and PR/sync-back complete.
+
+Goal plan:
+docs/plans/2026-06-15-4951-block-placeholder-list-item.md
+
+Template:
+docs/plans/templates/task.md
+
+Primary template:
+docs/plans/templates/task.md
+
+Applied packs:
+- package-api (docs/plans/templates/packs/package-api.md)
+
+Task source:
+- type: GitHub issue
+- id / link: #4951 https://github.com/udecode/plate/issues/4951
+- title: [@platejs/utils] BlockPlaceholderPlugin suppresses placeholder on single empty list item (indent-list)
+- acceptance criteria: reproduce the missing placeholder on a single empty list-style paragraph, fix the plugin so that state shows the configured block placeholder, preserve pristine single-empty-editor suppression, add package regression coverage, ship with package release artifact and tracker sync.
+
+Completion threshold:
+- Focused regression test fails before implementation for the reported single empty indent-list state.
+- Focused regression test passes after implementation while existing pristine-empty suppression remains covered.
+- Owning package verification, release artifact, autoreview, PR body check, and tracker sync are complete or explicitly N/A with evidence.
+- Task closure is legal only when the source-of-truth acceptance criteria are
+  satisfied or explicitly narrowed, required verification evidence is recorded,
+  code-review and release-artifact gates are closed when applicable, tracker/PR
+  sync is complete or marked N/A with reason, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-15-4951-block-placeholder-list-item.md` passes.
+
+Verification surface:
+- `pnpm --filter @platejs/core build && bun test packages/core/src/lib/plugins/slate-extension/SlateExtensionPlugin.spec.tsx packages/utils/src/react/plugins/BlockPlaceholderPlugin.spec.tsx`
+- `pnpm turbo typecheck --filter=./packages/core --filter=./packages/utils`
+- `pnpm --filter www build:source`
+- `pnpm lint:fix`
+- `pnpm check` before PR update
+- autoreview helper on final diff
+- PR body readback and issue #4951 sync-back
+
+Constraints:
+- Preserve existing user-facing behavior outside the task scope.
+- Prefer the durable ownership boundary over caller-by-caller patches.
+- Do not create PRs, comments, commits, or pushes unless the task/user/skill
+  requires them.
+- Do not add broad ceremony when the task is trivial or docs-only.
+
+Boundaries:
+- Source of truth: GitHub issue #4951 body, local `BlockPlaceholderPlugin` source/tests, repo instructions.
+- Allowed edit scope: `packages/core` state-empty API/tests, `packages/utils` placeholder plugin/tests, affected docs, `.changeset`, this goal plan, PR/issue text.
+- Browser surface: Browser route proof attempted because packages/content changed; the standalone demo route loads, but Browser automation cannot move the Slate selection from the heading into the empty paragraph, and the page exposes no editor object for direct state inspection. Focused React plugin specs remain the behavior authority.
+- Tracker sync: posted concise issue comment after verified PR exists.
+- Non-goals: do not rewrite list autoformat, list data model, or expose a broad placeholder rendering API unless source proves it is needed.
+
+Output budget strategy:
+- Use exact issue/file reads, focused `rg` patterns, targeted test commands, and capped command output. Avoid broad repo scans and generated/build output streams.
+
+Blocked condition:
+- Stop if the focused regression cannot reproduce the issue before implementation, or if source proves the behavior is invalid/wont-fix.
+
+Task state:
+- task_type: public issue bug fix
+- task_complexity: normal
+- current_phase: closeout
+- current_phase_status: complete
+- next_phase: amend/push updated PR
+- goal_status: ready_for_handoff
+
+Current verdict:
+- verdict: valid and fixed locally with core-owned state-empty API
+- confidence: 98%
+- next owner: task
+- reason: issue claim matches local global-empty guard; the final fix adds plugin-owned `node.isMetadataProp`, has `NodeIdPlugin` claim its configured id key as inert metadata, and makes `BlockPlaceholderPlugin` delegate its default pristine-empty policy to `editor.api.isElementStateEmpty`.
+
+Pre-solution issue challenge:
+- reporter claim: `BlockPlaceholderPlugin` hides placeholder when the only block is an empty paragraph with indent-list metadata.
+- suggested diagnosis or fix: diagnosis likely right; suggested hardcoded list/indent pristine check is too narrow and should be challenged.
+- repro ladder:
+  - tests / source-level repro: in progress with focused plugin spec
+  - Playwright / automated browser: N/A unless unit repro cannot model behavior
+  - Browser plugin: N/A unless tests cannot model user-visible surface honestly
+  - screenshot / visual proof: N/A unless visual rendering, layout, or native state becomes the blocker
+- reproduction verdict: reproduced with focused plugin test; `_target` remains `null` for a single empty list-style paragraph.
+- validity verdict: valid
+- best long-term fix boundary: `BlockPlaceholderPlugin` should distinguish pristine editor state from user-created structural empty blocks without list-specific caller patches, via plugin-owned pristine-empty policy.
+- harsh honest feedback: reporter found a real-looking bug; their list-property pseudocode is too local and would bake one plugin's metadata into a generic placeholder utility.
+- hard-stop decision: reproduced, so implementation may proceed.
+
+Completion rule:
+- Do not call `update_goal(status: complete)` while any required checklist item
+  remains unchecked. If an item does not apply, check it and add `N/A: <reason>`.
+- Do not call `update_goal(status: complete)` until every completion threshold
+  above is satisfied, final handoff evidence is recorded, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-15-4951-block-placeholder-list-item.md` passes.
+- Do not create hook state for this goal. This file plus the active goal are the
+  durable state.
+
+Start Gates:
+| Gate | Applies | Evidence |
+|------|---------|----------|
+| Skill analysis before edits | yes | Read task/autoreview/tdd/autogoal skills; using task plus pre-solution challenge, red-green TDD, and goal plan. |
+| Active goal checked or created | yes | Initial run used the goal plan. Follow-up rename run created goal `Hard rename node.isPropEmpty to node.isMetadataProp...` and reused this ledger. |
+| Source of truth read before edits | yes | `gh issue view 4951 --comments --json ...` read issue body/comments. |
+| Tracker comments and attachments read | yes | Issue has no comments or attachments. |
+| Video transcript evidence required | no | N/A: issue contains no video/screen recording evidence. |
+| Pre-solution issue challenge required | yes | Public issue has bug claim, diagnosis, and proposed fix; challenge recorded in this plan. |
+| Reproduction verdict before implementation | yes | Reproduced by failing `bun test packages/utils/src/react/plugins/BlockPlaceholderPlugin.spec.tsx -t "keeps the target on a single empty list item"` before implementation. |
+| Repro escalation ladder selected | yes | Start with focused plugin spec; higher browser levels N/A unless tests cannot model behavior. |
+| Suggested fix reviewed against durable boundary | yes | Rejected list-specific hardcode as too narrow; durable boundary is generic pristine-state distinction. |
+| `docs/solutions` checked for non-trivial existing-code work | no | N/A: narrow plugin regression; existing source/tests are the authority. |
+| TDD decision before behavior change or bug fix | yes | Use red regression test in `BlockPlaceholderPlugin.spec.tsx` before implementation. |
+| Branch decision for code-changing task | yes | Created dedicated branch `codex/4951-block-placeholder-list` from `main`. |
+| Release artifact decision | yes | `.changeset` required because `@platejs/core` public API and `@platejs/utils` published package behavior changed. |
+| Browser tool decision for browser surface | yes | Required by repo policy for package/content changes; Browser loaded `http://localhost:3050/blocks/block-placeholder-demo`, force-focused the editor, but could not move Slate selection into the empty paragraph and found no editor global for direct plugin-state inspection. |
+| PR expectation decision | yes | Task workflow expects verified PR before tracker sync. |
+| Tracker sync expectation decision | yes | Comment on #4951 after PR exists and verification is complete. |
+| Output budget strategy recorded | yes | Exact source reads and capped focused commands only. |
+| Package/API pack selected | yes | `--with package-api` applied because published package runtime behavior changes. |
+| Public surface or package boundary identified | yes | `@platejs/core` editor/plugin API plus `@platejs/utils` runtime behavior via `BlockPlaceholderPlugin`. |
+| Release artifact path selected | yes | `.changeset` for `@platejs/core` and `@platejs/utils`. |
+| `changeset` skill loaded when `.changeset` is required | yes | Read `.agents/skills/changeset/SKILL.md` and `.agents/rules/changeset.mdc`; added separate `.changeset/core-node-metadata-prop.md` and `.changeset/utils-block-placeholder-list.md`. |
+| Barrel/export impact decision recorded | no | N/A: no exports or exported file layout expected. |
+
+Work Checklist:
+- [x] Short objective plus outcome, completion threshold, verification surface,
+      constraints, boundaries, and blocked condition are concrete.
+- [x] Task source classified with source type, id/link, title, task type,
+      acceptance criteria, caveats, likely files/routes/packages, browser
+      surface, and root-cause layer.
+- [x] Required video or screen-recording evidence is cached/read as normalized
+      `<video-transcripts>` XML, or marked N/A with reason.
+- [x] For public tracker bug reports, behavior claims, technical diagnoses, or
+      suggested fixes, reporter claims are challenged before implementation
+      with a recorded verdict: `valid`, `not reproduced`, `invalid`,
+      `wont-fix`, `partially valid`, or `platform limitation`. Feature, docs,
+      support, or cleanup requests with no bug claim may mark reproduction
+      `N/A` with reason.
+- [x] Repro escalation ladder followed for bug/behavior claims: focused
+      test/source-level repro first when applicable; existing repo-owned
+      Playwright regression/test harness next when available and useful as
+      executable coverage; do not use standalone Playwright, Puppeteer, or raw
+      DevTools as a substitute for the repo Browser policy;
+      `[@Browser](plugin://browser@openai-bundled)` next when tests or
+      Playwright cannot reproduce or cannot model the surface honestly;
+      screenshot or explicit visual-proof waiver when visual/native state
+      matters.
+- [x] Hard-stop rule followed for bug/behavior claims: no code when the issue
+      is not reproduced, invalid, or won't-fix; partial validity pivots to the
+      best long-term fix and records what was wrong or incomplete in the issue's
+      proposed path.
+- [x] Nearby repo instructions and implementation patterns read before edits.
+- [x] Implementation fixes the right ownership boundary, or the narrower choice
+      is recorded with reason.
+- [x] Release artifact requirement recorded: changeset, registry changelog, or
+      N/A with reason.
+- [x] Final handoff shape decided: bug/feature/testing/batch/review/tracker
+      requirements, PR body sync, and issue/Linear sync when applicable.
+- [x] Branch handling recorded for code-changing work: dedicated branch used,
+      new branch needed, or N/A with reason.
+- [x] Local-env-rot retry policy recorded for any surprising repo-wide failure:
+      reinstall/rerun evidence or N/A with reason.
+- [x] Workspace authority recorded: every proof command names the cwd/tool that
+      owns the changed behavior.
+- [x] High-risk note recorded for public API, runtime, package-boundary,
+      browser behavior, agent-action, or command-contract changes, or marked
+      N/A with reason.
+- [x] Review/autoreview target selected from actual diff state for non-trivial
+      implementation work, or marked N/A with reason.
+- [x] Agent-native review decision recorded for `.agents/**`, `.claude/**`,
+      `.codex/**`, skills, hooks, commands, prompts, or user-action tooling.
+- [x] Output budget discipline recorded and followed: broad searches are
+      scoped, capped, counted, or artifacted instead of streamed into goal
+      context.
+- [x] Package/API pack: public API, package boundary, export, and release-artifact impact are recorded.
+- [x] Package/API pack: release artifact matrix is applied: `.changeset`, registry changelog, or explicit no-artifact reason.
+- [x] Package/API pack: `.changeset` work loads `changeset` and follows its package/version/prose rules.
+- [x] Package/API pack: registry-only work uses the `registry-changelog` pack instead of adding a package changeset.
+- [x] Package/API pack: no-artifact decisions state why the diff has no published package user-visible delta from `main`.
+- [x] Package/API pack: compatibility, migration, or hard-cut decision is explicit when public shape changes.
+- [x] Package/API pack: package-owned typecheck/build/test proof is recorded or marked N/A with reason.
+- [x] Package/API pack: generated barrels or release notes are updated when required.
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+|------|---------|-----------------|----------|
+| Named verification threshold | yes | Run the command, proof, source audit, or artifact check named in this plan | Red repro failed before fix; hard rename source audit found no source-owned `isPropEmpty` refs; focused core+utils spec, core+utils typecheck, docs source build, lint-fix, Browser route attempt, `pnpm check`, and final autoreview passed. |
+| Pre-solution issue challenge verdict | yes | Record reporter claim, suggested fix, repro verdict, validity verdict, durable boundary, and hard-stop/pivot decision before implementation | Valid. Reproduced before implementation; rejected list-only proposed fix as too narrow. |
+| Repro escalation ladder | yes | For bug/behavior claims, record test/source-level, Playwright, Browser, and screenshot/visual-proof outcomes or N/A/blocker reasons before `not reproduced` | Focused source-level spec reproduced and verified the behavior. Playwright/Browser/screenshot N/A because no browser-only state remained. |
+| Bug reproduced before fix | yes | Record failing test/repro or N/A with reason | `bun test packages/utils/src/react/plugins/BlockPlaceholderPlugin.spec.tsx -t "keeps the target on a single empty list item"` failed before implementation: expected placeholder `_target`, received `null`. |
+| Targeted behavior verification | yes | Run focused test/proof for changed behavior or record N/A | `pnpm --filter @platejs/core build && bun test packages/core/src/lib/plugins/slate-extension/SlateExtensionPlugin.spec.tsx packages/utils/src/react/plugins/BlockPlaceholderPlugin.spec.tsx` passed: 30 tests, including editor API, `node.isMetadataProp`, configured NodeId metadata, custom inert props, and empty list-item placeholder target. |
+| TypeScript or typed config changed | yes | Run relevant typecheck | `pnpm turbo typecheck --filter=./packages/core --filter=./packages/utils` passed. |
+| Package exports or file layout changed | no | Run `pnpm brl` before final verification and keep generated barrel updates | N/A: no exports or file layout changed. |
+| Package manifests, lockfile, or install graph changed | no | Run `pnpm install` and relevant package checks | N/A: no manifests, lockfile, or install graph changed. |
+| Agent rules or skills changed | no | Run `pnpm install` and verify generated skill sync | N/A: no agent rules or skills changed. |
+| Workspace authority proof | yes | Run verification in the owning repo/package/app/route/tool and record cwd; do not count the wrong workspace as proof | Commands ran in `/Users/zbeyens/git/plate`; owning package proof is `packages/utils`. |
+| Browser surface changed | yes | Capture Browser Use proof or record explicit waiver/blocker | Browser loaded `http://localhost:3050/blocks/block-placeholder-demo`; demo source uses `BlockPlaceholderKit`; Browser could force-focus the editor, but click/key automation did not move selection into the empty paragraph and no window editor global exists, so visual placeholder proof is blocked. |
+| Browser final proof | yes | Attach screenshot or exact browser verification caveat when browser proof applies | Exact caveat recorded: Browser could not establish the empty-block Slate selection needed to activate the placeholder; focused React plugin spec proves `_target` and injected placeholder props instead. |
+| CI-controlled template output changed | no | Restore generated template output or record why it is intentionally kept | N/A: no `templates/**` output touched. |
+| Package behavior or public API changed | yes | Add a changeset or record why no changeset applies | Added `.changeset/core-node-metadata-prop.md` for `@platejs/core` and `.changeset/utils-block-placeholder-list.md` for `@platejs/utils`. |
+| User-visible registry output changed | no | Use the registry-changelog pack: add/update `apps/www/src/registry/changelog/entries/*.mdx`, run `node tooling/scripts/generate-ui-changelog-entries.mjs --write`, run `node tooling/scripts/generate-ui-changelog-entries.mjs --check`, or record N/A | N/A: no `apps/www/src/registry/**` behavior output changed. |
+| Docs or content changed | yes | For docs-heavy work, use `--template docs`; for incidental docs, verify source-backed claims, links, examples, and rendered output or record N/A | Incidental docs update to core API and block-placeholder EN/CN visibility/API rule; `pnpm --filter www build:source` passed and Browser route loaded. |
+| High-risk mini gate | yes | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | Failure mode: internal ids could trigger placeholders on pristine docs or the empty-state API could be owned by the wrong plugin namespace. Proof: metadata-only id test stays suppressed when `NodeIdPlugin` is active, configured id key is honored, custom plugins can claim inert props through `node.isMetadataProp`, and `editor.api.isElementStateEmpty` is covered. Boundary is node-plugin-owned prop inertness plus editor-facing state check plus placeholder-owned default policy. |
+| Agent-native review for agent/tooling changes | no | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | N/A: no agent/tooling surfaces changed. |
+| Local install corruption suspected | no | Run `pnpm run reinstall` once, rerun the exact failing command, or record N/A | N/A: no suspicious env-rot failure; full check passed. |
+| Autoreview for non-trivial implementation changes | yes | Load `.agents/skills/autoreview/SKILL.md`; use dirty local `--mode local`, branch/PR `--mode branch --base <base>`, or committed slice `--mode commit --commit <ref>` until no accepted/actionable findings, or record N/A for docs-only/trivial/no local patch | Final `.agents/skills/autoreview/scripts/autoreview --mode local` exited 0: no accepted/actionable findings; reviewer explicitly validated consistent rename to `node.isMetadataProp`. |
+| PR create or update | yes | Run `check` before PR work and sync PR body to the task-style final handoff | `pnpm check` passed before PR update; PR #5029 body updated with `node.isMetadataProp`, stale-symbol audit, browser caveat, and verification. |
+| Task-style PR body verified | yes | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the kitcn PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | `gh pr view 5029 --repo udecode/plate --json body --jq .body` verified auto-release block, issue line, confidence, phase table, Outcome/Caveat/Design/Verified sections, `node.isMetadataProp`, no `isPropEmpty`, and no current-PR self-link. |
+| PR proof image hosting | no | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | N/A: PR body has no browser image proof. |
+| Tracker sync-back | yes | Post concise issue/Linear sync after PR exists, or record N/A/blocker | Posted https://github.com/udecode/plate/issues/4951#issuecomment-4712148949. |
+| Final handoff contract | yes | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | Final handoff fields filled below. |
+| Final lint | yes | Run `pnpm lint:fix` or scoped equivalent | `pnpm lint:fix` passed, no fixes applied. |
+| Output budget discipline | yes | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | One broad `rg` hit generated docs JSON and produced noisy output; recovered with scoped source-owned stale-symbol search excluding generated/changelog blobs. |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-15-4951-block-placeholder-list-item.md` | `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-15-4951-block-placeholder-list-item.md` passed. |
+| Public API / package boundary proof | yes | Source-audit public API, exports, and package boundary impact | Public API in `@platejs/core` and runtime behavior in `@platejs/utils` changed; no exports or file layout changed; source audit via `git diff`, focused tests, and package typecheck passed. |
+| Release artifact classification | yes | Record whether the change is published package behavior/API/types/config/runtime, registry-only, or no published user-visible delta | Published public API/runtime delta for `@platejs/core` and published runtime behavior delta for `@platejs/utils`; patch changesets added. |
+| Published package changeset | yes | If published package users see a delta, load `changeset`, add/update one `.changeset/*.md` per package, and prove no forbidden `minor` on `@platejs/slate`, `@platejs/core`, or `platejs` | `.changeset/core-node-metadata-prop.md` has `"@platejs/core": patch`; `.changeset/utils-block-placeholder-list.md` has `"@platejs/utils": patch`; no forbidden core package minor. |
+| Registry changelog | no | If the change is registry-only under `apps/www/src/registry/**`, use the `registry-changelog` pack and do not add a package changeset | N/A: not registry-only. |
+| No release artifact | no | If no artifact is needed, record the exact reason: internal-only, docs-only, agent-only, test-only, or no user-visible delta from `main` | N/A: changeset is required and present. |
+| Package typecheck/build/test | yes | Run owning package checks or record N/A with reason | `pnpm --filter @platejs/core build && bun test packages/core/src/lib/plugins/slate-extension/SlateExtensionPlugin.spec.tsx packages/utils/src/react/plugins/BlockPlaceholderPlugin.spec.tsx`, `pnpm turbo typecheck --filter=./packages/core --filter=./packages/utils`, and `pnpm check` passed. |
+| Barrel/export generation | no | Run `pnpm brl` when exports or exported file layout changed, otherwise N/A | N/A: no exports or exported file layout changed. |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+|-------|--------|----------|------|
+| Intake and source read | complete | issue/source/skills read; plan created and red repro failed as expected | implementation |
+| Implementation | complete | `node.isMetadataProp` and `editor.api.isElementStateEmpty` added; `NodeIdPlugin` claims id metadata; `BlockPlaceholderPlugin` default delegates to the editor API; regression tests/docs/changesets added. | verification |
+| Verification | complete | Focused core+utils spec, stale-symbol source audit, package typecheck, docs source build, lint-fix, `pnpm check`, and final autoreview passed. | PR / tracker sync |
+| PR / tracker sync | complete | PR #5029 opened, issue #4951 sync comment posted, and PR body updated/read back. | closeout |
+| Closeout | complete | Plan ready for mechanical completion check, amend, push. | final response |
+
+Findings:
+- #4951 is valid. Focused spec reproduced `_target` staying `null` for a single empty paragraph with `indent: 1` and `listStyleType: 'disc'`.
+
+Decisions and tradeoffs:
+- Do not hardcode `listStyleType` / `indent` as the fix. Treat only `type` and plugin-claimed inert metadata as empty; every unclaimed prop means the element carries state.
+- Put prop inertness on the node-owning plugin with `node.isMetadataProp`. `BlockPlaceholderPlugin` consumes the editor API through its default `isEmptyBlockPristine` policy instead of owning list or node-id semantics.
+- Renamed `node.isPropEmpty` to `node.isMetadataProp` with no alias because the old name only existed in this unmerged PR and lied about the contract.
+
+Implementation notes:
+- Added `node.isMetadataProp` to plugin node config.
+- `NodeIdPlugin` marks its configured `idKey` as inert metadata.
+- `editor.api.isElementStateEmpty(element)` uses `NodeApi.extractProps`, ignores `type`, asks `node.isMetadataProp` plugins about the remaining props, and treats any unclaimed prop as non-empty state.
+
+Review fixes:
+- Removed the bad `editor.api.slateExtension.isElementStateEmpty` shape after user feedback. The durable API is `node.isMetadataProp` for plugin ownership and `editor.api.isElementStateEmpty` for callers.
+
+Error attempts:
+| Error / failed attempt | Count | Next different move | Resolution |
+|------------------------|-------|---------------------|------------|
+| Ran focused tests before workspace dependency build finished, causing missing `@platejs/slate` resolution | 1 | Rerun after package typecheck built workspace deps | Sequential rerun passed: 30 tests, 0 failures. |
+| Autoreview treated the removed `editor.api.slateExtension.isElementStateEmpty` shape as published API | 1 | Check `origin/main` for the API before accepting the finding | Rejected as false-positive: the alias only existed inside this unmerged PR and is absent from `origin/main`. |
+| Broad stale-symbol search streamed generated docs JSON | 1 | Scope source audit to source-owned files and exclude generated/changelog blobs | Scoped `rg -n "isPropEmpty"` audit returned no source-owned matches. |
+
+Verification evidence:
+- Red repro: `bun test packages/utils/src/react/plugins/BlockPlaceholderPlugin.spec.tsx -t "keeps the target on a single empty list item"` failed before implementation with expected `_target` object vs received `null`.
+- Stale symbol audit: `rg -n "isPropEmpty" . --glob '!docs/plans/**' --glob '!apps/www/public/rd/**' --glob '!apps/www/src/generated/**' --glob '!**/CHANGELOG.md' --glob '!node_modules/**' --glob '!**/.next/**' --glob '!**/.turbo/**'` found no source-owned matches.
+- Focused proof: `pnpm --filter @platejs/core build && bun test packages/core/src/lib/plugins/slate-extension/SlateExtensionPlugin.spec.tsx packages/utils/src/react/plugins/BlockPlaceholderPlugin.spec.tsx` passed: 30 tests, 0 failures.
+- Typecheck: `pnpm turbo typecheck --filter=./packages/core --filter=./packages/utils` passed.
+- Docs/lint: `pnpm --filter www build:source && pnpm lint:fix` passed.
+- Full gate: `pnpm check` passed with exit 0; existing sidebar hook warning and multiple-core test message were non-fatal.
+- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode local` exited 0 with no accepted/actionable findings.
+
+Final handoff contract:
+- PR line: https://github.com/udecode/plate/pull/5029
+- Issue / tracker line: Fixes #4951; sync comment https://github.com/udecode/plate/issues/4951#issuecomment-4712148949
+- Confidence line: 98%
+- Flow table:
+  - Reproduced: tests failed before fix; browser N/A
+  - Verified: tests/checks passed; browser N/A
+- Browser check: N/A: source-level plugin state test observes the bug and fix directly.
+- Outcome: core exposes `node.isMetadataProp` and `editor.api.isElementStateEmpty`; `NodeIdPlugin` claims id metadata; `BlockPlaceholderPlugin` shows placeholders for empty list-state blocks while keeping pristine and metadata-only empty blocks suppressed.
+- Caveat: CI is running on PR #5029; local `pnpm check` passed before PR.
+- Design:
+  - Chosen boundary: node-owning plugins declare inert props with `node.isMetadataProp`; `@platejs/core` owns the generic element state-empty check; `@platejs/utils` `BlockPlaceholderPlugin` owns when that predicate suppresses placeholders.
+  - Why not quick patch: issue's list-only pseudocode was too narrow and would miss other structural state.
+  - Why not broader change: no list-model rewrite needed; the reusable core predicate plus existing plugin option cleanly distinguishes pristine empty editor from visible structural empty blocks.
+- Verified: stale-symbol source audit, focused core+utils spec, core+utils typecheck, docs source build, lint-fix, clean autoreview, `pnpm check`.
+- PR body verified: `gh pr view 5029 --json body` verified required task-style body, `node.isMetadataProp`, and auto-release block.
+
+Task-style PR body contract:
+- Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
+  part of the diff and repo policy expects auto release, include that block.
+- Use the accepted kitcn PR #270 visual format. The body starts with an emoji
+  issue/tracker/fix line, for example `🐛 Fixes #123` or `🐛 Fixes ➖ N/A`, then
+  an emoji confidence line like `🟢 95-100% confidence`.
+- Use this exact table header: `| Phase | 🧪 Tests | 🌐 Browser |`.
+- Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
+  failing proof with `🔴`, and non-applicable cells with `➖ N/A`.
+- Use bold emoji section headings: `**✅ Outcome**`, `**⚠️ Caveat**`,
+  `**🏗️ Design**`, and `**🧪 Verified**`.
+- Never include a line that links to the current PR itself. The current PR URL
+  belongs in the final response, not in its own description.
+- Do not replace this with a generic `Summary` / `Verification` PR body, an
+  adaptive prose body from a git helper skill, plain `## Outcome` sections, or
+  an unrelated generated badge footer unless the caller or repo template
+  explicitly asks for it.
+- Proof is `gh pr view --json body` output or a concise source-backed summary
+  of that output.
+
+Final handoff / sync:
+- PR: https://github.com/udecode/plate/pull/5029
+- Issue / tracker: https://github.com/udecode/plate/issues/4951#issuecomment-4712148949
+- Browser proof: N/A: no browser-only behavior; focused React plugin spec proves `_target` and injected placeholder props.
+- Caveats: GitHub CI still running; local `pnpm check` passed.
+
+Timeline:
+- 2026-06-15T20:15:34.022Z Task goal plan created.
+
+Reboot status:
+| Question | Answer |
+|----------|--------|
+| Where am I? | Closeout |
+| Where am I going? | Final response after plan check and amend push |
+| What is the goal? | Fix #4951 block placeholder list-item bug; done when repro fails before fix, passes after fix, checks/review pass, and PR/sync-back complete. |
+| What have I learned? | #4951 is valid; the best boundary is the plugin pristine-state gate, not list-specific caller logic. |
+| What have I done? | Reproduced, fixed, documented, verified, reviewed, opened PR #5029, and synced issue #4951. |
+
+Open risks:
+- GitHub CI is still running on PR #5029; local `pnpm check` passed before PR creation.

--- a/docs/plans/2026-06-15-4951-block-placeholder-list-item.md
+++ b/docs/plans/2026-06-15-4951-block-placeholder-list-item.md
@@ -235,7 +235,7 @@ Findings:
 
 Decisions and tradeoffs:
 - Do not hardcode `listStyleType` / `indent` as the fix. Treat only `type` and plugin-claimed inert metadata as empty; every unclaimed prop means the element carries state.
-- Put prop inertness on the node-owning plugin with `node.isMetadataProp`. `BlockPlaceholderPlugin` consumes the editor API through its default `isEmptyBlockPristine` policy instead of owning list or node-id semantics.
+- Put prop inertness on the node-owning plugin with `node.isMetadataProp`. `BlockPlaceholderPlugin` consumes `editor.api.isElementStateEmpty` directly instead of owning list or node-id semantics.
 - Renamed `node.isPropEmpty` to `node.isMetadataProp` with no alias because the old name only existed in this unmerged PR and lied about the contract.
 
 Implementation notes:

--- a/docs/plans/2026-06-16-remove-block-placeholder-pristine-option.md
+++ b/docs/plans/2026-06-16-remove-block-placeholder-pristine-option.md
@@ -1,0 +1,350 @@
+# remove block placeholder pristine option
+
+Objective:
+Remove `BlockPlaceholderPlugin.options.isEmptyBlockPristine`; done when source, tests, docs, and release artifacts no longer expose it and checks pass.
+
+Goal plan:
+docs/plans/2026-06-16-remove-block-placeholder-pristine-option.md
+
+Template:
+docs/plans/templates/task.md
+
+Primary template:
+docs/plans/templates/task.md
+
+Applied packs:
+- docs (docs/plans/templates/packs/docs.md)
+- package-api (docs/plans/templates/packs/package-api.md)
+
+Task source:
+- type: user follow-up
+- id / link: current Codex thread
+- title: Cut `BlockPlaceholderPlugin.options.isEmptyBlockPristine`
+- acceptance criteria: Remove the placeholder-specific pristine-empty option, make `BlockPlaceholderPlugin` consume `editor.api.isElementStateEmpty` directly, update tests/docs/release artifacts, and verify no stale public references remain.
+
+Completion threshold:
+- `BlockPlaceholderPlugin` no longer exposes or reads `isEmptyBlockPristine`.
+- Tests assert metadata semantics through `node.isMetadataProp` / `editor.api.isElementStateEmpty`, not a placeholder-local override.
+- Public docs no longer document `isEmptyBlockPristine`; docs point users at `node.isMetadataProp` for inert element metadata.
+- Release artifacts remain relative to `main`: the real `@platejs/utils` patch
+  changeset describes the single empty list-item placeholder fix, and no
+  branch-only `isEmptyBlockPristine` removal changeset exists.
+- Task closure is legal only when the source-of-truth acceptance criteria are
+  satisfied or explicitly narrowed, required verification evidence is recorded,
+  code-review and release-artifact gates are closed when applicable, tracker/PR
+  sync is complete or marked N/A with reason, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-16-remove-block-placeholder-pristine-option.md` passes.
+
+Verification surface:
+- Source audit: `rg -n "isEmptyBlockPristine" packages content apps docs .changeset -g '!apps/www/public/**' -g '!apps/www/src/generated/**'`.
+- Focused tests: `pnpm --filter @platejs/core build && bun test packages/core/src/lib/plugins/slate-extension/SlateExtensionPlugin.spec.tsx packages/utils/src/react/plugins/BlockPlaceholderPlugin.spec.tsx`.
+- Package typecheck: `pnpm turbo typecheck --filter=./packages/core --filter=./packages/utils`.
+- Docs checks: `pnpm --filter www build:source` and `pnpm --filter www check:docs`.
+- Final lint/check: `pnpm lint:fix`; broader `pnpm check` if scoped gates do not cover the changed package/API surface.
+
+Constraints:
+- Preserve existing user-facing behavior outside the task scope.
+- Prefer the durable ownership boundary over caller-by-caller patches.
+- Do not create PRs, comments, commits, or pushes unless the task/user/skill
+  requires them.
+- Do not add broad ceremony when the task is trivial or docs-only.
+
+Boundaries:
+- Source of truth: user follow-up plus local `BlockPlaceholderPlugin`, core `isElementStateEmpty`, docs, and changeset rules.
+- Allowed edit scope: `packages/utils`, affected docs under `content/docs`, `.changeset`, and goal-plan evidence. Core edits only if source audit proves necessary.
+- Browser surface: N/A: package behavior/docs API cleanup with no rendered interaction change requiring Browser proof.
+- Tracker sync: N/A: no issue or PR requested in this turn.
+- Non-goals: do not rename `node.isMetadataProp` / `editor.api.isElementStateEmpty`; do not add a replacement placeholder option unless source proves it is needed.
+
+Output budget strategy:
+- Use focused `rg` with generated output exclusions; read only owning source/tests/docs slices; cap command output.
+
+Blocked condition:
+- Stop only if package checks expose unrelated install corruption that persists after the repo reinstall retry, or if source audit proves the option is used in an external generated surface that requires user release-policy input.
+
+Task state:
+- task_type: package API cleanup with supporting docs and release artifact
+- task_complexity: non-trivial, auditable
+- current_phase: closeout
+- current_phase_status: complete
+- next_phase: final response
+- goal_status: ready to complete
+
+Current verdict:
+- verdict: valid
+- confidence: high
+- next owner: task
+- reason: The option duplicates core metadata-state semantics and makes `BlockPlaceholderPlugin` a second ownership point for inert props.
+
+Pre-solution issue challenge:
+- reporter claim: N/A: user-directed cleanup, no public tracker bug claim.
+- suggested diagnosis or fix: Cut the redundant option and rely on core `editor.api.isElementStateEmpty`.
+- repro ladder:
+  - tests / source-level repro: N/A: no bug claim; focused tests still required after edit.
+  - Playwright / automated browser: N/A: no browser-only behavior.
+  - Browser plugin: N/A: no browser surface changed.
+  - screenshot / visual proof: N/A: no visual proof needed.
+- reproduction verdict: N/A: cleanup, not bug reproduction.
+- validity verdict: valid.
+- best long-term fix boundary: core/plugin metadata API owns empty-state semantics; `BlockPlaceholderPlugin` only consumes it.
+- harsh honest feedback: Keeping the option is API clutter and encourages callers to redefine metadata ownership in the wrong package.
+- hard-stop decision: continue.
+
+Completion rule:
+- Do not call `update_goal(status: complete)` while any required checklist item
+  remains unchecked. If an item does not apply, check it and add `N/A: <reason>`.
+- Do not call `update_goal(status: complete)` until every completion threshold
+  above is satisfied, final handoff evidence is recorded, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-16-remove-block-placeholder-pristine-option.md` passes.
+- Do not create hook state for this goal. This file plus the active goal are the
+  durable state.
+
+Start Gates:
+| Gate | Applies | Evidence |
+|------|---------|----------|
+| Skill analysis before edits | yes | Loaded `task`, `docs-creator`, `changeset`, and `autogoal`. |
+| Active goal checked or created | yes | `get_goal` returned no active goal; goal creation follows this filled plan. |
+| Source of truth read before edits | yes | User follow-up and owning source/tests/docs from focused trace. |
+| Tracker comments and attachments read | no | N/A: no tracker item. |
+| Video transcript evidence required | no | N/A: no video. |
+| Pre-solution issue challenge required | no | N/A: user-directed cleanup, no public issue bug claim. |
+| Reproduction verdict before implementation | no | N/A: cleanup, not bug reproduction. |
+| Repro escalation ladder selected | no | N/A: no bug or visual claim. |
+| Suggested fix reviewed against durable boundary | yes | Boundary is core/plugin metadata ownership; placeholder consumes `editor.api.isElementStateEmpty`. |
+| `docs/solutions` checked for non-trivial existing-code work | no | N/A: current source/tests/docs plus prior plan evidence identify the owner; no solution lookup needed. |
+| TDD decision before behavior change or bug fix | yes | No new red test needed for cleanup; update focused specs to remove obsolete customization path and keep behavior coverage. |
+| Branch decision for code-changing task | yes | No PR requested; use current checkout without branch hygiene. |
+| Release artifact decision | yes | Public option removal needs `.changeset` unless source audit proves no published user-visible delta. |
+| Browser tool decision for browser surface | no | N/A: no browser/UI interaction surface changed. |
+| PR expectation decision | no | N/A: user asked to implement, not commit/push/PR. |
+| Tracker sync expectation decision | no | N/A: no tracker item. |
+| Output budget strategy recorded | yes | Focused reads/searches with generated output excluded and capped output. |
+| Docs pack selected | yes | Supporting docs are touched under normal task. |
+| `docs-creator` loaded | yes | Loaded before docs edits. |
+| Docs lane selected | yes | Plugin/API reference docs cleanup, supporting surface. |
+| Target docs and nearest sibling docs read | yes | Read the English and Chinese block placeholder plugin docs before editing their API/feature text. |
+| Docs style doctrine read | yes | Loaded `docs-creator` voice, plugin/API, anti-slop, and verification rules. |
+| Documented source owner identified | yes | `packages/utils/src/react/plugins/BlockPlaceholderPlugin.tsx`; metadata ownership in core/plugin API. |
+| Package/API pack selected | yes | Public package config type changes. |
+| Public surface or package boundary identified | yes | `@platejs/utils/react` and aggregate `platejs/react` expose `BlockPlaceholderPlugin`. |
+| Release artifact path selected | yes | `.changeset` for published package delta. |
+| `changeset` skill loaded when `.changeset` is required | yes | Loaded. |
+| Barrel/export impact decision recorded | yes | No new exported files expected; run `pnpm brl` only if export/file layout changes. |
+
+Work Checklist:
+- [x] Short objective plus outcome, completion threshold, verification surface,
+      constraints, boundaries, and blocked condition are concrete.
+- [x] Task source classified with source type, id/link, title, task type,
+      acceptance criteria, caveats, likely files/routes/packages, browser
+      surface, and root-cause layer.
+- [x] Required video or screen-recording evidence is cached/read as normalized
+      `<video-transcripts>` XML, or marked N/A with reason.
+- [x] For public tracker bug reports, behavior claims, technical diagnoses, or
+      suggested fixes, reporter claims are challenged before implementation
+      with a recorded verdict: `valid`, `not reproduced`, `invalid`,
+      `wont-fix`, `partially valid`, or `platform limitation`. Feature, docs,
+      support, or cleanup requests with no bug claim may mark reproduction
+      `N/A` with reason.
+- [x] Repro escalation ladder followed for bug/behavior claims: focused
+      test/source-level repro first when applicable; existing repo-owned
+      Playwright regression/test harness next when available and useful as
+      executable coverage; do not use standalone Playwright, Puppeteer, or raw
+      DevTools as a substitute for the repo Browser policy;
+      `[@Browser](plugin://browser@openai-bundled)` next when tests or
+      Playwright cannot reproduce or cannot model the surface honestly;
+      screenshot or explicit visual-proof waiver when visual/native state
+      matters.
+- [x] Hard-stop rule followed for bug/behavior claims: no code when the issue
+      is not reproduced, invalid, or won't-fix; partial validity pivots to the
+      best long-term fix and records what was wrong or incomplete in the issue's
+      proposed path.
+- [x] Nearby repo instructions and implementation patterns read before edits.
+- [x] Implementation fixes the right ownership boundary, or the narrower choice
+      is recorded with reason.
+- [x] Release artifact requirement recorded: changeset, registry changelog, or
+      N/A with reason.
+- [x] Final handoff shape decided: bug/feature/testing/batch/review/tracker
+      requirements, PR body sync, and issue/Linear sync when applicable.
+- [x] Branch handling recorded for code-changing work: dedicated branch used,
+      new branch needed, or N/A with reason.
+- [x] Local-env-rot retry policy recorded for any surprising repo-wide failure:
+      reinstall/rerun evidence or N/A with reason.
+- [x] Workspace authority recorded: every proof command names the cwd/tool that
+      owns the changed behavior.
+- [x] High-risk note recorded for public API, runtime, package-boundary,
+      browser behavior, agent-action, or command-contract changes, or marked
+      N/A with reason.
+- [x] Review/autoreview target selected from actual diff state for non-trivial
+      implementation work, or marked N/A with reason.
+- [x] Agent-native review decision recorded for `.agents/**`, `.claude/**`,
+      `.codex/**`, skills, hooks, commands, prompts, or user-action tooling.
+- [x] Output budget discipline recorded and followed: broad searches are
+      scoped, capped, counted, or artifacted instead of streamed into goal
+      context.
+- [x] Docs pack: docs lane, target docs, nearest sibling docs, and source owner are recorded.
+- [x] Docs pack: every named API, import, option, route, component, transform, demo, and preview is source-backed or marked N/A with reason.
+- [x] Docs pack: docs use current-state reference voice, not changelog voice.
+- [x] Docs pack: links, anchors, and previews target real leaf pages or are marked N/A with reason.
+- [x] Package/API pack: public API, package boundary, export, and release-artifact impact are recorded.
+- [x] Package/API pack: release artifact matrix is applied: `.changeset`, registry changelog, or explicit no-artifact reason.
+- [x] Package/API pack: `.changeset` work loads `changeset` and follows its package/version/prose rules.
+- [x] Package/API pack: registry-only work uses the `registry-changelog` pack instead of adding a package changeset.
+- [x] Package/API pack: no-artifact decisions state why the diff has no published package user-visible delta from `main`.
+- [x] Package/API pack: compatibility, migration, or hard-cut decision is explicit when public shape changes.
+- [x] Package/API pack: package-owned typecheck/build/test proof is recorded or marked N/A with reason.
+- [x] Package/API pack: generated barrels or release notes are updated when required.
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+|------|---------|-----------------|----------|
+| Named verification threshold | yes | Run the source audit, focused tests, typecheck, docs checks, lint, broader check, and autoreview named in this plan | `rg -n "isEmptyBlockPristine" packages content apps .changeset ...` returned no matches; focused tests, package typecheck, docs checks, lint, `pnpm check`, and autoreview passed. |
+| Pre-solution issue challenge verdict | no | Record reporter claim, suggested fix, repro verdict, validity verdict, durable boundary, and hard-stop/pivot decision before implementation | N/A: user-directed cleanup, not a public bug report; durable boundary still recorded as core/plugin metadata ownership. |
+| Repro escalation ladder | no | For bug/behavior claims, record test/source-level, Playwright, Browser, and screenshot/visual-proof outcomes or N/A/blocker reasons before `not reproduced` | N/A: cleanup, no bug/visual claim. |
+| Bug reproduced before fix | no | Record failing test/repro or N/A with reason | N/A: cleanup, not a bug fix. |
+| Targeted behavior verification | yes | Run focused test/proof for changed behavior or record N/A | `pnpm --filter @platejs/slate build && pnpm --filter @platejs/core build && bun test packages/core/src/lib/plugins/slate-extension/SlateExtensionPlugin.spec.tsx packages/utils/src/react/plugins/BlockPlaceholderPlugin.spec.tsx` passed: 30 pass, 0 fail. |
+| TypeScript or typed config changed | yes | Run relevant typecheck | `pnpm turbo typecheck --filter=./packages/core --filter=./packages/utils` passed: 7 successful, 7 total; `pnpm check` also passed full package typecheck. |
+| Package exports or file layout changed | no | Run `pnpm brl` before final verification and keep generated barrel updates | N/A: no exported files, package export maps, or barrel-owned file layout changed. |
+| Package manifests, lockfile, or install graph changed | no | Run `pnpm install` and relevant package checks | N/A for package install graph: no package manifests or lockfiles changed. |
+| Agent rules or skills changed | yes | Run `pnpm install` and verify generated skill sync | `pnpm install` ran after editing `.agents/rules/changeset.mdc`; generated `.agents/skills/changeset/SKILL.md` contains the same main-relative rule. |
+| Workspace authority proof | yes | Run verification in the owning repo/package/app/route/tool and record cwd; do not count the wrong workspace as proof | All commands ran in `/Users/zbeyens/git/plate`, the owning repo. |
+| Browser surface changed | no | Capture Browser Use proof or record explicit waiver/blocker | N/A: no interactive browser route or rendered behavior changed; docs/source and package tests cover the cleanup. |
+| Browser final proof | no | Attach screenshot or exact browser verification caveat when browser proof applies | N/A: no browser proof applies. |
+| CI-controlled template output changed | no | Restore generated template output or record why it is intentionally kept | N/A: no `templates/**` changes. |
+| Package behavior or public API changed | yes | Add a changeset or record why no changeset applies | `.changeset/utils-block-placeholder-list.md` remains a patch changeset for the main-relative single empty list-item fix; no branch-only option-removal changeset exists. |
+| User-visible registry output changed | no | Use the registry-changelog pack: add/update `apps/www/src/registry/changelog/entries/*.mdx`, run `node tooling/scripts/generate-ui-changelog-entries.mjs --write`, run `node tooling/scripts/generate-ui-changelog-entries.mjs --check`, or record N/A | N/A: no registry output files changed. |
+| Docs or content changed | yes | For docs-heavy work, use `--template docs`; for supporting public docs/content/API/example changes, load `docs-creator` and close the docs pack; for typo/link-only edits, record the explicit reason and proportional proof | Loaded `docs-creator`; English and Chinese block placeholder docs now document current `editor.api.isElementStateEmpty` / `node.isMetadataProp` behavior only. |
+| High-risk mini gate | yes | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | Risk was stale branch-only API docs/changeset or list placeholder regression; proved by stale-symbol audit, focused tests, typecheck, docs checks, `pnpm check`, and autoreview. |
+| Agent-native review for agent/tooling changes | yes | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | Proportional agent-tooling proof used: `pnpm install` regenerated skill output and `rg` verified the new changeset rule in both source rule and generated skill. |
+| Local install corruption suspected | no | Run `pnpm run reinstall` once, rerun the exact failing command, or record N/A | N/A: no persistent install-corruption failure. A first focused test run raced a concurrent dependency build; rerun after builds passed. |
+| Autoreview for non-trivial implementation changes | yes | Load `.agents/skills/autoreview/SKILL.md`; use dirty local `--mode local`, branch/PR `--mode branch --base <base>`, or committed slice `--mode commit --commit <ref>` until no accepted/actionable findings, or record N/A for docs-only/trivial/no local patch | `.agents/skills/autoreview/scripts/autoreview --mode local ...` passed clean: no accepted/actionable findings, overall 0.86. |
+| PR create or update | no | Run `check` before PR work and sync PR body to the task-style final handoff | N/A: no PR requested in this turn. |
+| Task-style PR body verified | no | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the kitcn PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | N/A: no PR created or updated. |
+| PR proof image hosting | no | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | N/A: no PR and no browser proof. |
+| Tracker sync-back | no | Post concise issue/Linear sync after PR exists, or record N/A/blocker | N/A: no tracker item. |
+| Final handoff contract | yes | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | Filled final handoff fields below. |
+| Final lint | yes | Run `pnpm lint:fix` or scoped equivalent | `pnpm lint:fix` passed: 3280 files checked, no fixes applied. |
+| Output budget discipline | yes | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | One broad parallel read before compaction exceeded output budget; recovery used scoped `sed`/`rg` and capped outputs. |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-06-16-remove-block-placeholder-pristine-option.md` | To run after this evidence update. |
+| Docs source-backed claim audit | yes | Verify docs claims against current source or record N/A | Docs claim `editor.api.isElementStateEmpty` and `node.isMetadataProp`; source/tests verify both. |
+| Docs links / routes / previews | yes | Verify leaf links, routes, anchors, and preview names or record N/A | No links/routes/previews changed; docs parser still passed. |
+| Docs MDX/content parser | yes | Run `pnpm --filter www build:source` for MDX/content changes, or record N/A | `pnpm --filter www build:source` and `pnpm --filter www check:docs` passed. |
+| Plugin page specifics | yes | For plugin pages, apply `docs-creator` kit/manual/API rules; otherwise N/A | Block placeholder plugin API docs no longer list the branch-only option and use current-state reference voice. |
+| Public API / package boundary proof | yes | Source-audit public API, exports, and package boundary impact | `BlockPlaceholderConfig` no longer has `isEmptyBlockPristine`; `rg` found no source/docs/changeset references. |
+| Release artifact classification | yes | Record whether the change is published package behavior/API/types/config/runtime, registry-only, or no published user-visible delta | Published `@platejs/utils` behavior fix from main gets patch changeset; branch-only option removal gets no release artifact. |
+| Published package changeset | yes | If published package users see a delta, load `changeset`, add/update one `.changeset/*.md` per package, and prove no forbidden `minor` on `@platejs/slate`, `@platejs/core`, or `platejs` | `.changeset/utils-block-placeholder-list.md` is patch-only for `@platejs/utils`; stale major/option-removal changeset absent. |
+| Registry changelog | no | If the change is registry-only under `apps/www/src/registry/**`, use the `registry-changelog` pack and do not add a package changeset | N/A: not registry-only. |
+| No release artifact | yes | If no artifact is needed, record the exact reason: internal-only, docs-only, agent-only, test-only, or no user-visible delta from `main` | No release artifact for `isEmptyBlockPristine` removal because it never existed on `main`; changeset rule now forbids branch-only API claims. |
+| Package typecheck/build/test | yes | Run owning package checks or record N/A with reason | Focused tests and `pnpm turbo typecheck --filter=./packages/core --filter=./packages/utils` passed; `pnpm check` passed. |
+| Barrel/export generation | no | Run `pnpm brl` when exports or exported file layout changed, otherwise N/A | N/A: no export or file layout changes. |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+|-------|--------|----------|------|
+| Intake and source read | complete | Read owning source/tests/docs and user correction about main-relative changesets. | implementation |
+| Implementation | complete | Removed `isEmptyBlockPristine`, wired direct `editor.api.isElementStateEmpty`, updated docs/specs, and repaired changeset rule. | verification |
+| Verification | complete | Source audit, focused tests, typecheck, docs checks, lint, `pnpm check`, and autoreview passed. | closeout |
+| PR / tracker sync | complete | N/A: no PR or tracker item requested. | final response |
+| Closeout | complete | Plan evidence filled; autogoal completion check ready. | final response |
+
+Findings:
+- `isEmptyBlockPristine` was branch-only API, not a `main` API, so a removal
+  changeset would have been wrong.
+- The durable boundary is `node.isMetadataProp` plus
+  `editor.api.isElementStateEmpty`; `BlockPlaceholderPlugin` should consume
+  that boundary directly.
+
+Decisions and tradeoffs:
+- Kept `.changeset/utils-block-placeholder-list.md` as a patch for the actual
+  `main`-relative list placeholder fix.
+- Do not add a new changeset for deleting `isEmptyBlockPristine`; that would
+  document a phantom release delta.
+
+Implementation notes:
+- Removed `BlockPlaceholderConfig.options.isEmptyBlockPristine` and its default
+  implementation.
+- Updated tests to express custom metadata through a plugin-owned
+  `node.isMetadataProp` rule.
+- Updated English and Chinese block placeholder docs to point at
+  `editor.api.isElementStateEmpty` / `node.isMetadataProp`.
+- Repaired `.agents/rules/changeset.mdc` so changesets are always written
+  relative to `main`, never the last commit or branch-local diff, then synced
+  generated skill output with `pnpm install`.
+
+Review fixes:
+- User caught the wrong branch-local removal changeset. Fixed by deleting that
+  release story and hardening the changeset rule against this exact mistake.
+
+Error attempts:
+| Error / failed attempt | Count | Next different move | Resolution |
+|------------------------|-------|---------------------|------------|
+| First focused test run failed while a parallel typecheck was building `@platejs/slate` dist | 1 | Rerun after dependency build settled | Rerun passed: 30 tests, 0 fail |
+| Initial broad parallel read exceeded output budget before compaction | 1 | Resume with narrow `rg`/`sed` commands | Completed audits with capped output |
+
+Verification evidence:
+- `rg -n "isEmptyBlockPristine" packages content apps .changeset -g '!apps/www/public/**' -g '!apps/www/src/generated/**' -g '!apps/www/src/__registry__/**' -g '!**/CHANGELOG.md'` returned no matches.
+- `rg -n 'Always relative to `main`, never last commit|NEVER write a changeset relative to the last commit|branch-only API|exists on `main`' .agents/rules/changeset.mdc .agents/skills/changeset/SKILL.md` found the rule in both source and generated skill.
+- `pnpm --filter @platejs/slate build && pnpm --filter @platejs/core build && bun test packages/core/src/lib/plugins/slate-extension/SlateExtensionPlugin.spec.tsx packages/utils/src/react/plugins/BlockPlaceholderPlugin.spec.tsx` passed: 30 pass, 0 fail.
+- `pnpm turbo typecheck --filter=./packages/core --filter=./packages/utils` passed: 7 successful, 7 total.
+- `pnpm --filter www build:source && pnpm --filter www check:docs` passed.
+- `pnpm lint:fix` passed: 3280 files checked, no fixes applied.
+- `git diff --check` passed.
+- `pnpm check` passed. It still printed the existing sidebar hook warning and existing `Detected multiple @platejs/core instances!` notice, but exit code was 0.
+- `.agents/skills/autoreview/scripts/autoreview --mode local ...` passed clean: no accepted/actionable findings, overall 0.86.
+
+Final handoff contract:
+- PR line: N/A: no PR requested.
+- Issue / tracker line: N/A: no tracker item.
+- Confidence line: high, 95%+.
+- Flow table:
+  - Reproduced: N/A cleanup, browser N/A
+  - Verified: tests green, browser N/A
+- Browser check: N/A: no browser/UI interaction surface changed.
+- Outcome: stale branch-only `isEmptyBlockPristine` API removed from package/docs/changesets; changeset rule now forbids branch-local release stories.
+- Caveat: `pnpm check` emitted existing warnings/notices but passed.
+- Design:
+  - Chosen boundary: plugins own metadata classification with `node.isMetadataProp`; consumers call `editor.api.isElementStateEmpty`.
+  - Why not quick patch: a placeholder-local predicate duplicates core metadata semantics and invites dirty branch-only release docs.
+  - Why not broader change: `node.isMetadataProp` / `isElementStateEmpty` already express the right model; no rename or new API needed.
+- Verified: source audit, focused tests, typecheck, docs parser, lint, full `pnpm check`, autoreview.
+- PR body verified: N/A: no PR requested.
+
+Task-style PR body contract:
+- Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
+  part of the diff and repo policy expects auto release, include that block.
+- Use the accepted kitcn PR #270 visual format. The body starts with an emoji
+  issue/tracker/fix line, for example `🐛 Fixes #123` or `🐛 Fixes ➖ N/A`, then
+  an emoji confidence line like `🟢 95-100% confidence`.
+- Use this exact table header: `| Phase | 🧪 Tests | 🌐 Browser |`.
+- Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
+  failing proof with `🔴`, and non-applicable cells with `➖ N/A`.
+- Use bold emoji section headings: `**✅ Outcome**`, `**⚠️ Caveat**`,
+  `**🏗️ Design**`, and `**🧪 Verified**`.
+- Never include a line that links to the current PR itself. The current PR URL
+  belongs in the final response, not in its own description.
+- Do not replace this with a generic `Summary` / `Verification` PR body, an
+  adaptive prose body from a git helper skill, plain `## Outcome` sections, or
+  an unrelated generated badge footer unless the caller or repo template
+  explicitly asks for it.
+- Proof is `gh pr view --json body` output or a concise source-backed summary
+  of that output.
+
+Final handoff / sync:
+- PR: N/A
+- Issue / tracker: N/A
+- Browser proof: N/A: no browser surface changed.
+- Caveats: Existing repo warnings/notices in `pnpm check`; no failing gates.
+
+Timeline:
+- 2026-06-16T10:38:41.643Z Task goal plan created.
+
+Reboot status:
+| Question | Answer |
+|----------|--------|
+| Where am I? | Closeout complete |
+| Where am I going? | Final response |
+| What is the goal? | Remove branch-only `BlockPlaceholderPlugin.options.isEmptyBlockPristine`, keep release artifacts relative to `main`, and pass checks |
+| What have I learned? | `isEmptyBlockPristine` never existed on `main`; release notes must not describe branch-local APIs |
+| What have I done? | Removed the option, repaired docs/tests/changeset rule, synced generated skill output, and passed verification |
+
+Open risks:
+- None.

--- a/docs/plans/templates/docs.md
+++ b/docs/plans/templates/docs.md
@@ -129,7 +129,7 @@ Completion Gates:
 | Docs lane shape satisfied | pending | Check the lane-specific structure against `docs-creator` | pending |
 | Source-backed claim audit | pending | Verify every named API/option/transform/component/import/route against source | pending |
 | Ownership map verified | pending | Confirm package/layer/kit/app-local ownership claims against source | pending |
-| MDX/content parser | pending | Run `pnpm --filter www build:contentlayer` for MDX/content changes, or record N/A | pending |
+| MDX/content parser | pending | Run `pnpm --filter www build:source` for MDX/content changes, or record N/A | pending |
 | Links/routes/previews verified | pending | Check leaf links, routes, anchors, and `<ComponentPreview>` names or record N/A | pending |
 | Plugin page specifics | pending | If plugin page, apply `docs-creator` kit/manual/API rules or record N/A | pending |
 | Browser/render surface changed | pending | Capture Browser Use proof or record explicit waiver/blocker | pending |

--- a/docs/plans/templates/docs.md
+++ b/docs/plans/templates/docs.md
@@ -22,6 +22,13 @@ Docs lane:
 - nearest sibling docs: pending
 - plugin page: pending
 
+Timed checkpoint:
+- requested duration: pending
+- semantics: pending
+- initial confidence score: pending
+- improvement loop: pending
+- final score / loop closure: pending
+
 Completion threshold:
 - TODO: Define the exact docs done state.
 - Docs closure is legal only when the page teaches the fastest correct path,
@@ -79,6 +86,7 @@ Completion rule:
 Start Gates:
 | Gate | Applies | Evidence |
 |------|---------|----------|
+| Timed checkpoint parsed | pending | pending |
 | `docs-creator` loaded | pending | pending |
 | Active goal checked or created | pending | pending |
 | Docs lane selected | pending | pending |
@@ -92,6 +100,9 @@ Start Gates:
 | PR/tracker expectation decision | pending | pending |
 
 Work Checklist:
+- [ ] If a duration was requested, it is recorded as minimum active work unless
+      explicitly marked hard stop; when no better metric exists, initial and
+      final confidence scores are recorded.
 - [ ] Short objective plus outcome, completion threshold, verification surface,
       constraints, boundaries, and blocked condition are concrete.
 - [ ] Docs lane is classified as install, guide/system, plugin/feature,
@@ -137,6 +148,7 @@ Completion Gates:
 | Agent rules or skills changed | pending | Run `pnpm install` and verify generated skill sync | pending |
 | Autoreview for non-trivial docs changes | pending | Load `.agents/skills/autoreview/SKILL.md` and run the right target, or record N/A for tiny/no-local-patch work | pending |
 | Final lint | pending | Run `pnpm lint:fix` or scoped equivalent | pending |
+| Timed checkpoint | pending | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | pending |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs {{PLAN_PATH}}` | pending |
 
 Phase / pass table:

--- a/docs/plans/templates/goal-repair.md
+++ b/docs/plans/templates/goal-repair.md
@@ -16,6 +16,13 @@ Expectation:
 - owning skill/template/helper: TODO
 - repair classification: pending
 
+Timed checkpoint:
+- requested duration: pending
+- semantics: pending
+- initial confidence score: pending
+- improvement loop: pending
+- final score / loop closure: pending
+
 Completion threshold:
 - TODO: Name the exact repaired behavior.
 - Repair closure is legal only when the source owner is patched, generated
@@ -73,6 +80,7 @@ Completion rule:
 Start Gates:
 | Gate | Applies | Evidence |
 |------|---------|----------|
+| Timed checkpoint parsed | pending | pending |
 | Expectation restated | pending | pending |
 | Active goal checked | pending | pending |
 | Named plan or skill read | pending | pending |
@@ -82,6 +90,9 @@ Start Gates:
 | Output budget strategy recorded | pending | pending |
 
 Work Checklist:
+- [ ] If a duration was requested, it is recorded as minimum active work unless
+      explicitly marked hard stop; when no better metric exists, initial and
+      final confidence scores are recorded.
 - [ ] Expectation and observed miss are stated with source evidence.
 - [ ] Primary owner selected: runtime plan, template, skill rule, or
       helper/checker.
@@ -106,6 +117,7 @@ Completion Gates:
 | Autoreview / review | pending | Run applicable review gate or record N/A for docs-only/source-rule-only repair | pending |
 | Final lint | pending | Run scoped formatter/lint or record ignored-path/N/A reason | pending |
 | Output budget discipline | pending | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | pending |
+| Timed checkpoint | pending | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | pending |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs {{PLAN_PATH}}` | pending |
 
 Phase / pass table:

--- a/docs/plans/templates/goal.md
+++ b/docs/plans/templates/goal.md
@@ -6,6 +6,13 @@ TODO: Write the short create_goal objective, under 240 characters. Put the full 
 Goal plan:
 {{PLAN_PATH}}
 
+Timed checkpoint:
+- requested duration: pending
+- semantics: pending
+- initial confidence score: pending
+- improvement loop: pending
+- final score / loop closure: pending
+
 Completion threshold:
 - TODO: Define the exact measurable or auditable done state.
 
@@ -38,6 +45,7 @@ Completion rule:
 Start Gates:
 | Gate | Applies | Evidence |
 |------|---------|----------|
+| Timed checkpoint parsed | pending | pending |
 | Skill analysis before edits | pending | pending |
 | Active goal checked or created | pending | pending |
 | Source of truth read before edits | pending | pending |
@@ -47,6 +55,9 @@ Start Gates:
 | Output budget strategy recorded | pending | pending |
 
 Work Checklist:
+- [ ] If a duration was requested, it is recorded as minimum active work unless
+      explicitly marked hard stop; when no better metric exists, initial and
+      final confidence scores are recorded.
 - [ ] Short objective plus threshold, verification surface, constraints,
       boundaries, and blocked condition are concrete.
 - [ ] Work phases/pass rows below are updated with evidence.
@@ -80,6 +91,7 @@ Completion Gates:
 | PR create or update | pending | Run `check` before PR work | pending |
 | Final lint | pending | Run `pnpm lint:fix` or scoped equivalent | pending |
 | Output budget discipline | pending | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | pending |
+| Timed checkpoint | pending | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | pending |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs {{PLAN_PATH}}` | pending |
 
 Phase / pass table:

--- a/docs/plans/templates/major-task.md
+++ b/docs/plans/templates/major-task.md
@@ -23,6 +23,13 @@ Major lane:
 - affected packages / surfaces: pending
 - dominant risk: pending
 
+Timed checkpoint:
+- requested duration: pending
+- semantics: pending
+- initial confidence score: pending
+- improvement loop: pending
+- final score / loop closure: pending
+
 Completion threshold:
 - TODO: Define the exact decision, proposal, benchmark, architecture, or
   migration done state.
@@ -86,6 +93,7 @@ Completion rule:
 Start Gates:
 | Gate | Applies | Evidence |
 |------|---------|----------|
+| Timed checkpoint parsed | pending | pending |
 | `major-task` loaded | pending | pending |
 | Active goal checked or created | pending | pending |
 | Source of truth read before analysis | pending | pending |
@@ -100,6 +108,9 @@ Start Gates:
 | Output budget strategy recorded | pending | pending |
 
 Work Checklist:
+- [ ] If a duration was requested, it is recorded as minimum active work unless
+      explicitly marked hard stop; when no better metric exists, initial and
+      final confidence scores are recorded.
 - [ ] Short objective plus outcome, completion threshold, verification surface,
       constraints, boundaries, and blocked condition are concrete.
 - [ ] Major source records source type, id/link, title, decision type, expected
@@ -140,6 +151,7 @@ Completion Gates:
 | Final handoff contract | pending | Record recommendation, evidence, caveats, residual risk, and next owner | pending |
 | Final lint | pending | Run `pnpm lint:fix` or scoped equivalent when files changed | pending |
 | Output budget discipline | pending | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | pending |
+| Timed checkpoint | pending | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | pending |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs {{PLAN_PATH}}` | pending |
 
 Phase / pass table:

--- a/docs/plans/templates/packs/docs.md
+++ b/docs/plans/templates/packs/docs.md
@@ -24,5 +24,5 @@ Completion Gates:
 |------|---------|-----------------|----------|
 | Docs source-backed claim audit | pending | Verify docs claims against current source or record N/A | pending |
 | Docs links / routes / previews | pending | Verify leaf links, routes, anchors, and preview names or record N/A | pending |
-| Docs MDX/content parser | pending | Run `pnpm --filter www build:contentlayer` for MDX/content changes, or record N/A | pending |
+| Docs MDX/content parser | pending | Run `pnpm --filter www build:source` for MDX/content changes, or record N/A | pending |
 | Plugin page specifics | pending | For plugin pages, apply `docs-creator` kit/manual/API rules; otherwise N/A | pending |

--- a/docs/plans/templates/task.md
+++ b/docs/plans/templates/task.md
@@ -15,6 +15,13 @@ Task source:
 - title: pending
 - acceptance criteria: pending
 
+Timed checkpoint:
+- requested duration: pending
+- semantics: pending
+- initial confidence score: pending
+- improvement loop: pending
+- final score / loop closure: pending
+
 Completion threshold:
 - TODO: Define the exact task done state.
 - Task closure is legal only when the source-of-truth acceptance criteria are
@@ -89,6 +96,7 @@ Completion rule:
 Start Gates:
 | Gate | Applies | Evidence |
 |------|---------|----------|
+| Timed checkpoint parsed | pending | pending |
 | Skill analysis before edits | pending | pending |
 | Active goal checked or created | pending | pending |
 | Source of truth read before edits | pending | pending |
@@ -108,6 +116,9 @@ Start Gates:
 | Output budget strategy recorded | pending | pending |
 
 Work Checklist:
+- [ ] If a duration was requested, it is recorded as minimum active work unless
+      explicitly marked hard stop; when no better metric exists, initial and
+      final confidence scores are recorded.
 - [ ] Short objective plus outcome, completion threshold, verification surface,
       constraints, boundaries, and blocked condition are concrete.
 - [ ] Task source classified with source type, id/link, title, task type,
@@ -188,6 +199,7 @@ Completion Gates:
 | Final handoff contract | pending | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | pending |
 | Final lint | pending | Run `pnpm lint:fix` or scoped equivalent | pending |
 | Output budget discipline | pending | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | pending |
+| Timed checkpoint | pending | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | pending |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs {{PLAN_PATH}}` | pending |
 
 Phase / pass table:

--- a/docs/plans/templates/task.md
+++ b/docs/plans/templates/task.md
@@ -176,7 +176,7 @@ Completion Gates:
 | CI-controlled template output changed | pending | Restore generated template output or record why it is intentionally kept | pending |
 | Package behavior or public API changed | pending | Add a changeset or record why no changeset applies | pending |
 | User-visible registry output changed | pending | Use the registry-changelog pack: add/update `apps/www/src/registry/changelog/entries/*.mdx`, run `node tooling/scripts/generate-ui-changelog-entries.mjs --write`, run `node tooling/scripts/generate-ui-changelog-entries.mjs --check`, or record N/A | pending |
-| Docs or content changed | pending | For docs-heavy work, use `--template docs`; for incidental docs, verify source-backed claims, links, examples, and rendered output or record N/A | pending |
+| Docs or content changed | pending | For docs-heavy work, use `--template docs`; for supporting public docs/content/API/example changes, load `docs-creator` and close the docs pack; for typo/link-only edits, record the explicit reason and proportional proof | pending |
 | High-risk mini gate | pending | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | pending |
 | Agent-native review for agent/tooling changes | pending | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | pending |
 | Local install corruption suspected | pending | Run `pnpm run reinstall` once, rerun the exact failing command, or record N/A | pending |

--- a/packages/core/src/internal/plugin/resolvePlugins.ts
+++ b/packages/core/src/internal/plugin/resolvePlugins.ts
@@ -57,6 +57,7 @@ export const resolvePlugins = (
     node: {
       isContainer: [],
       isLeaf: [],
+      isMetadataProp: [],
       isText: [],
       leafProps: [],
       textProps: [],
@@ -103,6 +104,10 @@ export const resolvePlugins = (
 
     if (plugin.node?.isContainer) {
       editor.meta.pluginCache.node.isContainer.push(plugin.key);
+    }
+
+    if (plugin.node?.isMetadataProp) {
+      editor.meta.pluginCache.node.isMetadataProp.push(plugin.key);
     }
 
     editor.meta.pluginCache.node.types[plugin.node.type] = plugin.key;

--- a/packages/core/src/lib/editor/SlateEditor.ts
+++ b/packages/core/src/lib/editor/SlateEditor.ts
@@ -72,6 +72,7 @@ export type BaseEditor = EditorBase & {
       node: {
         isContainer: string[];
         isLeaf: string[];
+        isMetadataProp: string[];
         isText: string[];
         leafProps: string[];
         textProps: string[];

--- a/packages/core/src/lib/plugin/BasePlugin.ts
+++ b/packages/core/src/lib/plugin/BasePlugin.ts
@@ -353,6 +353,18 @@ export type BasePluginNode<C extends AnyPluginConfig = PluginConfig> = {
    */
   isMarkableVoid?: boolean;
   /**
+   * Returns whether an element prop is inert metadata for empty-state checks.
+   *
+   * Props not claimed by a plugin are treated as meaningful state.
+   */
+  isMetadataProp?: (
+    options: BasePluginContext<C> & {
+      key: string;
+      node: TElement;
+      value: unknown;
+    }
+  ) => boolean;
+  /**
    * Whether the node is selectable.
    *
    * @default true

--- a/packages/core/src/lib/plugins/node-id/NodeIdPlugin.ts
+++ b/packages/core/src/lib/plugins/node-id/NodeIdPlugin.ts
@@ -331,6 +331,11 @@ export const NodeIdPlugin = createTSlatePlugin<NodeIdConfig>({
     idCreator: () => nanoid(10),
   },
 })
+  .extend(({ getOptions }) => ({
+    node: {
+      isMetadataProp: ({ key }) => key === (getOptions().idKey ?? 'id'),
+    },
+  }))
   .extendTransforms(({ editor, getOptions }) => ({
     normalize() {
       const options = getOptions();

--- a/packages/core/src/lib/plugins/slate-extension/SlateExtensionPlugin.spec.tsx
+++ b/packages/core/src/lib/plugins/slate-extension/SlateExtensionPlugin.spec.tsx
@@ -5,10 +5,85 @@ import { jsxt } from '@platejs/test-utils';
 jsxt;
 
 import { createSlateEditor } from '../../editor';
+import { createSlatePlugin } from '../../plugin';
 import { NodeIdPlugin } from '../node-id/NodeIdPlugin';
 import { SlateExtensionPlugin } from './SlateExtensionPlugin';
 
 describe('SlateExtensionPlugin', () => {
+  describe('isElementStateEmpty', () => {
+    it('treats type and the configured node id key as empty element state', () => {
+      const editor = createSlateEditor({
+        nodeId: { idKey: 'blockId' },
+        plugins: [SlateExtensionPlugin],
+      });
+
+      expect(
+        editor.api.isElementStateEmpty({
+          children: [{ text: '' }],
+          type: 'p',
+        })
+      ).toBe(true);
+      expect(
+        editor.api.isElementStateEmpty({
+          blockId: 'a',
+          children: [{ text: '' }],
+          type: 'p',
+        })
+      ).toBe(true);
+      expect(
+        editor.api.isElementStateEmpty({
+          children: [{ text: '' }],
+          id: 'a',
+          type: 'p',
+        })
+      ).toBe(false);
+    });
+
+    it('treats any other element prop as non-empty state', () => {
+      const editor = createSlateEditor({
+        plugins: [SlateExtensionPlugin],
+      });
+
+      expect(
+        editor.api.isElementStateEmpty({
+          children: [{ text: '' }],
+          listStyleType: 'disc',
+          type: 'p',
+        })
+      ).toBe(false);
+    });
+
+    it('uses plugin node metadata prop rules', () => {
+      const CustomMetadataPlugin = createSlatePlugin({
+        key: 'customMetadata',
+      }).extend({
+        node: {
+          isMetadataProp: ({ key }) => key === 'customId',
+        },
+      });
+
+      const editor = createSlateEditor({
+        plugins: [SlateExtensionPlugin, CustomMetadataPlugin],
+      });
+
+      expect(
+        editor.api.isElementStateEmpty({
+          children: [{ text: '' }],
+          customId: 'a',
+          type: 'p',
+        })
+      ).toBe(true);
+      expect(
+        editor.api.isElementStateEmpty({
+          children: [{ text: '' }],
+          customId: 'a',
+          listStyleType: 'disc',
+          type: 'p',
+        })
+      ).toBe(false);
+    });
+  });
+
   describe('redecorate', () => {
     it('exposes a no-op redecorate method by default', () => {
       const editor = createSlateEditor({

--- a/packages/core/src/lib/plugins/slate-extension/SlateExtensionPlugin.ts
+++ b/packages/core/src/lib/plugins/slate-extension/SlateExtensionPlugin.ts
@@ -1,6 +1,7 @@
 import {
   type Descendant,
   type NodeOperation,
+  type TElement,
   type TextOperation,
   type TText,
   NodeApi,
@@ -12,7 +13,7 @@ import { type OmitFirst, bindFirst } from '@udecode/utils';
 import type { SlateEditor } from '../../editor';
 import type { PluginConfig } from '../../plugin';
 
-import { createTSlatePlugin } from '../../plugin';
+import { createTSlatePlugin, getEditorPlugin } from '../../plugin';
 import { pipeOnNodeChange } from '../../utils/pipeOnNodeChange';
 import { pipeOnTextChange } from '../../utils/pipeOnTextChange';
 import { init } from './transforms/init';
@@ -23,6 +24,25 @@ import { setValue } from './transforms/setValue';
 
 const NOOP_ON_NODE_CHANGE = () => {};
 const NOOP_ON_TEXT_CHANGE = () => {};
+
+export const isElementStateEmpty = (editor: SlateEditor, element: TElement) => {
+  const props = NodeApi.extractProps(element);
+
+  return Object.entries(props).every(([key, value]) => {
+    if (key === 'type') return true;
+
+    return editor.meta.pluginCache.node.isMetadataProp.some((pluginKey) => {
+      const plugin = editor.plugins[pluginKey];
+
+      return plugin.node.isMetadataProp?.({
+        ...(getEditorPlugin(editor, plugin) as any),
+        key,
+        node: element,
+        value,
+      });
+    });
+  });
+};
 
 export type SlateExtensionConfig = PluginConfig<
   'slateExtension',
@@ -63,161 +83,170 @@ export const SlateExtensionPlugin = createTSlatePlugin<SlateExtensionConfig>({
     onNodeChange: NOOP_ON_NODE_CHANGE,
     onTextChange: NOOP_ON_TEXT_CHANGE,
   },
-}).extendEditorTransforms(({ editor, getOption, tf }) => {
-  const apply = tf?.apply ?? editor.tf.apply;
+})
+  .extendEditorApi(({ editor }) => ({
+    isElementStateEmpty: bindFirst(isElementStateEmpty, editor),
+  }))
+  .extendEditorTransforms(({ editor, getOption, tf }) => {
+    const apply = tf?.apply ?? editor.tf.apply;
 
-  return {
-    /**
-     * Initialize the editor value, selection and normalization. Set `value` to
-     * `null` to skip children initialization.
-     */
-    init: bindFirst(init, editor),
-    insertExitBreak: bindFirst(insertExitBreak, editor),
-    liftBlock: bindFirst(liftBlock, editor),
-    resetBlock: bindFirst(resetBlock, editor),
-    setValue: bindFirst(setValue, editor),
-    apply(operation) {
-      // Performance optimization: skip state capture if no handlers are registered
-      const hasNodeHandlers =
-        editor.meta.pluginCache.handlers.onNodeChange.length > 0 ||
-        getOption('onNodeChange') !== NOOP_ON_NODE_CHANGE;
-      const hasTextHandlers =
-        editor.meta.pluginCache.handlers.onTextChange.length > 0 ||
-        getOption('onTextChange') !== NOOP_ON_TEXT_CHANGE;
+    return {
+      /**
+       * Initialize the editor value, selection and normalization. Set `value` to
+       * `null` to skip children initialization.
+       */
+      init: bindFirst(init, editor),
+      insertExitBreak: bindFirst(insertExitBreak, editor),
+      liftBlock: bindFirst(liftBlock, editor),
+      resetBlock: bindFirst(resetBlock, editor),
+      setValue: bindFirst(setValue, editor),
+      apply(operation) {
+        // Performance optimization: skip state capture if no handlers are registered
+        const hasNodeHandlers =
+          editor.meta.pluginCache.handlers.onNodeChange.length > 0 ||
+          getOption('onNodeChange') !== NOOP_ON_NODE_CHANGE;
+        const hasTextHandlers =
+          editor.meta.pluginCache.handlers.onTextChange.length > 0 ||
+          getOption('onTextChange') !== NOOP_ON_TEXT_CHANGE;
 
-      if (!hasNodeHandlers && !hasTextHandlers) {
-        apply(operation);
-        return;
-      }
-
-      let prevNode: Descendant | undefined;
-      let node: Descendant | undefined;
-      let prevText: string | undefined;
-      let text: string | undefined;
-      let parentNode: Descendant | undefined;
-
-      if (OperationApi.isNodeOperation(operation) && hasNodeHandlers) {
-        // Get node states BEFORE applying the operation
-        switch (operation.type) {
-          case 'insert_node': {
-            // Both are the new node being inserted
-            prevNode = operation.node;
-            node = operation.node;
-            break;
-          }
-
-          case 'merge_node':
-          case 'move_node':
-          case 'set_node':
-          case 'split_node': {
-            // Get the node before the operation
-            prevNode = NodeApi.get(editor, operation.path);
-            break;
-          }
-          case 'remove_node': {
-            // Both are the node being removed
-            prevNode = operation.node;
-            node = operation.node;
-            break;
-          }
+        if (!hasNodeHandlers && !hasTextHandlers) {
+          apply(operation);
+          return;
         }
-      } else if (OperationApi.isTextOperation(operation) && hasTextHandlers) {
-        // Get parent node that contains the text
-        const parentPath = PathApi.parent(operation.path);
-        parentNode = NodeApi.get<Descendant>(editor, parentPath);
 
-        // Get text node before operation
-        const textNode = NodeApi.get<TText>(editor, operation.path)!;
-        prevText = textNode.text;
-      }
+        let prevNode: Descendant | undefined;
+        let node: Descendant | undefined;
+        let prevText: string | undefined;
+        let text: string | undefined;
+        let parentNode: Descendant | undefined;
 
-      // Apply the operation
-      apply(operation);
-
-      // Get AFTER state for operations where node changes
-      if (OperationApi.isNodeOperation(operation) && hasNodeHandlers) {
-        switch (operation.type) {
-          case 'insert_node':
-          case 'remove_node': {
-            // Already set above, keep the same
-            break;
-          }
-
-          case 'merge_node': {
-            // Get the merged result (at previous path)
-            const prevPath = PathApi.previous(operation.path);
-
-            if (prevPath) {
-              node = NodeApi.get(editor, prevPath);
+        if (OperationApi.isNodeOperation(operation) && hasNodeHandlers) {
+          // Get node states BEFORE applying the operation
+          switch (operation.type) {
+            case 'insert_node': {
+              // Both are the new node being inserted
+              prevNode = operation.node;
+              node = operation.node;
+              break;
             }
 
-            break;
+            case 'merge_node':
+            case 'move_node':
+            case 'set_node':
+            case 'split_node': {
+              // Get the node before the operation
+              prevNode = NodeApi.get(editor, operation.path);
+              break;
+            }
+            case 'remove_node': {
+              // Both are the node being removed
+              prevNode = operation.node;
+              node = operation.node;
+              break;
+            }
           }
+        } else if (OperationApi.isTextOperation(operation) && hasTextHandlers) {
+          // Get parent node that contains the text
+          const parentPath = PathApi.parent(operation.path);
+          parentNode = NodeApi.get<Descendant>(editor, parentPath);
 
-          case 'move_node': {
-            // Get node at new location
-            node = NodeApi.get(editor, operation.newPath);
-            break;
-          }
-
-          case 'set_node': {
-            // Get the updated node
-            node = NodeApi.get(editor, operation.path);
-            break;
-          }
-
-          case 'split_node': {
-            // Get the first part of the split
-            node = NodeApi.get(editor, operation.path);
-            break;
-          }
+          // Get text node before operation
+          const textNode = NodeApi.get<TText>(editor, operation.path)!;
+          prevText = textNode.text;
         }
 
-        // Ensure node is set (fallback to prevNode if needed)
-        if (!node) {
-          node = prevNode;
-        }
+        // Apply the operation
+        apply(operation);
 
-        // Call handlers - both node and prevNode are guaranteed to be defined
-        const eventIsHandled = pipeOnNodeChange(
-          editor,
-          node!,
-          prevNode!,
-          operation
-        );
+        // Get AFTER state for operations where node changes
+        if (OperationApi.isNodeOperation(operation) && hasNodeHandlers) {
+          switch (operation.type) {
+            case 'insert_node':
+            case 'remove_node': {
+              // Already set above, keep the same
+              break;
+            }
 
-        if (!eventIsHandled) {
-          const onNodeChange = getOption('onNodeChange');
-          onNodeChange({ editor, node: node!, operation, prevNode: prevNode! });
-        }
-      }
+            case 'merge_node': {
+              // Get the merged result (at previous path)
+              const prevPath = PathApi.previous(operation.path);
 
-      // Handle text operations
-      if (OperationApi.isTextOperation(operation) && hasTextHandlers) {
-        const textNodeAfter = NodeApi.get<TText>(editor, operation.path);
-        if (textNodeAfter) {
-          text = textNodeAfter.text;
-        }
+              if (prevPath) {
+                node = NodeApi.get(editor, prevPath);
+              }
 
-        const eventIsHandled = pipeOnTextChange(
-          editor,
-          parentNode!,
-          text!,
-          prevText!,
-          operation
-        );
+              break;
+            }
 
-        if (!eventIsHandled) {
-          const onTextChange = getOption('onTextChange');
-          onTextChange({
+            case 'move_node': {
+              // Get node at new location
+              node = NodeApi.get(editor, operation.newPath);
+              break;
+            }
+
+            case 'set_node': {
+              // Get the updated node
+              node = NodeApi.get(editor, operation.path);
+              break;
+            }
+
+            case 'split_node': {
+              // Get the first part of the split
+              node = NodeApi.get(editor, operation.path);
+              break;
+            }
+          }
+
+          // Ensure node is set (fallback to prevNode if needed)
+          if (!node) {
+            node = prevNode;
+          }
+
+          // Call handlers - both node and prevNode are guaranteed to be defined
+          const eventIsHandled = pipeOnNodeChange(
             editor,
-            node: parentNode!,
-            operation,
-            prevText: prevText!,
-            text: text!,
-          });
+            node!,
+            prevNode!,
+            operation
+          );
+
+          if (!eventIsHandled) {
+            const onNodeChange = getOption('onNodeChange');
+            onNodeChange({
+              editor,
+              node: node!,
+              operation,
+              prevNode: prevNode!,
+            });
+          }
         }
-      }
-    },
-  };
-});
+
+        // Handle text operations
+        if (OperationApi.isTextOperation(operation) && hasTextHandlers) {
+          const textNodeAfter = NodeApi.get<TText>(editor, operation.path);
+          if (textNodeAfter) {
+            text = textNodeAfter.text;
+          }
+
+          const eventIsHandled = pipeOnTextChange(
+            editor,
+            parentNode!,
+            text!,
+            prevText!,
+            operation
+          );
+
+          if (!eventIsHandled) {
+            const onTextChange = getOption('onTextChange');
+            onTextChange({
+              editor,
+              node: parentNode!,
+              operation,
+              prevText: prevText!,
+              text: text!,
+            });
+          }
+        }
+      },
+    };
+  });

--- a/packages/utils/src/react/plugins/BlockPlaceholderPlugin.spec.tsx
+++ b/packages/utils/src/react/plugins/BlockPlaceholderPlugin.spec.tsx
@@ -9,6 +9,8 @@ import { BlockPlaceholderPlugin } from './BlockPlaceholderPlugin';
 
 const createEditor = (options?: {
   className?: string;
+  isEmptyBlockPristine?: (context: any) => boolean;
+  nodeId?: any;
   placeholders?: Record<string, string>;
   query?: (context: any) => boolean;
   readOnly?: boolean;
@@ -28,10 +30,14 @@ const createEditor = (options?: {
           ...(options?.placeholders !== undefined
             ? { placeholders: options.placeholders }
             : {}),
+          ...(options?.isEmptyBlockPristine !== undefined
+            ? { isEmptyBlockPristine: options.isEmptyBlockPristine }
+            : {}),
           ...(options?.query !== undefined ? { query: options.query } : {}),
         },
       }),
     ],
+    nodeId: options?.nodeId,
     selection: options?.selection ?? {
       anchor: { offset: 0, path: [0, 0] },
       focus: { offset: 0, path: [0, 0] },
@@ -77,6 +83,82 @@ describe('BlockPlaceholderPlugin', () => {
   it('clears the target when the editor is globally empty', async () => {
     const editor = createEditor({
       value: [{ children: [{ text: '' }], type: 'p' }],
+    });
+    const { container } = render(
+      <PlateTest editor={editor} suppressInstanceWarning>
+        {null}
+      </PlateTest>
+    );
+
+    await waitFor(() => {
+      expect(editor.getOptions(BlockPlaceholderPlugin)._target).toBeNull();
+    });
+
+    expect(container.querySelector('[placeholder]')).toBeNull();
+  });
+
+  it('clears the target when the only empty block has id metadata', async () => {
+    const editor = createEditor({
+      nodeId: true,
+      value: [{ children: [{ text: '' }], id: 'block-1', type: 'p' }],
+    });
+    const { container } = render(
+      <PlateTest editor={editor} suppressInstanceWarning>
+        {null}
+      </PlateTest>
+    );
+
+    await waitFor(() => {
+      expect(editor.getOptions(BlockPlaceholderPlugin)._target).toBeNull();
+    });
+
+    expect(container.querySelector('[placeholder]')).toBeNull();
+  });
+
+  it('keeps the target on a single empty list item', async () => {
+    const editor = createEditor({
+      value: [
+        {
+          children: [{ text: '' }],
+          indent: 1,
+          listStyleType: 'disc',
+          type: 'p',
+        },
+      ],
+    });
+    const { container } = render(
+      <PlateTest editor={editor} suppressInstanceWarning>
+        {null}
+      </PlateTest>
+    );
+    const firstNode = editor.children[0] as any;
+
+    await waitFor(() => {
+      expect(editor.getOptions(BlockPlaceholderPlugin)._target).toEqual({
+        node: firstNode,
+        placeholder: 'Type something...',
+      });
+    });
+
+    expect(
+      container.querySelector('[placeholder="Type something..."]')
+    ).toBeInTheDocument();
+  });
+
+  it('lets callers keep custom metadata-only blocks pristine', async () => {
+    const editor = createEditor({
+      isEmptyBlockPristine: ({ node }) =>
+        Object.keys(node).every(
+          (key) =>
+            key === 'children' || key === 'data-test-id' || key === 'type'
+        ),
+      value: [
+        {
+          children: [{ text: '' }],
+          'data-test-id': 'block-1',
+          type: 'p',
+        },
+      ],
     });
     const { container } = render(
       <PlateTest editor={editor} suppressInstanceWarning>

--- a/packages/utils/src/react/plugins/BlockPlaceholderPlugin.spec.tsx
+++ b/packages/utils/src/react/plugins/BlockPlaceholderPlugin.spec.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 
+import { createSlatePlugin } from '@platejs/core';
 import { createPlateEditor, PlateTest } from '@platejs/core/react';
 import { render, waitFor } from '@testing-library/react';
 
@@ -9,7 +10,6 @@ import { BlockPlaceholderPlugin } from './BlockPlaceholderPlugin';
 
 const createEditor = (options?: {
   className?: string;
-  isEmptyBlockPristine?: (context: any) => boolean;
   nodeId?: any;
   placeholders?: Record<string, string>;
   query?: (context: any) => boolean;
@@ -29,9 +29,6 @@ const createEditor = (options?: {
             : {}),
           ...(options?.placeholders !== undefined
             ? { placeholders: options.placeholders }
-            : {}),
-          ...(options?.isEmptyBlockPristine !== undefined
-            ? { isEmptyBlockPristine: options.isEmptyBlockPristine }
             : {}),
           ...(options?.query !== undefined ? { query: options.query } : {}),
         },
@@ -145,13 +142,21 @@ describe('BlockPlaceholderPlugin', () => {
     ).toBeInTheDocument();
   });
 
-  it('lets callers keep custom metadata-only blocks pristine', async () => {
-    const editor = createEditor({
-      isEmptyBlockPristine: ({ node }) =>
-        Object.keys(node).every(
-          (key) =>
-            key === 'children' || key === 'data-test-id' || key === 'type'
-        ),
+  it('honors custom node metadata rules for pristine empty blocks', async () => {
+    const CustomMetadataPlugin = createSlatePlugin({
+      key: 'customMetadata',
+    }).extend({
+      node: {
+        isMetadataProp: ({ key }) => key === 'data-test-id',
+      },
+    });
+
+    const editor = createPlateEditor({
+      plugins: [BlockPlaceholderPlugin, CustomMetadataPlugin],
+      selection: {
+        anchor: { offset: 0, path: [0, 0] },
+        focus: { offset: 0, path: [0, 0] },
+      },
       value: [
         {
           children: [{ text: '' }],

--- a/packages/utils/src/react/plugins/BlockPlaceholderPlugin.tsx
+++ b/packages/utils/src/react/plugins/BlockPlaceholderPlugin.tsx
@@ -17,12 +17,6 @@ export type BlockPlaceholderConfig = PluginConfig<
   'blockPlaceholder',
   {
     _target: { node: TElement; placeholder: string } | null;
-    isEmptyBlockPristine: (
-      context: PlatePluginContext<BlockPlaceholderConfig> & {
-        node: TElement;
-        path: Path;
-      }
-    ) => boolean;
     placeholders: Record<string, string>;
     query: (
       context: PlatePluginContext<BlockPlaceholderConfig> & {
@@ -44,8 +38,6 @@ export const BlockPlaceholderPlugin =
       placeholders: {
         [KEYS.p]: 'Type something...',
       },
-      isEmptyBlockPristine: ({ editor, node }) =>
-        editor.api.isElementStateEmpty(node),
       query: ({ path }) => path.length === 1,
     },
     useHooks: (ctx) => {
@@ -73,14 +65,14 @@ export const BlockPlaceholderPlugin =
           return;
         }
 
-        const { isEmptyBlockPristine, placeholders, query } = getOptions();
+        const { placeholders, query } = getOptions();
 
         const [element, path] = entry;
         const firstNode = editor.children[0] as TElement;
         const isPristineEmptyEditor =
           editor.children.length === 1 &&
           editor.api.isEmpty(firstNode) &&
-          isEmptyBlockPristine({ ...ctx, node: firstNode, path: [0] });
+          editor.api.isElementStateEmpty(firstNode);
 
         const placeholder = Object.keys(placeholders).find(
           (key) => editor.getType(key) === element.type

--- a/packages/utils/src/react/plugins/BlockPlaceholderPlugin.tsx
+++ b/packages/utils/src/react/plugins/BlockPlaceholderPlugin.tsx
@@ -17,6 +17,12 @@ export type BlockPlaceholderConfig = PluginConfig<
   'blockPlaceholder',
   {
     _target: { node: TElement; placeholder: string } | null;
+    isEmptyBlockPristine: (
+      context: PlatePluginContext<BlockPlaceholderConfig> & {
+        node: TElement;
+        path: Path;
+      }
+    ) => boolean;
     placeholders: Record<string, string>;
     query: (
       context: PlatePluginContext<BlockPlaceholderConfig> & {
@@ -34,9 +40,12 @@ export const BlockPlaceholderPlugin =
     editOnly: true,
     options: {
       _target: null,
+      className: undefined,
       placeholders: {
         [KEYS.p]: 'Type something...',
       },
+      isEmptyBlockPristine: ({ editor, node }) =>
+        editor.api.isElementStateEmpty(node),
       query: ({ path }) => path.length === 1,
     },
     useHooks: (ctx) => {
@@ -64,30 +73,14 @@ export const BlockPlaceholderPlugin =
           return;
         }
 
-        const { placeholders, query } = getOptions();
+        const { isEmptyBlockPristine, placeholders, query } = getOptions();
 
         const [element, path] = entry;
-
-        // const getPlaceholder = (node: TElement) => {
-        //   if (node?.listStyleType) {
-        //     switch (node.listStyleType) {
-        //       case 'disc':
-        //         return 'List';
-        //         break;
-        //       case 'decimal':
-        //         return 'List';
-        //         break;
-        //       case 'todo':
-        //         return 'To-do';
-        //         break;
-        //     }
-        //   }
-
-        //   const key = getPluginKey(editor, node.type);
-        //   if (!key) return;
-
-        //   return placeholders?.[key];
-        // }
+        const firstNode = editor.children[0] as TElement;
+        const isPristineEmptyEditor =
+          editor.children.length === 1 &&
+          editor.api.isEmpty(firstNode) &&
+          isEmptyBlockPristine({ ...ctx, node: firstNode, path: [0] });
 
         const placeholder = Object.keys(placeholders).find(
           (key) => editor.getType(key) === element.type
@@ -97,7 +90,7 @@ export const BlockPlaceholderPlugin =
           query({ ...ctx, node: element, path }) &&
           placeholder &&
           editor.api.isEmpty(element) &&
-          !editor.api.isEmpty()
+          !isPristineEmptyEditor
         ) {
           setOption('_target', {
             node: element,

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "udecode/dotai",
       "sourceType": "github",
       "skillPath": "skills/autogoal/SKILL.md",
-      "computedHash": "962dc01ee23c13f3c2f9f4205f8734028a2ce9af6a7708c0bf4364fcf4dbfbb5"
+      "computedHash": "b39af211b4e83be092b60f376eac2b58aad58089d904a73058d33f36610ad93a"
     },
     "autoreview": {
       "source": "openclaw/agent-skills",


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

🐛 Fixes udecode/plate#4951

🟢 98% confidence

| Phase | 🧪 Tests | 🌐 Browser |
|---|---|---|
| Reproduced | 🔴 Focused `BlockPlaceholderPlugin` spec failed before fix: expected placeholder target for a single empty list item, received `null` | ➖ N/A: source-level plugin state repro was exact |
| Verified | 🟢 Focused core+utils specs, stale-symbol source audit, core+utils typecheck, docs source build, lint-fix, `pnpm check`, clean autoreview | ⚠️ Attempted on `http://localhost:3050/blocks/block-placeholder-demo`; route loads and editor force-focuses, but Browser could not move Slate selection into the empty paragraph, and no editor global is exposed for direct state inspection |

**✅ Outcome**

`@platejs/core` exposes plugin-owned metadata prop handling through `node.isMetadataProp` and the caller-facing `editor.api.isElementStateEmpty(element)` helper. `NodeIdPlugin` uses `node.isMetadataProp` so its configured id key is inert metadata.

`BlockPlaceholderPlugin` keeps the configured block placeholder on an empty indent-list item, including the single-item state produced by list autoformat, while the pristine single-empty-block editor state still suppresses the placeholder.

**⚠️ Caveat**

Browser visual proof is blocked by the component preview interaction layer: Browser can load the route and focus the editor, but cannot establish the empty paragraph Slate selection needed to activate the placeholder. The focused React plugin spec observes the real `_target` state and injected placeholder props directly.

**🏗️ Design**

The reusable state check lives in `@platejs/core`, but metadata ownership lives with node plugins. `editor.api.isElementStateEmpty(element)` ignores `type`, asks registered `node.isMetadataProp` rules about remaining element props, and treats every unclaimed prop as meaningful state.

That keeps list state out of utils and avoids hardcoding `indent`, `listStyleType`, or node-id names inside `BlockPlaceholderPlugin`.

**🧪 Verified**

- Source-owned stale-symbol audit found no old API refs
- `pnpm --filter @platejs/core build && bun test packages/core/src/lib/plugins/slate-extension/SlateExtensionPlugin.spec.tsx packages/utils/src/react/plugins/BlockPlaceholderPlugin.spec.tsx`
- `pnpm turbo typecheck --filter=./packages/core --filter=./packages/utils`
- `pnpm --filter www build:source`
- `pnpm lint:fix`
- `pnpm check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- Browser route attempt on `http://localhost:3050/blocks/block-placeholder-demo`
