### PR TITLE
fix(markdown): expand marked version range to support marked v18 (#5060)

### DIFF
--- a/.changeset/fix-markdown-marked-v18-version-range.md
+++ b/.changeset/fix-markdown-marked-v18-version-range.md
@@ -1,0 +1,5 @@
+---
+"@platejs/markdown": patch
+---
+
+Expand `marked` dependency version range in `@platejs/markdown` to allow `marked` v15 through v18 (`^15.0.12 || ^16.0.0 || ^17.0.0 || ^18.0.0`), eliminating duplicate lockfile entries for projects using `marked` v18.

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@platejs/date": "workspace:*",
     "lodash": "^4.17.23",
-    "marked": "^15.0.12",
+    "marked": "^15.0.12 || ^16.0.0 || ^17.0.0 || ^18.0.0",
     "mdast-util-math": "3.0.0",
     "mdast-util-mdx": "3.0.0",
     "react-compiler-runtime": "^1.0.0",


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## 🎯 Summary

Fixes #5060 — marked fixed to v15 in `@platejs/markdown` causing duplicate lockfile entries for marked v18 users.

## 🔍 Root Cause Analysis

`@platejs/markdown` pinned `marked` to `^15.0.12` in dependencies. Projects using `marked` v18 (or v16/v17) were forced to ship duplicate versions of the `marked` library in their bundle and lockfile.

## 🛠️ Surgical Patch Breakdown

1. **`packages/markdown/package.json`**:
   Expanded `marked` dependency specifier to `^15.0.12 || ^16.0.0 || ^17.0.0 || ^18.0.0`, allowing projects using marked v15 through v18 to reuse a single dependency instance.
2. **`.changeset/fix-markdown-marked-v18-version-range.md`**: Added patch changeset for `@platejs/markdown`.

## 🧪 Verification & Test Coverage

- **Lockfile Deduplication**: Allows applications on marked v18 to resolve a single dependency entry.
- **Changeset Included**: Patch changeset generated for `@platejs/markdown`.
- **Clean Merge**: Branch rebased cleanly against `main` with 0 conflicts.
