### PR TITLE
fix(table): read table element from context to prevent stale-path crash on Enter (#5064)

### DIFF
--- a/.changeset/fix-table-grid-enter-crash.md
+++ b/.changeset/fix-table-grid-enter-crash.md
@@ -1,0 +1,5 @@
+---
+"@platejs/table": patch
+---
+
+Fix crash when pressing Enter before a table on the homepage editor. `useTableColSizes` now reads the table element from React context (`useElement`) instead of re-reading from the editor via a potentially stale path, preventing `compileTableGrid` from receiving a non-table node during mid-transaction re-renders.

--- a/packages/table/src/react/useTableElement.ts
+++ b/packages/table/src/react/useTableElement.ts
@@ -4,9 +4,8 @@ import {
   useEditorPlugin,
   useEditorSelector,
   useElement,
-  useElementSelector,
 } from '@platejs/core/react';
-import { PathApi } from '@platejs/plite';
+
 import { useClaimEditableDOMCommit } from '@platejs/plite-react/internal';
 import { KEYS, type TTableElement } from '@platejs/utils';
 import React from 'react';
@@ -52,31 +51,30 @@ export const useTableColSizes = ({
 } = {}): number[] => {
   const { editor } = useEditorPlugin(TablePlugin);
   const colSizeOverrides = useTableValue('colSizeOverrides');
-  const tablePath = useElementSelector(([, path]) => path, {
-    name: KEYS.table,
-  });
 
-  const overriddenColSizes = useEditorSelector(
-    () => {
-      const tableNode = editor.read.nodes.get<TTableElement>(tablePath)?.[0];
+  // Read the table element from React context rather than re-reading from the
+  // editor via a path. During a transaction that inserts or splits a block
+  // before the table (e.g. pressing Enter in a heading), the path from
+  // useElementSelector can become stale and resolve to the wrong node, crashing
+  // compileTableGrid. useElement always returns the context-bound table node.
+  const tableElement = useElement<TTableElement>(KEYS.table);
 
-      if (!tableNode) return [];
+  const overriddenColSizes = React.useMemo(() => {
+    if (!tableElement) return [];
 
-      const colSizes = editor
-        .plugin(TablePlugin)
-        .api.getOverriddenColumnSizes(
-          tableNode,
-          disableOverrides ? undefined : colSizeOverrides
-        );
+    const colSizes = editor
+      .plugin(TablePlugin)
+      .api.getOverriddenColumnSizes(
+        tableElement,
+        disableOverrides ? undefined : colSizeOverrides
+      );
 
-      if (transformColSizes) {
-        return transformColSizes(colSizes);
-      }
+    if (transformColSizes) {
+      return transformColSizes(colSizes);
+    }
 
-      return colSizes;
-    },
-    { equalityFn: (a, b) => !!a && PathApi.equals(a, b) }
-  );
+    return colSizes;
+  }, [tableElement, colSizeOverrides, disableOverrides, editor, transformColSizes]);
 
   return overriddenColSizes;
 };


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## Summary

Fixes #5064 — Homepage editor throws from table grid code when pressing Enter on `next`.

## Root Cause

`useTableColSizes` reads the table path via `useElementSelector` and then re-reads the table node from the editor using that path. During a transaction that inserts or splits a block before the table (e.g. pressing Enter in a heading above the table), the path becomes stale and resolves to the wrong node (the newly inserted heading). This non-table node gets passed into `compileTableGrid` → `compileTableElement`, which expects table rows but receives heading children, causing:

```
TypeError: Cannot read properties of undefined (reading 'forEach')
  at packages/table/src/lib/internal/grid.ts:138
```

## Fix

Replace the stale-path re-read pattern with `useElement<TTableElement>(KEYS.table)`, which always returns the context-bound table element from React's element provider. This makes the hook immune to mid-transaction path shifts.

### Before
```ts
const tablePath = useElementSelector(([, path]) => path, { name: KEYS.table });
const overriddenColSizes = useEditorSelector(() => {
  const tableNode = editor.read.nodes.get<TTableElement>(tablePath)?.[0];
  // tablePath can be stale → wrong node → crash
  ...
});
```

### After
```ts
const tableElement = useElement<TTableElement>(KEYS.table);
const overriddenColSizes = React.useMemo(() => {
  if (!tableElement) return [];
  // Always the correct, context-bound table node
  ...
}, [tableElement, colSizeOverrides, disableOverrides, editor, transformColSizes]);
```

## Changes

- **`packages/table/src/react/useTableElement.ts`**: `useTableColSizes` now reads the table element from `useElement(KEYS.table)` instead of re-reading from the editor via a stale path. Removed unused `useElementSelector` and `PathApi` imports.
- **`.changeset/fix-table-grid-enter-crash.md`**: Patch changeset for `@platejs/table`.

## Verification

- Traced the crash path: Enter → block insert → path shift → stale path resolves to heading → `compileTableElement` receives heading → `tableRow.children.forEach` throws on undefined.
- The fix eliminates the stale-path dependency entirely by using React context, which is always in sync with the rendered element.
