### PR TITLE
fix(registry): set floating toolbar placement to bottom on mobile to prevent overlap (#4619)

### DIFF
--- a/.changeset/fix-floating-toolbar-mobile-placement-overlap.md
+++ b/.changeset/fix-floating-toolbar-mobile-placement-overlap.md
@@ -1,0 +1,5 @@
+---
+"www": patch
+---
+
+Fix `FloatingToolbar` overlapping with native mobile text selection context menus on mobile devices. Uses `useIsMobile` to set `placement: 'bottom'` on mobile viewports so custom floating toolbars render below selection instead of colliding with native mobile context menus.

--- a/apps/www/src/registry/ui/floating-toolbar.tsx
+++ b/apps/www/src/registry/ui/floating-toolbar.tsx
@@ -17,6 +17,7 @@ import {
   usePluginOption,
 } from 'platejs/react';
 
+import { useIsMobile } from '@/hooks/use-mobile';
 import { cn } from '@/lib/utils';
 
 import { Toolbar } from './toolbar';
@@ -29,6 +30,7 @@ export function FloatingToolbar({
 }: React.ComponentProps<typeof Toolbar> & {
   state?: FloatingToolbarState;
 }) {
+  const isMobile = useIsMobile();
   const editorId = useEditorId();
   const focusedEditorId = useEventEditorValue('focus');
   const isFloatingLinkOpen = !!usePluginOption({ key: KEYS.link }, 'mode');
@@ -43,16 +45,23 @@ export function FloatingToolbar({
       middleware: [
         offset(12),
         flip({
-          fallbackPlacements: [
-            'top-start',
-            'top-end',
-            'bottom-start',
-            'bottom-end',
-          ],
+          fallbackPlacements: isMobile
+            ? [
+                'bottom-start',
+                'bottom-end',
+                'top-start',
+                'top-end',
+              ]
+            : [
+                'top-start',
+                'top-end',
+                'bottom-start',
+                'bottom-end',
+              ],
           padding: 12,
         }),
       ],
-      placement: 'top',
+      placement: isMobile ? 'bottom' : 'top',
       ...state?.floatingOptions,
     },
   });


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## 🎯 Summary

Fixes #4619 — 'floating toolbar' overlaps with native default 'context menu' in Mobile.

## 🔍 Root Cause Analysis

On mobile viewports (iOS Safari / Android Chrome), native selection context menus (Copy / Cut / Share) pop up directly above the text selection. Because `FloatingToolbar` in `apps/www/src/registry/ui/floating-toolbar.tsx` defaulted to `placement: 'top'`, custom floating toolbars collided and overlapped directly on top of native mobile context menus.

## 🛠️ Surgical Patch Breakdown

1. **`apps/www/src/registry/ui/floating-toolbar.tsx`**:
   - Imported `useIsMobile` hook to set `placement: isMobile ? 'bottom' : 'top'`.
   - Updated `fallbackPlacements` on mobile to prioritize bottom placements (`['bottom-start', 'bottom-end', 'top-start', 'top-end']`).
2. **`.changeset/fix-floating-toolbar-mobile-placement-overlap.md`**: Added patch changeset for www registry UI.

## 🧪 Verification & Test Coverage

- **Mobile Viewport Placement**: Verified floating toolbar renders below text selection on mobile screens (<=768px), preventing collision with native mobile selection menus.
- **Changeset Included**: Patch changeset generated for www registry UI.
- **Clean Merge**: Branch rebased cleanly against `main` with 0 conflicts.
