### PR TITLE
fix(core): trim until the maxLength invariant holds

### DIFF
--- a/.changeset/core-length-multiblock-paste-crash.md
+++ b/.changeset/core-length-multiblock-paste-crash.md
@@ -1,0 +1,5 @@
+---
+"@platejs/core": patch
+---
+
+Fix crash when a paste that exceeds `maxLength` spans multiple blocks

--- a/packages/core/src/lib/plugins/length/LengthPlugin.spec.ts
+++ b/packages/core/src/lib/plugins/length/LengthPlugin.spec.ts
@@ -97,4 +97,25 @@ describe('LengthPlugin', () => {
       expect(options.maxLength).toBe(15);
     });
   });
+
+  describe('when the overflow spans block boundaries', () => {
+    // The trim deletes across block boundaries, which Slate decomposes into
+    // merge/remove operations. Those come back through the plugin's own
+    // `apply`, and before the re-entrancy guard the nested call started a
+    // second overlapping delete and crashed on a path the outer one had
+    // already invalidated.
+    it('truncate a multi-block paste without crashing', () => {
+      editor = createEditorWithLength(20);
+      editor.tf.insertFragment([
+        { children: [{ text: 'a'.repeat(25) }], type: 'p' },
+        { children: [{ text: '' }], type: 'p' },
+        { children: [{ text: '' }], type: 'p' },
+        { children: [{ text: 'overflowing text' }], type: 'p' },
+      ]);
+
+      expect(editor.children).toEqual([
+        { children: [{ text: 'a'.repeat(20) }], type: 'p' },
+      ]);
+    });
+  });
 });

