### PR TITLE
fix(link): reject shebang lines in validateUrl to prevent autolinking (#5039)

### DIFF
--- a/.changeset/fix-link-plugin-autolink-shebang.md
+++ b/.changeset/fix-link-plugin-autolink-shebang.md
@@ -1,0 +1,5 @@
+---
+"@platejs/link": patch
+---
+
+Fix `LinkPlugin` autolinking plain text shebang lines starting with `#!` (e.g. `#!/bin/sh` or `#!/usr/bin/env node`). `validateUrl` now rejects shebang patterns so plain text shell scripts are not wrapped in anchor link nodes.

--- a/packages/link/src/lib/utils/validateUrl.spec.ts
+++ b/packages/link/src/lib/utils/validateUrl.spec.ts
@@ -136,5 +136,11 @@ describe('validateUrl', () => {
       expect(validateUrl(editor, '#heading1')).toBe(true);
       expect(validateUrl(editor, '##heading2')).toBe(true);
     });
+
+    it('rejects shebang lines starting with #!', () => {
+      const editor = createTestEditor();
+      expect(validateUrl(editor, '#!/bin/sh')).toBe(false);
+      expect(validateUrl(editor, '#!/usr/bin/env node')).toBe(false);
+    });
   });
 });

--- a/packages/link/src/lib/utils/validateUrl.ts
+++ b/packages/link/src/lib/utils/validateUrl.ts
@@ -4,6 +4,7 @@ import { BaseLinkPlugin } from '../BaseLinkPlugin';
 
 // Markdown headings have a space after the # symbols
 const MARKDOWN_HEADING_PATTERN = /^#{1,6}\s+/;
+const SHEBANG_PATTERN = /^#!(\/.*)?$/;
 
 export const validateUrl = (editor: SlateEditor, url: string): boolean => {
   const { allowedSchemes, dangerouslySkipSanitization, isUrl } =
@@ -15,10 +16,10 @@ export const validateUrl = (editor: SlateEditor, url: string): boolean => {
     return customIsUrl ? customIsUrl(url) : true;
   }
 
-  // For strings starting with #, check if it's a markdown heading
+  // For strings starting with #, check if it's a markdown heading or shebang
   if (url.startsWith('#')) {
-    if (MARKDOWN_HEADING_PATTERN.test(url)) {
-      return false; // This is a markdown heading, not a valid link
+    if (MARKDOWN_HEADING_PATTERN.test(url) || SHEBANG_PATTERN.test(url)) {
+      return false; // This is a markdown heading or shebang, not a valid link
     }
     return customIsUrl ? customIsUrl(url) : true;
   }


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## 🎯 Summary

Fixes #5039 — LinkPlugin autolinks pasted plain text starting with "#" or "/" (e.g. shebang "#!/bin/sh").

## 🔍 Root Cause Analysis

When plain text starting with a shebang (e.g. `#!/bin/sh` or `#!/usr/bin/env node`) was pasted into an editor with `LinkPlugin` enabled, `validateUrl` checked `url.startsWith('#')` and treated it as an anchor link URL. Because it returned `true` before checking `isUrl`, plain text shell scripts were misdetected and wrapped into a single link node.

## 🛠️ Surgical Patch Breakdown

1. **`packages/link/src/lib/utils/validateUrl.ts`**:
   Added `SHEBANG_PATTERN = /^#!(/.*)?$/`. In `validateUrl`, reject shebang lines starting with `#!` so they are not misdetected as valid anchor links.
2. **`packages/link/src/lib/utils/validateUrl.spec.ts`**:
   Added unit tests verifying `validateUrl` rejects shebang lines starting with `#!`.
3. **`.changeset/fix-link-plugin-autolink-shebang.md`**: Added patch changeset for `@platejs/link`.

## 🧪 Verification & Test Coverage

- **Automated Unit Tests**: Unit tests in `packages/link/src/lib/utils/validateUrl.spec.ts` verify shebang lines (`#!/bin/sh`, `#!/usr/bin/env node`) return `false`.
- **Changeset Included**: Patch changeset generated for `@platejs/link`.
- **Clean Merge**: Branch rebased cleanly against `main` with 0 conflicts.
