### PR TITLE
fix(comment): strip discussion ids when pasting fragments

### DIFF
--- a/.changeset/strip-comment-ids-on-paste.md
+++ b/.changeset/strip-comment-ids-on-paste.md
@@ -1,0 +1,5 @@
+---
+'@platejs/comment': patch
+---
+
+Strip comment and discussion marks when pasting a Slate fragment so copied text does not keep sharing source discussion IDs.

--- a/packages/comment/src/lib/BaseCommentPlugin.spec.ts
+++ b/packages/comment/src/lib/BaseCommentPlugin.spec.ts
@@ -198,4 +198,92 @@ describe('BaseCommentPlugin', () => {
       text: 'b',
     });
   });
+
+  it('strips source comment keys when pasting a slate fragment into another editor', () => {
+    const sourceFragment = [
+      {
+        children: [
+          { text: 'plain ' },
+          {
+            bold: true,
+            comment: true,
+            comment_discussion1: true,
+            text: 'commented',
+          },
+          {
+            comment: true,
+            commentTransient: true,
+            comment_discussion2: true,
+            comment_draft: true,
+            italic: true,
+            text: 'drafted',
+          },
+        ],
+        type: 'p',
+      },
+    ];
+    const source = createCommentEditor(sourceFragment);
+    const dest = createCommentEditor([
+      {
+        children: [{ text: '' }],
+        type: 'p',
+      },
+    ]);
+
+    dest.selection = {
+      anchor: { offset: 0, path: [0, 0] },
+      focus: { offset: 0, path: [0, 0] },
+    };
+
+    dest.tf.insertData({
+      files: [],
+      getData: (mimeType: string) =>
+        mimeType === 'application/x-slate-fragment'
+          ? window.btoa(encodeURIComponent(JSON.stringify(sourceFragment)))
+          : '',
+    } as any);
+
+    expect(collectCommentRefKeys(dest.children)).toEqual([]);
+    expect(dest.children).toEqual([
+      {
+        children: [
+          { text: 'plain ' },
+          {
+            bold: true,
+            text: 'commented',
+          },
+          {
+            italic: true,
+            text: 'drafted',
+          },
+        ],
+        type: 'p',
+      },
+    ]);
+    expect(source.children[0].children[1]).toMatchObject({
+      comment: true,
+      comment_discussion1: true,
+      text: 'commented',
+    });
+  });
 });
+
+const collectCommentRefKeys = (nodes: any[]): string[] => {
+  const keys: string[] = [];
+  const visit = (node: any) => {
+    Object.keys(node).forEach((key) => {
+      if (
+        key === 'comment' ||
+        key === 'commentTransient' ||
+        key.startsWith('comment_')
+      ) {
+        keys.push(key);
+      }
+    });
+    node.children?.forEach(visit);
+  };
+
+  nodes.forEach(visit);
+
+  return keys;
+};

--- a/packages/comment/src/lib/withComments.ts
+++ b/packages/comment/src/lib/withComments.ts
@@ -1,16 +1,48 @@
-import type { OverrideEditor, TCommentText } from 'platejs';
+import type { Descendant, OverrideEditor, TCommentText } from 'platejs';
 
-import { KEYS } from 'platejs';
+import { ElementApi, KEYS, TextApi } from 'platejs';
 
 import type { BaseCommentConfig } from './BaseCommentPlugin';
 
-import { getCommentCount, getDraftCommentKey } from './utils';
+import {
+  getCommentCount,
+  getCommentKeys,
+  getDraftCommentKey,
+  getTransientCommentKey,
+} from './utils';
+
+/** Drop source document comment marks so paste does not share discussion ids. */
+export const stripCommentKeysFromFragment = (fragment: Descendant[]) => {
+  const visit = (node: Descendant) => {
+    if (TextApi.isText(node)) {
+      const text = node as TCommentText;
+
+      for (const key of getCommentKeys(text)) {
+        delete text[key];
+      }
+
+      delete text[KEYS.comment];
+      delete text[getDraftCommentKey()];
+      delete text[getTransientCommentKey()];
+    }
+
+    if (ElementApi.isElement(node)) {
+      node.children.forEach(visit);
+    }
+  };
+
+  fragment.forEach(visit);
+};
 
 export const withComment: OverrideEditor<BaseCommentConfig> = ({
   editor,
-  tf: { normalizeNode },
+  tf: { insertFragment, normalizeNode },
 }) => ({
   transforms: {
+    insertFragment(fragment) {
+      stripCommentKeysFromFragment(fragment);
+      return insertFragment(fragment);
+    },
     normalizeNode(entry) {
       const [node, path] = entry;
 


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## Summary

Pasting Slate fragments that carry comment marks kept `comment`, `comment_*` discussion keys, draft, and transient flags. Resolving the pasted comment then mutated the source discussion.

`insertFragment` now strips those keys before insert so pasted text is plain formatting only.

## Test plan

- [x] `bun test --preload ./tooling/config/bunTestSetup.ts packages/comment/src/lib/BaseCommentPlugin.spec.ts`
- [ ] Manual: copy commented text from one editor, paste into another; confirm pasted leaves have no `comment_*` keys and resolving in the destination does not affect the source discussion

Fixes #5093
