### PR TITLE
Add MiniMax M3 to playground model picker

### DIFF
--- a/templates/plate-playground-template/src/components/editor/settings-dialog.tsx
+++ b/templates/plate-playground-template/src/components/editor/settings-dialog.tsx
@@ -143,6 +143,9 @@ export const models: Model[] = [
   { label: 'LongCat Flash Chat', value: 'meituan/longcat-flash-chat' },
   { label: 'LongCat Flash Thinking', value: 'meituan/longcat-flash-thinking' },
 
+  // MiniMax Models
+  { label: 'MiniMax M3', value: 'minimax/minimax-m3' },
+
   // Meta Models
   { label: 'Llama 3 70B', value: 'meta/llama-3-70b' },
   { label: 'Llama 3 8B', value: 'meta/llama-3-8b' },


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Add MiniMax M3 to the playground template model picker so it is available alongside the existing AI Gateway models.

## Checks
- `git diff --check HEAD^ HEAD`