### PR TITLE
fix(registry): fix block drag handle displaying I-beam text cursor (#4535)

### DIFF
--- a/.changeset/fix-block-draggable-cursor-grab.md
+++ b/.changeset/fix-block-draggable-cursor-grab.md
@@ -1,0 +1,5 @@
+---
+"www": patch
+---
+
+Fix block drag handle cursor showing I-beam text cursor (`cursor-text`). Updated `slate-gutterLeft` to `cursor-pointer` and added `cursor-grab active:cursor-grabbing select-none` to drag handle button in `block-draggable.tsx`.

--- a/apps/www/src/registry/ui/block-draggable.tsx
+++ b/apps/www/src/registry/ui/block-draggable.tsx
@@ -149,7 +149,7 @@ function Draggable(props: PlateElementProps) {
               <Button
                 ref={handleRef}
                 variant="ghost"
-                className="-left-0 absolute h-6 w-full p-0"
+                className="-left-0 absolute h-6 w-full p-0 cursor-grab active:cursor-grabbing select-none"
                 style={{ top: `${dragButtonTop + 3}px` }}
                 data-plate-prevent-deselect
               >
@@ -206,7 +206,7 @@ function Gutter({
       {...props}
       className={cn(
         'slate-gutterLeft',
-        '-translate-x-full absolute top-0 z-50 flex h-full cursor-text hover:opacity-100 sm:opacity-0',
+        '-translate-x-full absolute top-0 z-50 flex h-full cursor-pointer hover:opacity-100 sm:opacity-0',
         getPluginByType(editor, element.type)?.node.isContainer
           ? 'group-hover/container:opacity-100'
           : 'group-hover:opacity-100',


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## 🎯 Summary

Fixes #4535 — Draggable cursor has "input cursor".

## 🔍 Root Cause Analysis

When hovering over or clicking the block drag handle in `apps/www/src/registry/ui/block-draggable.tsx`, `slate-gutterLeft` had `cursor-text` applied to its CSS classes, forcing the browser to display an I-beam input cursor over the drag handle icon instead of a drag pointer.

## 🛠️ Surgical Patch Breakdown

1. **`apps/www/src/registry/ui/block-draggable.tsx`**:
   - Replaced `cursor-text` with `cursor-pointer` on `slate-gutterLeft` in `Gutter` component.
   - Added `cursor-grab active:cursor-grabbing select-none` to the drag handle `Button` component.
2. **`.changeset/fix-block-draggable-cursor-grab.md`**: Added patch changeset for www registry UI.

## 🧪 Verification & Test Coverage

- **Cursor Verification**: Drag handle displays proper grab cursor (`cursor-grab`) during hover and active grabbing cursor (`active:cursor-grabbing`) during drag operations.
- **Changeset Included**: Patch changeset generated for `www` registry UI.
- **Clean Merge**: Branch rebased cleanly against `main` with 0 conflicts.
