### PR TITLE
fix(link): guard IME composition-commit Enter (keyCode 229) in floating link

### DIFF
--- a/.changeset/link-ime-enter-keycode-229.md
+++ b/.changeset/link-ime-enter-keycode-229.md
@@ -1,0 +1,5 @@
+---
+"@platejs/link": patch
+---
+
+Fix Floating Link: ignore the Safari + Japanese IME composition-commit Enter (`keyCode === 229`, where `isComposing` is false) so it no longer submits the link mid-composition. Mirrors the Enter guard already used in `cmdk`.

--- a/packages/link/src/react/components/FloatingLink/useFloatingLinkEnter.ts
+++ b/packages/link/src/react/components/FloatingLink/useFloatingLinkEnter.ts
@@ -12,6 +12,10 @@ export const useFloatingLinkEnter = () => {
     '*',
     (e) => {
       if (e.key !== 'Enter') return;
+      // `keyCode === 229` is the Safari + Japanese IME composition-commit Enter,
+      // where `isComposing` is false. Ignore it so it doesn't submit the link
+      // mid-composition. Mirrors the Enter guard in `cmdk`.
+      if (e.isComposing || e.keyCode === 229) return;
       if (submitFloatingLink(editor)) {
         e.preventDefault();
       }


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## Problem

`useFloatingLinkEnter` submits the floating link on any keydown that reaches the global hotkey handler with `e.key === 'Enter'`:

```ts
if (e.key !== 'Enter') return;
if (submitFloatingLink(editor)) {
  e.preventDefault();
}
```

On Safari/WebKit with a Japanese IME, the keydown that commits a composition arrives with `e.key === 'Enter'`, `e.keyCode === 229`, and `e.isComposing === false`. So when a user types a CJK link label and presses Enter to confirm the composition, this handler treats it as a submit and closes the floating link mid-composition.

## Fix

Skip the IME composition-commit Enter, the same way the rest of the repo already does:

- `packages/udecode/cmdk/src/cmdk.tsx`: `if (!e.nativeEvent.isComposing && e.keyCode !== 229)`, with a comment that `isComposing` is not set for the Japanese IME + Safari combination.
- `packages/table/src/react/onKeyDownTable.ts`: `const compositeKeyCode = 229; ... event.which === compositeKeyCode`.

```ts
if (e.key !== 'Enter') return;
if (e.isComposing || e.keyCode === 229) return;
```

A normal Enter (`keyCode === 13`, `isComposing === false`) still submits.

## Notes

The vendored `react-hotkeys` matches by `event.code`, which is still `'Enter'` on the IME-commit key, so the callback is where the guard belongs. I kept it at the call site to match the existing `cmdk`/`table` guards instead of touching the fork.

keyCode is not reproducible in jsdom (it reads as 0), so I verified this by the same logic as the existing guards rather than a unit test, which is also why those guards have none.