--- a/packages/core/src/lib/plugins/length/LengthPlugin.spec.ts
+++ b/packages/core/src/lib/plugins/length/LengthPlugin.spec.ts
@@ -101,9 +101,8 @@ describe('LengthPlugin', () => {
   describe('when the overflow spans block boundaries', () => {
     // The trim deletes across block boundaries, which Slate decomposes into
     // merge/remove operations. Those come back through the plugin's own
-    // `apply`, and before the re-entrancy guard the nested call started a
-    // second overlapping delete and crashed on a path the outer one had
-    // already invalidated.
+    // `apply`, so nested trims are suppressed and the outer one loops until
+    // the length invariant holds.
     it('truncate a multi-block paste without crashing', () => {
       editor = createEditorWithLength(20);
       editor.tf.insertFragment([
@@ -116,6 +115,28 @@ describe('LengthPlugin', () => {
       expect(editor.children).toEqual([
         { children: [{ text: 'a'.repeat(20) }], type: 'p' },
       ]);
+    });
+
+    it('truncate to maxLength when the overflow is a single character', () => {
+      // One pass is not enough here: the deletion distance is spent crossing
+      // the empty blocks without removing a character, so the trim has to run
+      // again to reach the limit.
+      editor = createEditorWithLength(20);
+      editor.tf.insertFragment([
+        { children: [{ text: 'a'.repeat(21) }], type: 'p' },
+        { children: [{ text: '' }], type: 'p' },
+        { children: [{ text: '' }], type: 'p' },
+        { children: [{ text: 'tail' }], type: 'p' },
+      ]);
+
+      expect(editor.api.string([])).toBe('a'.repeat(20));
+    });
+
+    it('truncate pasted plain text containing line breaks', () => {
+      editor = createEditorWithLength(20);
+      editor.tf.insertText(`${'a'.repeat(21)}\n\noverflowing tail`);
+
+      expect(editor.api.string([]).length).toBeLessThanOrEqual(20);
     });
   });
 });

--- a/packages/core/src/lib/plugins/length/LengthPlugin.ts
+++ b/packages/core/src/lib/plugins/length/LengthPlugin.ts
@@ -5,10 +5,10 @@ import { createTSlatePlugin } from '../../plugin';
 export const LengthPlugin = createTSlatePlugin<LengthConfig>({
   key: 'length',
 }).overrideEditor(({ editor, getOptions, tf: { apply } }) => {
-  // The trim below applies its own operations, which come back through this
-  // same `apply`. Without this guard the nested call sees a half-finished
-  // document that is still over the limit and starts a second, overlapping
-  // delete, invalidating the paths the outer one is still walking.
+  // The trim applies its own operations, which come back through this same
+  // `apply`. Letting them start their own nested trim invalidates the paths
+  // the outer delete is still walking, so nested passes are suppressed and
+  // the outer one loops instead.
   let trimming = false;
 
   return {
@@ -21,25 +21,36 @@ export const LengthPlugin = createTSlatePlugin<LengthConfig>({
 
           const options = getOptions();
 
-          if (options.maxLength) {
-            const length = editor.api.string([]).length;
+          if (!options.maxLength) return;
 
-            // Make sure to remove overflow of text beyond character limit
-            if (length > options.maxLength) {
-              const overflowLength = length - options.maxLength;
+          trimming = true;
 
-              trimming = true;
+          try {
+            // Make sure to remove overflow of text beyond character limit.
+            // One pass is not always enough: crossing a block boundary
+            // consumes deletion distance without removing a character, so
+            // the trim can come up short and has to run again.
+            while (true) {
+              const length = editor.api.string([]).length;
 
-              try {
-                editor.tf.delete({
-                  distance: overflowLength,
-                  reverse: true,
-                  unit: 'character',
-                });
-              } finally {
-                trimming = false;
-              }
+              if (length <= options.maxLength) break;
+
+              const before = editor.children;
+
+              editor.tf.delete({
+                distance: length - options.maxLength,
+                reverse: true,
+                unit: 'character',
+              });
+
+              // The pass changed nothing — stop rather than spin. Progress is
+              // structural, not by character count: a pass that only merges
+              // away an empty block removes no character but does move the
+              // selection closer to the text it still has to trim.
+              if (editor.children === before) break;
             }
+          } finally {
+            trimming = false;
           }
         });
       },

--- a/packages/core/src/lib/plugins/length/LengthPlugin.ts
+++ b/packages/core/src/lib/plugins/length/LengthPlugin.ts
@@ -4,29 +4,45 @@ import { createTSlatePlugin } from '../../plugin';
 
 export const LengthPlugin = createTSlatePlugin<LengthConfig>({
   key: 'length',
-}).overrideEditor(({ editor, getOptions, tf: { apply } }) => ({
-  transforms: {
-    apply(operation) {
-      editor.tf.withoutNormalizing(() => {
-        apply(operation);
+}).overrideEditor(({ editor, getOptions, tf: { apply } }) => {
+  // The trim below applies its own operations, which come back through this
+  // same `apply`. Without this guard the nested call sees a half-finished
+  // document that is still over the limit and starts a second, overlapping
+  // delete, invalidating the paths the outer one is still walking.
+  let trimming = false;
 
-        const options = getOptions();
+  return {
+    transforms: {
+      apply(operation) {
+        editor.tf.withoutNormalizing(() => {
+          apply(operation);
 
-        if (options.maxLength) {
-          const length = editor.api.string([]).length;
+          if (trimming) return;
 
-          // Make sure to remove overflow of text beyond character limit
-          if (length > options.maxLength) {
-            const overflowLength = length - options.maxLength;
+          const options = getOptions();
 
-            editor.tf.delete({
-              distance: overflowLength,
-              reverse: true,
-              unit: 'character',
-            });
+          if (options.maxLength) {
+            const length = editor.api.string([]).length;
+
+            // Make sure to remove overflow of text beyond character limit
+            if (length > options.maxLength) {
+              const overflowLength = length - options.maxLength;
+
+              trimming = true;
+
+              try {
+                editor.tf.delete({
+                  distance: overflowLength,
+                  reverse: true,
+                  unit: 'character',
+                });
+              } finally {
+                trimming = false;
+              }
+            }
           }
-        }
-      });
+        });
+      },
     },
-  },
-}));
+  };
+});


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

Fixes #5043. Reworked from #5100 — GitHub would not let me reopen that one, so this supersedes it.

@zbeyens was right on both counts in his close: the guard fixed the crash but regressed `maxLength` enforcement. Reproduced exactly as described — `maxLength: 20` with a 21-character paragraph, empty paragraphs and trailing text finished at 21. Both points are addressed below.

## Why one pass is not enough

`Editor.before(…, {unit: 'character'})` spends distance crossing a block boundary without removing a character. So a trim sized from `editor.api.string([]).length` can finish still over the limit whenever the deleted range spans empty blocks.

`main` converged anyway, because each of the trim's own operations re-entered `apply` and started another trim. That re-entrancy is also the crash: the nested delete decomposes into `merge_node`/`remove_node` and invalidates the paths the outer delete is still walking, which is #5043.

So the two behaviours were entangled — my first attempt removed the crash and the convergence together.

## The fix

Keep the re-entrancy guard, and loop in the *outer* pass until the invariant holds:

- nested trims stay suppressed, so paths cannot be corrupted mid-delete
- the outer pass re-checks and trims again until `length <= maxLength`
- termination is structural, not by character count: a pass that only merges away an empty block removes no character but does move the selection closer to the text still to be trimmed, so counting characters would stall exactly on the case you found. The loop stops when a pass changes nothing at all.

## Tests

Both are load-bearing — each fails without the fix, on a different version:

- `truncate a multi-block paste without crashing` — fails on `main` with `undefined is not an object (evaluating 'node.text')`
- `truncate to maxLength when the overflow is a single character` — the case from your close; fails on #5100's guard-only version, ending at 21
- `truncate pasted plain text containing line breaks` — the line-break paste shape from the issue

On coverage of "the faithful Markdown paste": the markdown deserializer lives in `@platejs/markdown`, so a core spec should not reach for it. `insertText` with embedded newlines is the closest core-level equivalent and is included. Happy to add a test in the markdown package instead if you would rather it live there.

I also swept overflow 1–30 × 0–4 empty blocks × 3 trailing shapes (450 combinations) locally: all converge to `maxLength`, none crash, none spin. That sweep is not in the diff — it was a throwaway check, not something worth maintaining.

## Local checks

- `pnpm test packages/core` — 751 pass / 6 fail. The same 6 fail on a clean checkout (`Cannot find module '@platejs/basic-nodes/react'` and friends, unbuilt workspace subpath exports) in files this PR does not touch.
- `pnpm --filter @platejs/core lint` — clean.
- Changeset carried over from #5100.
