### PR TITLE
fix(registry): add explicit width to ColorDropdownMenuItems to prevent dropdown clipping (#5052)

### DIFF
--- a/.changeset/fix-font-color-toolbar-button-dropdown-width.md
+++ b/.changeset/fix-font-color-toolbar-button-dropdown-width.md
@@ -1,0 +1,5 @@
+---
+"www": patch
+---
+
+Fix font & background color toolbar button dropdown clipping. Added explicit width (`w-[276px]`) to `ColorDropdownMenuItems` in `font-color-toolbar-button.tsx` so the 10-column color palette grid allocates full width without horizontal clipping.

--- a/apps/www/src/registry/ui/font-color-toolbar-button.tsx
+++ b/apps/www/src/registry/ui/font-color-toolbar-button.tsx
@@ -520,7 +520,7 @@ export function ColorDropdownMenuItems({
   return (
     <div
       className={cn(
-        'grid grid-cols-[repeat(10,1fr)] place-items-center gap-x-1',
+        'grid w-[276px] grid-cols-[repeat(10,1fr)] place-items-center gap-x-1',
         className
       )}
       {...props}


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## 🎯 Summary

Fixes #5052 — Font colour toolbar component has fragile dropdown sizing.

## 🔍 Root Cause Analysis

When opening the font color or background color picker dropdown in a toolbar with constrained width, `ColorDropdownMenuItems`'s 10-column grid (`grid-cols-[repeat(10,1fr)]`) lacked an explicit container width, causing the color items to shrink and clip horizontally.

## 🛠️ Surgical Patch Breakdown

1. **`apps/www/src/registry/ui/font-color-toolbar-button.tsx`**:
   Added explicit width (`w-[276px]`) to `ColorDropdownMenuItems`'s grid container so all 10 color columns allocate full required width without horizontal clipping.
2. **`.changeset/fix-font-color-toolbar-button-dropdown-width.md`**: Added patch changeset for registry UI.

## 🧪 Verification & Test Coverage

- **Layout Verification**: Verified `ColorDropdownMenuItems` allocates exact 276px container width for all 10 color swatches + gaps.
- **Changeset Included**: Patch changeset generated for `www` registry UI.
- **Clean Merge**: Branch rebased cleanly against `main` with 0 conflicts.
