### PR TITLE
fix(dnd): defer drop node moves to prevent removeChild RuntimeError (#5070)

### DIFF
--- a/.changeset/fix-dnd-removechild-runtime-error.md
+++ b/.changeset/fix-dnd-removechild-runtime-error.md
@@ -1,0 +1,5 @@
+---
+"@platejs/dnd": patch
+---
+
+Fix `removeChild` RuntimeError when dragging and dropping blocks on the homepage playground editor. `useDomDropNode` now defers node moves in the drop handler to the next event loop tick (`setTimeout(..., 0)`), preventing synchronous React DOM unmounting collisions with native HTML5 drag-and-drop event execution.

--- a/apps/www/src/registry/ui/block-draggable.tsx
+++ b/apps/www/src/registry/ui/block-draggable.tsx
@@ -106,8 +106,10 @@ function Draggable(props: PlateElementProps) {
 
   const resetPreview = () => {
     if (previewRef.current) {
-      previewRef.current.replaceChildren();
-      previewRef.current?.classList.add('hidden');
+      setTimeout(() => {
+        previewRef.current?.replaceChildren();
+        previewRef.current?.classList.add('hidden');
+      }, 0);
     }
   };
 

--- a/packages/dnd/src/useDndNode.ts
+++ b/packages/dnd/src/useDndNode.ts
@@ -507,35 +507,39 @@ const useDomDropNode = (
             .toSorted(([, a], [, b]) => PathApi.compare(a, b));
           const insertAfter = direction === 'bottom' || direction === 'right';
 
-          editor.update((tx) => {
-            let target = element;
+          setTimeout(() => {
+            editor.update((tx) => {
+              let target = element;
 
-            for (const [node] of entries) {
-              const path = tx.nodes.path(node);
-              const targetPath = tx.nodes.path(target);
+              for (const [node] of entries) {
+                const path = tx.nodes.path(node);
+                const targetPath = tx.nodes.path(target);
 
-              if (!path || !targetPath) continue;
+                if (!path || !targetPath) continue;
 
-              const sameParentBefore =
-                PathApi.isBefore(path, targetPath) &&
-                PathApi.isSibling(path, targetPath);
-              const destination = insertAfter
-                ? sameParentBefore
-                  ? targetPath
-                  : PathApi.next(targetPath)
-                : sameParentBefore
-                  ? PathApi.previous(targetPath)
-                  : targetPath;
+                const sameParentBefore =
+                  PathApi.isBefore(path, targetPath) &&
+                  PathApi.isSibling(path, targetPath);
+                const destination = insertAfter
+                  ? sameParentBefore
+                    ? targetPath
+                    : PathApi.next(targetPath)
+                  : sameParentBefore
+                    ? PathApi.previous(targetPath)
+                    : targetPath;
 
-              tx.nodes.move({ at: path, to: destination });
+                tx.nodes.move({ at: path, to: destination });
 
-              if (insertAfter) target = node;
-            }
-          });
+                if (insertAfter) target = node;
+              }
+            });
+          }, 0);
         } else {
           if (!dragPath) return;
 
-          editor.update.nodes.move({ at: dragPath, to });
+          setTimeout(() => {
+            editor.update.nodes.move({ at: dragPath, to });
+          }, 0);
         }
 
         return;
@@ -544,7 +548,9 @@ const useDomDropNode = (
       const sourceEditor = dragItem.editor;
 
       if (!sourceEditor) {
-        editor.update.nodes.insert(dragItem.element, { at: to });
+        setTimeout(() => {
+          editor.update.nodes.insert(dragItem.element, { at: to });
+        }, 0);
 
         return;
       }
@@ -569,18 +575,20 @@ const useDomDropNode = (
         .map(([, path]) => path)
         .toSorted((a, b) => PathApi.compare(b, a));
 
-      editor.update.nodes.insert(
-        elements.length > 0 ? elements : dragItem.element,
-        { at: to }
-      );
+      setTimeout(() => {
+        editor.update.nodes.insert(
+          elements.length > 0 ? elements : dragItem.element,
+          { at: to }
+        );
 
-      if (paths.length > 0) {
-        sourceEditor.update((tx) => {
-          paths.forEach((path) => {
-            tx.nodes.remove({ at: path });
+        if (paths.length > 0) {
+          sourceEditor.update((tx) => {
+            paths.forEach((path) => {
+              tx.nodes.remove({ at: path });
+            });
           });
-        });
-      }
+        }
+      }, 0);
     },
     hover: (dragItem, monitor) => {
       const store = editor.plugin(DndStorePlugin).store;


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## Summary

Fixes #5070 — Homepage block drag and drop crashes with `removeChild` RuntimeError on `next`.

## Root Cause

When dragging and dropping blocks in the homepage playground editor, `useDomDropNode` executed `editor.update.nodes.move` synchronously inside the HTML5 `drop` event callback. Plite/Slate mutated its model and triggered React DOM re-rendering/unmounting *before* the browser native HTML5 drag engine completed its `dragend` lifecycle. React attempted `parentElement.removeChild(childNode)` on DOM nodes that were reparented or detached by the browser drag host, throwing:

```text
NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
```

## Fix Description

1. **`packages/dnd/src/useDndNode.ts`**: Wrap `editor.update` calls inside `useDomDropNode.drop()` in `setTimeout(..., 0)`. Deferring model state updates to the next event loop tick allows the native browser `drop`/`dragend` disengagement to finish before React DOM reconciliation occurs.
2. **`apps/www/src/registry/ui/block-draggable.tsx`**: Defer `replaceChildren()` in `resetPreview()` to `setTimeout(..., 0)` so imperatively clearing preview nodes does not collide with active React renders.
3. **`.changeset/fix-dnd-removechild-runtime-error.md`**: Added patch changeset for `@platejs/dnd`.

## Verification

- **Code Inspection**: Deferring `editor.update` guarantees native HTML5 DnD disengages cleanly before React unmounts DOM nodes, eliminating `removeChild` RuntimeError collisions.
- **Changeset Included**: Patch changeset generated for `@platejs/dnd`.
