### PR TITLE
fix: repair broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To get started, check out our [contributing guide](CONTRIBUTING.md).
 
 We'd love for you to join us! Whether it's through giving us a 🌟 star, making a 📥 pull request, or **sharing your plugins**, your help is always appreciated.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=udecode/plate&type=Date)](https://star-history.com/#udecode/plate&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=udecode/plate&type=Date)](https://star-history.dera.page/#udecode/plate&Date)
 
 Need more help? Join us on [Discord](https://discord.gg/mAZRuBzGM3). We're always here to guide you.
 

--- a/tooling/cn/README.md
+++ b/tooling/cn/README.md
@@ -43,6 +43,6 @@ Plate
 
 我们希望您能加入我们！无论是给我们一个🌟星标，提交一个📥拉取请求，还是**分享您的插件**，您的帮助总是值得称赞的。
 
-[![Star历史图表](https://api.star-history.com/svg?repos=udecode/plate&type=Date)](https://star-history.com/#udecode/plate&Date)
+[![Star历史图表](https://star-history.dera.page/svg?repos=udecode/plate&type=Date)](https://star-history.dera.page/#udecode/plate&Date)
 
 需要更多帮助？加入我们的[Discord](https://discord.gg/mAZRuBzGM3)。我们随时为您提供指导。(可以在中文频道使用中文进行提问)


### PR DESCRIPTION
The star history chart is currently broken due to GitHub stargazer API restrictions. This PR switches the chart to star-history.dera.page, an alternative that uses a different data source requiring no API token. Updated in README.md and tooling/cn/README.md.