### PR TITLE
fix(suggestion): set userId on block removal suggestions

### DIFF
--- a/.changeset/crisp-geckos-smash.md
+++ b/.changeset/crisp-geckos-smash.md
@@ -1,0 +1,5 @@
+---
+"@platejs/suggestion": patch
+---
+
+Fix block removal suggestions missing `userId` metadata

--- a/packages/suggestion/src/lib/transforms/removeNodesSuggestion.ts
+++ b/packages/suggestion/src/lib/transforms/removeNodesSuggestion.ts
@@ -2,6 +2,7 @@ import type { NodeEntry, SlateEditor, TElement, Text } from 'platejs';
 
 import { KEYS } from 'platejs';
 
+import { BaseSuggestionPlugin } from '../BaseSuggestionPlugin';
 import { findSuggestionProps } from '../queries';
 
 export const removeNodesSuggestion = (
@@ -22,6 +23,7 @@ export const removeNodesSuggestion = (
           id,
           createdAt,
           type: 'remove',
+          userId: editor.getOptions(BaseSuggestionPlugin).currentUserId!,
         },
       },
       { at: blockPath }


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

Keep block-removal suggestions attributed to the current user so suggestion
rendering and downstream consumers never receive an undefined author id.

## Problem

In suggestion mode, block-level removals go through
`removeNodesSuggestion`, which creates a `remove` suggestion without
setting `userId`.

Other suggestion-producing transforms already attach the current user via
`editor.getOptions(BaseSuggestionPlugin).currentUserId`, so block removals are
the odd path out.

That leaves block removals:

- unattributed in suggestion UIs
- persisted with an undefined `userId`
- able to break downstream consumers that assume `suggestion.userId` exists

## Fix

Update `packages/suggestion/src/lib/transforms/removeNodesSuggestion.ts` to set
`userId` from `BaseSuggestionPlugin`, matching the other suggestion transforms.

## Reproduction

1. Enable suggestion mode with `isSuggesting: true` and `currentUserId` set.
2. Remove a whole block through a block-level `removeNodes` path.
3. Inspect the node suggestion metadata.

Before this change, `suggestion.userId` is `undefined`.
After this change, `suggestion.userId` matches `currentUserId`.

Inline text deletion behavior is unchanged.

## Notes

While integrating `@platejs/suggestion`, I noticed a few adjacent
suggestion-mode issues around inline voids and trigger-input tracking. I left
those out of this PR to keep the fix focused, but I can follow up with separate
issues or PRs if helpful.

## Checklist

- [x] `pnpm turbo build --filter=./packages/suggestion`
- [x] `pnpm turbo typecheck --filter=./packages/suggestion`
- [x] `pnpm lint:fix`
- [x] `bun test`
- [x] patch changeset added
- [x] `pnpm brl` not required
- [x] `docs/components/changelog.mdx` not required


<!--

Thanks for the PR. Please complete the checklist below to ensure your PR can be
merged as soon as possible.

- pnpm brl: Required if adding, moving or removing a file in a package.
- pnpm changeset: Required if updating `packages`. Please be brief and descriptive. For breaking
changes, use a major changeset. For new features, use a minor changeset. For
bug fixes, use a patch changeset.
- changelog: Required if updating `apps/www/src/registry`. See `apps/www/src/registry/components/changelog.mdx`.

-->
