### PR TITLE
fix(core): guard LengthPlugin against re-entrant trimming

### DIFF
--- a/.changeset/core-length-multiblock-paste-crash.md
+++ b/.changeset/core-length-multiblock-paste-crash.md
@@ -1,0 +1,5 @@
+---
+"@platejs/core": patch
+---
+
+Fix crash when a paste that exceeds `maxLength` spans multiple blocks

--- a/packages/core/src/lib/plugins/length/LengthPlugin.spec.ts
+++ b/packages/core/src/lib/plugins/length/LengthPlugin.spec.ts
@@ -97,4 +97,25 @@ describe('LengthPlugin', () => {
       expect(options.maxLength).toBe(15);
     });
   });
+
+  describe('when the overflow spans block boundaries', () => {
+    // The trim deletes across block boundaries, which Slate decomposes into
+    // merge/remove operations. Those come back through the plugin's own
+    // `apply`, and before the re-entrancy guard the nested call started a
+    // second overlapping delete and crashed on a path the outer one had
+    // already invalidated.
+    it('truncate a multi-block paste without crashing', () => {
+      editor = createEditorWithLength(20);
+      editor.tf.insertFragment([
+        { children: [{ text: 'a'.repeat(25) }], type: 'p' },
+        { children: [{ text: '' }], type: 'p' },
+        { children: [{ text: '' }], type: 'p' },
+        { children: [{ text: 'overflowing text' }], type: 'p' },
+      ]);
+
+      expect(editor.children).toEqual([
+        { children: [{ text: 'a'.repeat(20) }], type: 'p' },
+      ]);
+    });
+  });
 });

--- a/packages/core/src/lib/plugins/length/LengthPlugin.ts
+++ b/packages/core/src/lib/plugins/length/LengthPlugin.ts
@@ -4,29 +4,45 @@ import { createTSlatePlugin } from '../../plugin';
 
 export const LengthPlugin = createTSlatePlugin<LengthConfig>({
   key: 'length',
-}).overrideEditor(({ editor, getOptions, tf: { apply } }) => ({
-  transforms: {
-    apply(operation) {
-      editor.tf.withoutNormalizing(() => {
-        apply(operation);
+}).overrideEditor(({ editor, getOptions, tf: { apply } }) => {
+  // The trim below applies its own operations, which come back through this
+  // same `apply`. Without this guard the nested call sees a half-finished
+  // document that is still over the limit and starts a second, overlapping
+  // delete, invalidating the paths the outer one is still walking.
+  let trimming = false;
 
-        const options = getOptions();
+  return {
+    transforms: {
+      apply(operation) {
+        editor.tf.withoutNormalizing(() => {
+          apply(operation);
 
-        if (options.maxLength) {
-          const length = editor.api.string([]).length;
+          if (trimming) return;
 
-          // Make sure to remove overflow of text beyond character limit
-          if (length > options.maxLength) {
-            const overflowLength = length - options.maxLength;
+          const options = getOptions();
 
-            editor.tf.delete({
-              distance: overflowLength,
-              reverse: true,
-              unit: 'character',
-            });
+          if (options.maxLength) {
+            const length = editor.api.string([]).length;
+
+            // Make sure to remove overflow of text beyond character limit
+            if (length > options.maxLength) {
+              const overflowLength = length - options.maxLength;
+
+              trimming = true;
+
+              try {
+                editor.tf.delete({
+                  distance: overflowLength,
+                  reverse: true,
+                  unit: 'character',
+                });
+              } finally {
+                trimming = false;
+              }
+            }
           }
-        }
-      });
+        });
+      },
     },
-  },
-}));
+  };
+});


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

Fixes #5043.

## The bug

`LengthPlugin` enforces `maxLength` from inside its `apply` override, and trims the overflow with `editor.tf.delete`. That delete applies its own operations, which come straight back through the same `apply` override.

The nested call then runs the length check again against a half-finished document that is still over the limit, and starts a second, overlapping delete — invalidating the paths the outer delete is still walking.

This stayed invisible for a single text block, where the trim is one operation and the re-entrancy is harmless. It only surfaces when the overflow spans block boundaries: there the delete decomposes into `merge_node`/`remove_node` operations, and the nested delete removes a node the outer one still refers to:

```
TypeError: Cannot read properties of undefined (reading 'text')
    at isText (slate/dist/index.js)
    ...
    at apply (packages/core/src/lib/plugins/length/LengthPlugin.ts:10)   <- nested
    at deleteText (packages/slate/src/internal/transforms/deleteText.ts)
    at apply (packages/core/src/lib/plugins/length/LengthPlugin.ts:10)   <- outer
```

Which matches the two errors in the issue report (`Cannot read properties of undefined (reading 'text')` and `undefined is not iterable`).

## The fix

A re-entrancy guard: while the plugin is trimming, it does not trim again. The outer delete is already sized to bring the document back to `maxLength`, so the nested passes were never needed — only harmful.

## Test

`truncate a multi-block paste without crashing` in `LengthPlugin.spec.ts` pastes a 4-block fragment that overflows a `maxLength` of 20. It fails on `main` with the exact error above and passes with the fix.

Verified the result is also correct, not merely non-crashing: the document ends up as a single block holding exactly the first 20 characters.

## Local checks

- `pnpm test packages/core` — 749 pass / 6 fail. Those 6 also fail on a clean checkout of `main` (`Cannot find module '@platejs/basic-nodes/react'` and friends, from unbuilt workspace subpath exports) and are in files this PR does not touch. The +1 versus clean is the new test.
- `pnpm --filter @platejs/core lint` — clean.
- Changeset added (`@platejs/core`, patch).

`pnpm turbo typecheck --filter=./packages/core` could not run in my checkout — it fails resolving `@platejs/slate` types without a full workspace build, in files unrelated to this change. Happy to follow up if CI disagrees.
