### PR TITLE
fix(core): wrap root inline nodes in the default block on HTML deserialize

### DIFF
--- a/.changeset/core-normalize-inline-only-html.md
+++ b/.changeset/core-normalize-inline-only-html.md
@@ -1,5 +1,5 @@
 ---
-'@platejs/core': patch
+"@platejs/core": patch
 ---
 
 Fix `editor.api.html.deserialize` returning unwrapped text nodes at the root for inline-only HTML

--- a/.changeset/core-normalize-inline-only-html.md
+++ b/.changeset/core-normalize-inline-only-html.md
@@ -1,0 +1,5 @@
+---
+'@platejs/core': patch
+---
+
+Fix `editor.api.html.deserialize` returning unwrapped text nodes at the root for inline-only HTML

--- a/apps/www/src/__tests__/package-integration/core-html/deserializeHtml.slow.tsx
+++ b/apps/www/src/__tests__/package-integration/core-html/deserializeHtml.slow.tsx
@@ -31,7 +31,7 @@ describe('when collapseWhitespace is false', () => {
   const html = '<blockquote>test \n code</blockquote>';
   const element = getHtmlDocument(html).body.innerHTML;
 
-  const expectedOutput = [{ text: 'test \n code' }];
+  const expectedOutput = [{ children: [{ text: 'test \n code' }], type: 'p' }];
 
   it('preserves line breaks', () => {
     const convertedDocumentFragment = deserializeHtml(createSlateEditor(), {
@@ -49,11 +49,13 @@ describe('when element is a div', () => {
 
   const output = (
     <fragment>
-      <htext>test</htext>
+      <hp>
+        <htext>test</htext>
+      </hp>
     </fragment>
   ) as any;
 
-  it('returns a text fragment', () => {
+  it('wraps the text in the default block', () => {
     expect(
       deserializeHtml(createSlateEditor(), {
         element,
@@ -90,11 +92,13 @@ describe('when html is a text without tags', () => {
 
   const output = (
     <fragment>
-      <htext>test</htext>
+      <hp>
+        <htext>test</htext>
+      </hp>
     </fragment>
   ) as any;
 
-  it('returns a text fragment', () => {
+  it('wraps the text in the default block', () => {
     expect(
       deserializeHtml(createSlateEditor(), {
         element,

--- a/packages/core/src/lib/plugins/html/utils/deserializeHtml.spec.tsx
+++ b/packages/core/src/lib/plugins/html/utils/deserializeHtml.spec.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsxt */
+
+import { jsxt } from '@platejs/test-utils';
+
+import { createSlateEditor } from '../../../editor';
+import { deserializeHtml } from './deserializeHtml';
+
+jsxt;
+
+describe('deserializeHtml', () => {
+  it('wraps inline-only html in the default block', () => {
+    const editor = createSlateEditor();
+
+    expect(deserializeHtml(editor, { element: 'first<br><br>second' })).toEqual(
+      [
+        <hp>
+          <htext>{'first\n\nsecond'}</htext>
+        </hp>,
+      ]
+    );
+  });
+
+  it('wraps empty html in the default block', () => {
+    const editor = createSlateEditor();
+
+    expect(deserializeHtml(editor, { element: '' })).toEqual([
+      <hp>
+        <htext />
+      </hp>,
+    ]);
+  });
+});

--- a/packages/core/src/lib/utils/normalizeDescendantsToDocumentFragment.spec.tsx
+++ b/packages/core/src/lib/utils/normalizeDescendantsToDocumentFragment.spec.tsx
@@ -8,14 +8,18 @@ import { normalizeDescendantsToDocumentFragment } from './index';
 jsxt;
 
 describe('normalizeDescendantsToDocumentFragment()', () => {
-  it('returns a blank text node when descendants are empty', () => {
+  it('returns a blank default block when descendants are empty', () => {
     const editor = createSlateEditor();
 
     expect(
       normalizeDescendantsToDocumentFragment(editor, {
         descendants: [],
       })
-    ).toEqual([<htext />]);
+    ).toEqual([
+      <hp>
+        <htext />
+      </hp>,
+    ]);
   });
 
   it.each([
@@ -56,11 +60,21 @@ describe('normalizeDescendantsToDocumentFragment()', () => {
   it.each([
     {
       input: [<htext>text node</htext>, <htext>another text node</htext>],
-      output: [<htext>text node</htext>, <htext>another text node</htext>],
+      output: [
+        <hp>
+          <htext>text node</htext>
+          <htext>another text node</htext>
+        </hp>,
+      ],
     },
     {
       input: [<ha>inline element</ha>, <htext>text node</htext>],
-      output: [<ha>inline element</ha>, <htext>text node</htext>],
+      output: [
+        <hp>
+          <ha>inline element</ha>
+          <htext>text node</htext>
+        </hp>,
+      ],
     },
     {
       input: [<hp>block</hp>, <hp>another block</hp>, <htext>text node</htext>],
@@ -109,7 +123,7 @@ describe('normalizeDescendantsToDocumentFragment()', () => {
         </hp>,
       ],
     },
-  ])('wraps inline blocks and text nodes when they have a sibling block', ({
+  ])('wraps inline blocks and text nodes at the root or next to a sibling block', ({
     input,
     output,
   }: any) => {
@@ -126,11 +140,21 @@ describe('normalizeDescendantsToDocumentFragment()', () => {
   it.each([
     {
       input: [<htext>text node</htext>, <htext>another text node</htext>],
-      output: [<htext>text node</htext>, <htext>another text node</htext>],
+      output: [
+        <hblockquote>
+          <htext>text node</htext>
+          <htext>another text node</htext>
+        </hblockquote>,
+      ],
     },
     {
       input: [<ha>inline element</ha>, <htext>text node</htext>],
-      output: [<ha>inline element</ha>, <htext>text node</htext>],
+      output: [
+        <hblockquote>
+          <ha>inline element</ha>
+          <htext>text node</htext>
+        </hblockquote>,
+      ],
     },
     {
       input: [<hp>block</hp>, <hp>another block</hp>, <htext>text node</htext>],
@@ -183,7 +207,7 @@ describe('normalizeDescendantsToDocumentFragment()', () => {
         </hp>,
       ],
     },
-  ])('wraps inline blocks and text nodes with the default element when they have a sibling block', ({
+  ])('wraps inline blocks and text nodes with the default element at the root or next to a sibling block', ({
     input,
     output,
   }: any) => {

--- a/packages/core/src/lib/utils/normalizeDescendantsToDocumentFragment.ts
+++ b/packages/core/src/lib/utils/normalizeDescendantsToDocumentFragment.ts
@@ -36,17 +36,22 @@ const hasDifferentChildNodes = (
 /**
  * Handles 3rd constraint: "Block nodes can only contain other blocks, or inline
  * and text nodes."
+ *
+ * At the root, inline and text nodes are always wrapped in the default block,
+ * since the document root can only contain blocks.
  */
 const normalizeDifferentNodeTypes = (
   descendants: Descendant[],
   isInline: (node: Descendant) => boolean,
-  makeDefaultBlock: () => Descendant
+  makeDefaultBlock: () => Descendant,
+  forceWrapInline: boolean
 ): Descendant[] => {
-  const hasDifferentNodes = hasDifferentChildNodes(descendants, isInline);
+  const shouldWrapInlines =
+    forceWrapInline || hasDifferentChildNodes(descendants, isInline);
 
   const { fragment } = descendants.reduce(
     (memo, node) => {
-      if (hasDifferentNodes && isInline(node)) {
+      if (shouldWrapInlines && isInline(node)) {
         let block = memo.precedingBlock;
 
         if (!block) {
@@ -87,7 +92,8 @@ const normalizeEmptyChildren = (descendants: Descendant[]): Descendant[] => {
 const normalize = (
   descendants: Descendant[],
   isInline: (node: Descendant) => boolean,
-  makeDefaultBlock: () => Descendant
+  makeDefaultBlock: () => Descendant,
+  isRoot: boolean
 ): Descendant[] => {
   // biome-ignore lint/style/noParameterAssign: Sequential transformation pipeline pattern
   descendants = normalizeEmptyChildren(descendants);
@@ -95,7 +101,8 @@ const normalize = (
   descendants = normalizeDifferentNodeTypes(
     descendants,
     isInline,
-    makeDefaultBlock
+    makeDefaultBlock,
+    isRoot
   );
 
   // biome-ignore lint/style/noParameterAssign: Sequential transformation pipeline pattern
@@ -106,7 +113,8 @@ const normalize = (
         children: normalize(
           node.children as Descendant[],
           isInline,
-          makeDefaultBlock
+          makeDefaultBlock,
+          false
         ),
       };
     }
@@ -129,5 +137,5 @@ export const normalizeDescendantsToDocumentFragment = (
   const defaultType = editor.getType(defaultElementPlugin.key);
   const makeDefaultBlock = makeBlockLazy(defaultType);
 
-  return normalize(descendants, isInline, makeDefaultBlock as any);
+  return normalize(descendants, isInline, makeDefaultBlock as any, true);
 };


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

**Checklist**

- [x] `pnpm typecheck`
- [x] `pnpm lint:fix`
- [x] `bun test`
- [ ] `pnpm brl` (not needed, only a spec file was added)
- [x] `pnpm changeset`
- [ ] [ui changelog](docs/components/changelog.mdx) (no registry change)

Fixes #5061.

`editor.api.html.deserialize` returned bare text nodes at the root when the HTML had no block element. `normalizeDescendantsToDocumentFragment` wrapped inline and text nodes only when they sat next to a sibling block, so input like `first<br><br>second` came back as a flat list of text nodes. The Slate root can only hold blocks, and since chunking became the default that shape crashes the editor.

Root level normalization now always wraps runs of inline and text nodes in the default block. Nested element children keep the old rule, so a paragraph's own text children are still left alone.

One behavior change worth calling out: an empty fragment used to normalize to `[{ text: '' }]` and now normalizes to `[{ type: 'p', children: [{ text: '' }] }]`. That also fixes `setValue('')` and `init({ value: '' })`, which both left the editor with an invalid root.

Written with AI assistance. Fully tested: `bun test` in `packages/core` passes apart from three specs that cannot resolve unlinked workspace packages in my checkout, and those fail the same way on `main`.
