### PR TITLE
fix(math): close inline equation popover on edge ArrowLeft navigation (#5071)

### DIFF
--- a/.changeset/fix-inline-equation-arrowleft-popover.md
+++ b/.changeset/fix-inline-equation-arrowleft-popover.md
@@ -1,0 +1,5 @@
+---
+"@platejs/math": patch
+---
+
+Fix inline equation popover remaining open when `ArrowLeft` or `ArrowRight` reaches the input edge. `useEquationInput`'s `selectOutsideEquation` now triggers `onClose` when selection moves outside the inline equation element.

--- a/apps/www/src/registry/ui/equation-node.tsx
+++ b/apps/www/src/registry/ui/equation-node.tsx
@@ -121,6 +121,8 @@ export function InlineEquationElement(
     if (selected && isCollapsed) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- Open the inline equation popover when editor selection enters it.
       setOpen(true);
+    } else if (!selected) {
+      setOpen(false);
     }
   }, [selected, isCollapsed]);
 

--- a/packages/math/src/react/useEquation.spec.tsx
+++ b/packages/math/src/react/useEquation.spec.tsx
@@ -118,6 +118,6 @@ describe('useEquationInput', () => {
     expect(after).toHaveBeenCalledWith(element);
     expect(select).toHaveBeenNthCalledWith(1, beforePoint);
     expect(select).toHaveBeenNthCalledWith(2, afterPoint);
-    expect(onClose).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/math/src/react/useEquation.ts
+++ b/packages/math/src/react/useEquation.ts
@@ -159,5 +159,6 @@ export const useEquationInput = ({
     if (!point) return;
 
     editor.update({ tags: 'focus' }).selection.set(point);
+    onClose?.();
   }
 };


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## Summary

Fixes #5071 — Inline equation popover stays open when `ArrowLeft` reaches the input edge.

## Root Cause

When pressing `ArrowLeft` or `ArrowRight` at the edge of an inline equation input, `useEquationInput` calls `selectOutsideEquation`, which updates the editor selection to point before or after the equation element. However, `selectOutsideEquation` omitted calling `onClose?.()`. Consequently, while editor selection returned to the document, the popover state stayed open. Additionally, in `InlineEquationElement`, the popover effect only listened to opening conditions without setting `open(false)` when the element became deselected.

## Fix Description

1. **`packages/math/src/react/useEquation.ts`**: In `selectOutsideEquation`, invoke `onClose?.()` after moving selection outside the equation node so that popover state is closed cleanly.
2. **`apps/www/src/registry/ui/equation-node.tsx`**: In `InlineEquationElement`'s selection effect, add an `else if (!selected)` branch to set `open(false)` when the equation element is no longer selected.
3. **`packages/math/src/react/useEquation.spec.tsx`**: Updated test assertions to verify `onClose` is invoked on edge navigation.
4. **`.changeset/fix-inline-equation-arrowleft-popover.md`**: Added patch changeset for `@platejs/math`.

## Verification

- **Code Inspection**: Verified that when caret reaches input index 0 and `ArrowLeft` is pressed, `selectOutsideEquation('before')` updates selection to before the element AND invokes `onClose`, cleanly closing the popover.
- **Changeset Included**: Patch changeset generated for `@platejs/math`.
