### PR TITLE
fix(markdown): keep custom inline elements inside table cell paragraphs

### DIFF
--- a/.changeset/tidy-pugs-punch.md
+++ b/.changeset/tidy-pugs-punch.md
@@ -1,0 +1,5 @@
+---
+'@platejs/markdown': patch
+---
+
+Keep custom inline elements inside a table cell's paragraph when deserializing markdown. The cell deserializer recognised only `inlineEquation` as inline, so any other custom inline element was hoisted out of the paragraph and became its sibling. The cell serializer then separated those siblings with `<br/>`, and a second round trip turned that into a newline — silently destroying the element. The check now asks the editor whether the node is inline, which is the same answer the plugin configuration already holds.

--- a/packages/markdown/src/lib/rules/defaultRules.ts
+++ b/packages/markdown/src/lib/rules/defaultRules.ts
@@ -964,7 +964,11 @@ export const defaultRules: MdRules = {
 
               for (const child of cellChildren) {
                 // Text nodes or inline elements should be grouped into paragraphs
-                if (!child.type || child.type === KEYS.inlineEquation) {
+                if (
+                  !child.type ||
+                  child.type === KEYS.inlineEquation ||
+                  options.editor!.api.isInline(child)
+                ) {
                   currentParagraphChildren.push(child);
                 } else {
                   // Block-level elements should end the current paragraph and be added directly


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

The table cell deserializer groups a cell's children into paragraphs, and its comment says text nodes and inline elements belong in them. The check only ever recognised `inlineEquation`, so every other custom inline element took the block branch: it was hoisted out of the paragraph and became its sibling.

The cell serializer separates siblings with `<br/>`, so the next round trip read that as a line break, encoded it, and the element was gone — no error, nothing visible in the editor, just content missing from the stored markdown.

The editor already knows which plugins are inline, so this asks it instead of keeping a hand-written list that every new inline element has to be added to.

```diff
- if (!child.type || child.type === KEYS.inlineEquation) {
+ if (
+   !child.type ||
+   child.type === KEYS.inlineEquation ||
+   options.editor!.api.isInline(child)
+ ) {
```

`inlineEquation` is kept in the condition so nothing changes for it even if a consumer registers the plugin without the inline flag.

Closes #5067
