### PR TITLE
Delete _id instead of setting it to undefined

### DIFF
--- a/.changeset/unlucky-rocks-battle.md
+++ b/.changeset/unlucky-rocks-battle.md
@@ -1,0 +1,5 @@
+---
+"@platejs/core": patch
+---
+
+Unset `_id` instead of setting it to `undefined` when inserting a node

--- a/packages/core/src/lib/plugins/node-id/withNodeId.ts
+++ b/packages/core/src/lib/plugins/node-id/withNodeId.ts
@@ -163,7 +163,7 @@ export const withNodeId: OverrideEditor<NodeIdConfig> = ({
 
               if (!disableInsertOverrides && isDefined(entryNode._id)) {
                 const id = entryNode._id;
-                entryNode._id = undefined;
+                delete entryNode._id;
 
                 if (!hasIdInEditor(id)) {
                   entryNode[idKey] = id;

--- a/packages/core/src/lib/plugins/node-id/withNodeId.ts
+++ b/packages/core/src/lib/plugins/node-id/withNodeId.ts
@@ -163,6 +163,7 @@ export const withNodeId: OverrideEditor<NodeIdConfig> = ({
 
               if (!disableInsertOverrides && isDefined(entryNode._id)) {
                 const id = entryNode._id;
+                // biome-ignore lint/performance/noDelete: deleting _id is intentional here
                 delete entryNode._id;
 
                 if (!hasIdInEditor(id)) {


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

We have encountered a problem, when inserting new elements and then undo. Our form library `react-hook-form` will mark the form dirty, even though we have undo-ed all changes. If we compare the values of the plate js form field, we can see, that some nodes now have an `_id` key with value `undefined`, the old state doesn't have. This is a change for the diff algorithm of `react-hook-form`. plate should actually NEVER set temporary values within the document. They must live inside a plugin option or a weak map or similar.

This PR is just a first step, to make the problem less bad (by removing `_id` again from the nodes, instead of setting them to `undefined`). But in a second PR, it might be worth it, to completely store the `_id` in a different place, outside of the plate/slate document.

**Checklist**

- [x] `pnpm typecheck`
- [x] `pnpm lint:fix`
- [x] `bun test`
- [x] `pnpm brl`
- [x] `pnpm changeset`
- [x] [ui changelog](docs/components/changelog.mdx)

<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- pnpm brl: Required if adding, moving or removing a file in a package.
- pnpm changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/src/registry/components/changelog.mdx`.

-->
