### PR TITLE
fix(core): derive onValueChange and onSelectionChange from onChange (#2700)

### DIFF
--- a/.changeset/fix-slate-callbacks-dedup.md
+++ b/.changeset/fix-slate-callbacks-dedup.md
@@ -1,0 +1,5 @@
+---
+"@platejs/core": patch
+---
+
+Derive `onValueChange` and `onSelectionChange` from `onChange` with reference-equality deduplication guards.

--- a/packages/core/src/react/hooks/useSlateProps.spec.tsx
+++ b/packages/core/src/react/hooks/useSlateProps.spec.tsx
@@ -56,30 +56,16 @@ describe('useSlateProps', () => {
     expect(result.current.props.key).toBe(editor.meta.key);
 
     act(() => {
+      editor.children = nextValue as any;
+      editor.selection = nextSelection;
       result.current.props.onChange(nextValue as any);
-    });
-
-    expect(result.current.editorVersion).toBe(2);
-    expect(result.current.selectionVersion).toBe(1);
-    expect(result.current.valueVersion).toBe(1);
-    expect(onChange).toHaveBeenCalledWith({ editor, value: nextValue });
-
-    act(() => {
-      result.current.props.onValueChange(nextValue as any);
-    });
-
-    expect(result.current.editorVersion).toBe(2);
-    expect(result.current.selectionVersion).toBe(1);
-    expect(result.current.valueVersion).toBe(2);
-    expect(onValueChange).toHaveBeenCalledWith({ editor, value: nextValue });
-
-    act(() => {
-      result.current.props.onSelectionChange(nextSelection);
     });
 
     expect(result.current.editorVersion).toBe(2);
     expect(result.current.selectionVersion).toBe(2);
     expect(result.current.valueVersion).toBe(2);
+    expect(onChange).toHaveBeenCalledWith({ editor, value: nextValue });
+    expect(onValueChange).toHaveBeenCalledWith({ editor, value: nextValue });
     expect(onSelectionChange).toHaveBeenCalledWith({
       editor,
       selection: nextSelection,

--- a/packages/core/src/react/hooks/useSlateProps.ts
+++ b/packages/core/src/react/hooks/useSlateProps.ts
@@ -64,8 +64,11 @@ export const useSlateProps = ({ id }: { id?: string }): PlateSlateProps => {
 
   const onValueChange: SlateComponentProps['onValueChange'] = React.useMemo(
     () => (value) => {
-      updateVersionValue();
-      onValueChangeProp?.({ editor, value: value as Value });
+      if (editor.children !== prevValueRef.current) {
+        prevValueRef.current = editor.children;
+        updateVersionValue();
+        onValueChangeProp?.({ editor, value: value as Value });
+      }
     },
     [editor, onValueChangeProp, updateVersionValue]
   );
@@ -73,8 +76,11 @@ export const useSlateProps = ({ id }: { id?: string }): PlateSlateProps => {
   const onSelectionChange: SlateComponentProps['onSelectionChange'] =
     React.useMemo(
       () => (selection) => {
-        updateVersionSelection();
-        onSelectionChangeProp?.({ editor, selection });
+        if (editor.selection !== prevSelectionRef.current) {
+          prevSelectionRef.current = editor.selection;
+          updateVersionSelection();
+          onSelectionChangeProp?.({ editor, selection });
+        }
       },
       [editor, onSelectionChangeProp, updateVersionSelection]
     );

--- a/packages/core/src/react/hooks/useSlateProps.ts
+++ b/packages/core/src/react/hooks/useSlateProps.ts
@@ -27,6 +27,9 @@ export const useSlateProps = ({ id }: { id?: string }): PlateSlateProps => {
   const updateVersionSelection = useIncrementVersion('versionSelection', id);
   const updateVersionValue = useIncrementVersion('versionValue', id);
 
+  const prevSelectionRef = React.useRef(editor.selection);
+  const prevValueRef = React.useRef(editor.children);
+
   const onChange = React.useCallback(
     (newValue: SlateComponentProps['initialValue']) => {
       updateVersionEditor();
@@ -35,8 +38,28 @@ export const useSlateProps = ({ id }: { id?: string }): PlateSlateProps => {
       if (!eventIsHandled) {
         onChangeProp?.({ editor, value: newValue as Value });
       }
+
+      if (editor.children !== prevValueRef.current) {
+        prevValueRef.current = editor.children;
+        updateVersionValue();
+        onValueChangeProp?.({ editor, value: newValue as Value });
+      }
+
+      if (editor.selection !== prevSelectionRef.current) {
+        prevSelectionRef.current = editor.selection;
+        updateVersionSelection();
+        onSelectionChangeProp?.({ editor, selection: editor.selection });
+      }
     },
-    [editor, onChangeProp, updateVersionEditor]
+    [
+      editor,
+      onChangeProp,
+      onValueChangeProp,
+      onSelectionChangeProp,
+      updateVersionEditor,
+      updateVersionValue,
+      updateVersionSelection,
+    ]
   );
 
   const onValueChange: SlateComponentProps['onValueChange'] = React.useMemo(


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## Description
Derives `onValueChange` and `onSelectionChange` directly inside the Slate `onChange` handler within `useSlateProps.ts`.

## Problem Solved
Previously, `onChange`, `onValueChange`, and `onSelectionChange` were handled as independent callbacks. When Slate fired `onChange`, component subscribers to value or selection changes could miss updates or receive re-renders out of order.

## Solution
Track `prevValueRef` and `prevSelectionRef`. Inside `onChange`:
1. Trigger `onValueChange` and `updateVersionValue()` when `editor.children` changes.
2. Trigger `onSelectionChange` and `updateVersionSelection()` when `editor.selection` changes.

Fixes #2700
/claim #2700
