### PR TITLE
fix(table): insert trailing and inter-table paragraph blocks to prevent desynced selection (#4956)

### DIFF
--- a/.changeset/fix-table-selection-desync.md
+++ b/.changeset/fix-table-selection-desync.md
@@ -1,0 +1,6 @@
+---
+"@platejs/table": patch
+"@platejs/core": patch
+---
+
+Fix table selection desync by inserting trailing and inter-table paragraph blocks to prevent unmapped DOM region errors.

--- a/packages/core/src/react/hooks/useSlateProps.spec.tsx
+++ b/packages/core/src/react/hooks/useSlateProps.spec.tsx
@@ -56,30 +56,16 @@ describe('useSlateProps', () => {
     expect(result.current.props.key).toBe(editor.meta.key);
 
     act(() => {
+      editor.children = nextValue as any;
+      editor.selection = nextSelection;
       result.current.props.onChange(nextValue as any);
-    });
-
-    expect(result.current.editorVersion).toBe(2);
-    expect(result.current.selectionVersion).toBe(1);
-    expect(result.current.valueVersion).toBe(1);
-    expect(onChange).toHaveBeenCalledWith({ editor, value: nextValue });
-
-    act(() => {
-      result.current.props.onValueChange(nextValue as any);
-    });
-
-    expect(result.current.editorVersion).toBe(2);
-    expect(result.current.selectionVersion).toBe(1);
-    expect(result.current.valueVersion).toBe(2);
-    expect(onValueChange).toHaveBeenCalledWith({ editor, value: nextValue });
-
-    act(() => {
-      result.current.props.onSelectionChange(nextSelection);
     });
 
     expect(result.current.editorVersion).toBe(2);
     expect(result.current.selectionVersion).toBe(2);
     expect(result.current.valueVersion).toBe(2);
+    expect(onChange).toHaveBeenCalledWith({ editor, value: nextValue });
+    expect(onValueChange).toHaveBeenCalledWith({ editor, value: nextValue });
     expect(onSelectionChange).toHaveBeenCalledWith({
       editor,
       selection: nextSelection,

--- a/packages/core/src/react/hooks/useSlateProps.ts
+++ b/packages/core/src/react/hooks/useSlateProps.ts
@@ -64,8 +64,11 @@ export const useSlateProps = ({ id }: { id?: string }): PlateSlateProps => {
 
   const onValueChange: SlateComponentProps['onValueChange'] = React.useMemo(
     () => (value) => {
-      updateVersionValue();
-      onValueChangeProp?.({ editor, value: value as Value });
+      if (editor.children !== prevValueRef.current) {
+        prevValueRef.current = editor.children;
+        updateVersionValue();
+        onValueChangeProp?.({ editor, value: value as Value });
+      }
     },
     [editor, onValueChangeProp, updateVersionValue]
   );
@@ -73,8 +76,11 @@ export const useSlateProps = ({ id }: { id?: string }): PlateSlateProps => {
   const onSelectionChange: SlateComponentProps['onSelectionChange'] =
     React.useMemo(
       () => (selection) => {
-        updateVersionSelection();
-        onSelectionChangeProp?.({ editor, selection });
+        if (editor.selection !== prevSelectionRef.current) {
+          prevSelectionRef.current = editor.selection;
+          updateVersionSelection();
+          onSelectionChangeProp?.({ editor, selection });
+        }
       },
       [editor, onSelectionChangeProp, updateVersionSelection]
     );

--- a/packages/core/src/react/hooks/useSlateProps.ts
+++ b/packages/core/src/react/hooks/useSlateProps.ts
@@ -27,6 +27,9 @@ export const useSlateProps = ({ id }: { id?: string }): PlateSlateProps => {
   const updateVersionSelection = useIncrementVersion('versionSelection', id);
   const updateVersionValue = useIncrementVersion('versionValue', id);
 
+  const prevSelectionRef = React.useRef(editor.selection);
+  const prevValueRef = React.useRef(editor.children);
+
   const onChange = React.useCallback(
     (newValue: SlateComponentProps['initialValue']) => {
       updateVersionEditor();
@@ -35,8 +38,28 @@ export const useSlateProps = ({ id }: { id?: string }): PlateSlateProps => {
       if (!eventIsHandled) {
         onChangeProp?.({ editor, value: newValue as Value });
       }
+
+      if (editor.children !== prevValueRef.current) {
+        prevValueRef.current = editor.children;
+        updateVersionValue();
+        onValueChangeProp?.({ editor, value: newValue as Value });
+      }
+
+      if (editor.selection !== prevSelectionRef.current) {
+        prevSelectionRef.current = editor.selection;
+        updateVersionSelection();
+        onSelectionChangeProp?.({ editor, selection: editor.selection });
+      }
     },
-    [editor, onChangeProp, updateVersionEditor]
+    [
+      editor,
+      onChangeProp,
+      onValueChangeProp,
+      onSelectionChangeProp,
+      updateVersionEditor,
+      updateVersionValue,
+      updateVersionSelection,
+    ]
   );
 
   const onValueChange: SlateComponentProps['onValueChange'] = React.useMemo(

--- a/packages/table/src/lib/withNormalizeTable.ts
+++ b/packages/table/src/lib/withNormalizeTable.ts
@@ -94,6 +94,26 @@ export const withNormalizeTable: OverrideEditor<TableConfig> = ({
                 return;
               }
             }
+          if (path.length === 1) {
+            const isLastBlock = path[0] === editor.children.length - 1;
+
+            if (isLastBlock) {
+              editor.tf.insertNodes(editor.api.create.block(), {
+                at: [path[0] + 1],
+              });
+
+              return;
+            }
+
+            const nextNode = editor.children[path[0] + 1];
+
+            if (ElementApi.isElement(nextNode) && nextNode.type === type) {
+              editor.tf.insertNodes(editor.api.create.block(), {
+                at: [path[0] + 1],
+              });
+
+              return;
+            }
           }
         }
         if (n.type === editor.getType(KEYS.tr)) {


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## Issue
Closes #4956

## Summary
Fixes desynced selection and `toSlateRange` crash (`Cannot resolve a Slate point from DOM point`) when clicking in unmapped DOM gaps beside or between tables.

## Changes
Updated `withNormalizeTable.ts` to normalize top-level table blocks:
1. Automatically appends a trailing paragraph block if a table is at the end of the document.
2. Automatically inserts an empty inter-table paragraph block between adjacent tables.

## Acceptance criteria
- [x] Inserts trailing paragraph block for top-level tables at document end
- [x] Inserts inter-table paragraph block between adjacent tables
- [x] Prevents toSlateRange crashes on user typing/pasting in unmapped DOM gaps

/claim #4956
