### PR TITLE
fix(plite): filter out empty-children elements when maxLength limit is exceeded (#5043)

### DIFF
--- a/.changeset/fix-plite-max-length-multi-line-paste-crash.md
+++ b/.changeset/fix-plite-max-length-multi-line-paste-crash.md
@@ -1,0 +1,5 @@
+---
+"@platejs/plite": patch
+---
+
+Fix crash when pasting text with multiple line-breaks exceeding `maxLength` constraint. Filter out elements whose children are completely trimmed when remaining character budget is exhausted in `limitNode`, preventing empty-children elements (`{ children: [] }`) from entering the document model.

--- a/packages/plite/src/core/insert-limit.ts
+++ b/packages/plite/src/core/insert-limit.ts
@@ -74,6 +74,8 @@ const limitNode = <TNode extends ElementOrTextIn<Value>>(
     .map((child) => limitNode(child, remaining))
     .filter((child): child is ElementOrTextIn<Value> => child !== null);
 
+  if (children.length === 0) return null;
+
   return { ...node, children } as TNode;
 };
 

--- a/packages/plite/test/max-length-contract.test.ts
+++ b/packages/plite/test/max-length-contract.test.ts
@@ -71,6 +71,20 @@ describe('maxLength editor option', () => {
     assert.equal(editor.read.text.string([]), 'Hello');
   });
 
+  it('does not crash when pasting multiple line-breaks exceeding maxLength', () => {
+    const editor = createLimitedEditor(5);
+
+    editor.update((tx) => {
+      tx.fragment.replace([
+        paragraph('Hel'),
+        paragraph('lo'),
+        paragraph('overflow text line 3'),
+      ]);
+    });
+
+    assert.equal(editor.read.text.string([]), 'Hello');
+  });
+
   it('truncates inserted nodes', () => {
     const editor = createLimitedEditor(5);
 


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## 🎯 Summary

Fixes #5043 — Pasting text with multiple line-breaks crashes when maxLength constraint is set.

## 🔍 Root Cause Analysis

When pasting text containing multiple line-breaks (e.g. multiple paragraph blocks) into an editor with `maxLength` configured, `limitNode` in `packages/plite/src/core/insert-limit.ts` trimmed text children as remaining character budget was consumed. When remaining character budget reached 0, subsequent paragraph elements had all their text children filtered out, returning an element object with `children: []`. Slate/Plite document models require every element to contain at least one child node, causing an unhandled `TypeError: Cannot read properties of undefined (reading 'text')` crash on insertion.

## 🛠️ Surgical Patch Breakdown

1. **`packages/plite/src/core/insert-limit.ts`**:
   In `limitNode`, added `if (children.length === 0) return null;`. When an element's children are completely trimmed because the character budget is exhausted, return `null` so empty-children elements are filtered out rather than inserted into the document model.
2. **`packages/plite/test/max-length-contract.test.ts`**:
   Added unit test coverage verifying multi-paragraph paste with an exhausted `maxLength` limit does not crash or produce invalid empty-children elements.
3. **`.changeset/fix-plite-max-length-multi-line-paste-crash.md`**: Added patch changeset for `@platejs/plite`.

## 🧪 Verification & Test Coverage

- **Automated Unit Tests**: Unit test in `packages/plite/test/max-length-contract.test.ts` verifies multi-paragraph paste with exhausted `maxLength` limit.
- **Changeset Included**: Patch changeset generated for `@platejs/plite`.
- **Clean Merge**: Branch rebased cleanly against `next` with 0 conflicts.
